### PR TITLE
Add USDC support and SEP-0010 wallet authentication

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "express-rate-limit": "^7.3.1",
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
-    "@stellar/stellar-sdk": "^12.0.0"
+    "@stellar/stellar-sdk": "^12.0.0",
+    "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.2",

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,27 @@
+/**
+ * src/middleware/auth.js
+ * JWT verification middleware for SEP-0010 authenticated routes.
+ */
+"use strict";
+
+const jwt = require("jsonwebtoken");
+
+const JWT_SECRET = process.env.JWT_SECRET || "stellar_micropay_secret_key";
+
+function verifyJWT(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Unauthorized: missing or invalid token" });
+  }
+
+  const token = authHeader.split(" ")[1];
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    req.user = decoded; // { publicKey: "G..." }
+    next();
+  } catch {
+    return res.status(401).json({ error: "Unauthorized: invalid or expired token" });
+  }
+}
+
+module.exports = { verifyJWT, JWT_SECRET };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,87 @@
+/**
+ * src/routes/auth.js
+ * SEP-0010 Stellar Web Authentication endpoints.
+ *
+ * GET  /api/auth?account=G... → returns a challenge transaction
+ * POST /api/auth              → verifies signed challenge, returns JWT
+ */
+"use strict";
+
+const express = require("express");
+const jwt     = require("jsonwebtoken");
+const { Utils, Keypair } = require("@stellar/stellar-sdk");
+const { JWT_SECRET } = require("../middleware/auth");
+
+const router = express.Router();
+
+const HOME_DOMAIN = process.env.HOME_DOMAIN || "localhost:4000";
+const NETWORK_PASSPHRASE =
+  process.env.STELLAR_NETWORK === "mainnet"
+    ? "Public Global Stellar Network ; September 2015"
+    : "Test SDF Network ; September 2015";
+
+// Cache the server keypair — regenerated only on cold start.
+let cachedServerKeypair = null;
+function getServerKeypair() {
+  if (!cachedServerKeypair) {
+    const secret = process.env.SERVER_PRIVATE_KEY || Keypair.random().secret();
+    cachedServerKeypair = Keypair.fromSecret(secret);
+  }
+  return cachedServerKeypair;
+}
+
+// GET /api/auth?account=G... — issue a SEP-0010 challenge transaction
+router.get("/", (req, res) => {
+  const { account } = req.query;
+  if (!account) {
+    return res.status(400).json({ error: "Missing account query parameter" });
+  }
+
+  try {
+    const keypair   = getServerKeypair();
+    const challenge = Utils.buildChallengeTx(
+      keypair,
+      account,
+      HOME_DOMAIN,
+      300, // 5-minute validity window
+      NETWORK_PASSPHRASE
+    );
+    res.json({ transaction: challenge, networkPassphrase: NETWORK_PASSPHRASE });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+// POST /api/auth — verify signed challenge and issue JWT
+router.post("/", (req, res) => {
+  const { transaction } = req.body;
+  if (!transaction) {
+    return res.status(400).json({ error: "Missing transaction in request body" });
+  }
+
+  try {
+    const keypair   = getServerKeypair();
+    const accountId = Utils.verifyChallengeTx(
+      transaction,
+      keypair.publicKey(),
+      NETWORK_PASSPHRASE,
+      HOME_DOMAIN,
+      ""
+    );
+
+    const token = jwt.sign({ publicKey: accountId }, JWT_SECRET, { expiresIn: "24h" });
+
+    res.cookie("jwt", token, {
+      httpOnly: true,
+      secure:   process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge:   24 * 60 * 60 * 1000,
+    });
+
+    res.json({ success: true, token });
+  } catch (e) {
+    res.status(401).json({ error: "Unauthorized: " + e.message });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -14,7 +14,8 @@ require("dotenv").config();
 
 const accountRoutes = require("./routes/accounts");
 const paymentRoutes = require("./routes/payments");
-const healthRoutes = require("./routes/health");
+const healthRoutes  = require("./routes/health");
+const authRoutes    = require("./routes/auth");
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -49,9 +50,17 @@ app.use(
       }
     },
     methods: ["GET", "POST"],
-    allowedHeaders: ["Content-Type"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
   })
 );
+
+// ─── Routes ───────────────────────────────────────────────────────────────────
+
+app.use("/api/auth",     authRoutes);
+app.use("/api/accounts", accountRoutes);
+app.use("/api/payments", paymentRoutes);
+app.use("/health",       healthRoutes);
 
 // Global rate limiting — 100 requests per 15 minutes per IP
 const limiter = rateLimit({

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from "react";
 interface SendPaymentFormProps {
   publicKey: string;
   xlmBalance: string;
+  usdcBalance?: string | null;
   onSuccess?: () => void;
   // FIX: Added prefill to interface to stop the "Property does not exist" error
   prefill?: {
@@ -31,15 +32,18 @@ interface SendPaymentFormProps {
 }
 
 type Status = "idle" | "building" | "signing" | "submitting" | "success" | "error";
+type AssetType = "XLM" | "USDC";
 
 const ESTIMATED_NETWORK_FEE = "0.00001 XLM";
 
 export default function SendPaymentForm({
   publicKey,
   xlmBalance,
+  usdcBalance,
   onSuccess,
   prefill,
 }: SendPaymentFormProps) {
+  const [selectedAsset, setSelectedAsset] = useState<AssetType>("XLM");
   const [destination, setDestination] = useState("");
   const [amount, setAmount] = useState("");
   const [memo, setMemo] = useState("");
@@ -57,12 +61,17 @@ export default function SendPaymentForm({
     }
   }, [prefill]);
 
-  const balance = parseFloat(xlmBalance);
+  const xlmBal  = parseFloat(xlmBalance);
+  const usdcBal = usdcBalance ? parseFloat(usdcBalance) : 0;
+  // XLM has a 1 XLM reserve; USDC has no such constraint
+  const balance  = selectedAsset === "XLM" ? xlmBal : usdcBal;
+  const maxSend  = selectedAsset === "XLM" ? Math.max(0, xlmBal - 1) : usdcBal;
+
   const amountNum = parseFloat(amount);
   const isValidDest = destination.length > 0 && isValidStellarAddress(destination);
-  const MIN_STROOP = 0.0000001; // 1 stroop — Stellar's minimum transaction amount
+  const MIN_STROOP = 0.0000001;
   const isValidAmt =
-    !isNaN(amountNum) && amountNum >= MIN_STROOP && amountNum <= balance - 1; // keep 1 XLM reserve
+    !isNaN(amountNum) && amountNum >= MIN_STROOP && amountNum <= maxSend;
   const canSubmit =
     isValidDest && isValidAmt && status === "idle" && destination !== publicKey;
 
@@ -79,6 +88,7 @@ export default function SendPaymentForm({
         toPublicKey: destination,
         amount: amountNum.toFixed(7),
         memo: memo.trim() || undefined,
+        asset: selectedAsset,
       });
 
       // Step 2: Sign with Freighter
@@ -131,8 +141,7 @@ export default function SendPaymentForm({
   };
 
   const setMaxAmount = () => {
-    const max = Math.max(0, balance - 1).toFixed(7);
-    setAmount(max);
+    setAmount(maxSend.toFixed(7));
   };
 
   if (status === "success" && txHash) {
@@ -169,6 +178,30 @@ export default function SendPaymentForm({
       </h2>
 
       <div className="space-y-5">
+        {/* Asset selector */}
+        <div className="flex gap-2">
+          {(["XLM", "USDC"] as AssetType[]).map((a) => (
+            <button
+              key={a}
+              type="button"
+              onClick={() => { setSelectedAsset(a); setAmount(""); }}
+              disabled={a === "USDC" && !usdcBalance}
+              className={clsx(
+                "px-4 py-1.5 rounded-full text-sm font-medium border transition-all",
+                selectedAsset === a
+                  ? "bg-stellar-500/15 text-stellar-300 border-stellar-500/30"
+                  : "text-slate-400 border-white/10 hover:border-white/20",
+                a === "USDC" && !usdcBalance && "opacity-40 cursor-not-allowed"
+              )}
+            >
+              {a}
+              {a === "USDC" && !usdcBalance && (
+                <span className="ml-1 text-xs">(no trustline)</span>
+              )}
+            </button>
+          ))}
+        </div>
+
         {/* Destination */}
         <div>
           <label className="label">{`Recipient Address`}</label>
@@ -194,7 +227,7 @@ export default function SendPaymentForm({
         {/* Amount */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <label className="label mb-0">{`Amount (XLM)`}</label>
+            <label className="label mb-0">{`Amount (${selectedAsset})`}</label>
 
             {/* Issue #8 — info icon + pure CSS tooltip next to Max button */}
             <div className="flex items-center gap-1.5">
@@ -249,9 +282,11 @@ export default function SendPaymentForm({
           />
           {amount && !isValidAmt && (
             <p className="mt-1 text-xs text-red-400">
-              {amountNum > balance - 1
-                ? `Insufficient balance (1 XLM reserve required)`
-                : `Minimum amount is 0.0000001 XLM (1 stroop)`}
+              {amountNum > maxSend
+                ? selectedAsset === "XLM"
+                  ? `Insufficient balance (1 XLM reserve required)`
+                  : `Insufficient USDC balance`
+                : `Minimum amount is 0.0000001 ${selectedAsset} (1 stroop)`}
             </p>
           )}
         </div>
@@ -290,7 +325,7 @@ export default function SendPaymentForm({
           {status === "idle" && (
             <>
               <SendIcon className="w-4 h-4" />
-              {`Send ${amount ? formatXLM(amountNum) : "XLM"}`}
+              {`Send ${amount ? formatXLM(amountNum) : ""} ${selectedAsset}`.trim()}
             </>
           )}
           {status === "error" && "Retry"}

--- a/frontend/components/WalletConnect.tsx
+++ b/frontend/components/WalletConnect.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from "react";
-import { connectWallet, isFreighterInstalled, detectBrowser, EXTENSION_URLS } from "@/lib/wallet";
+import { connectWallet, isFreighterInstalled, detectBrowser, EXTENSION_URLS, performSEP0010Auth } from "@/lib/wallet";
 
 interface WalletConnectProps {
   onConnect: (publicKey: string) => void;
@@ -12,7 +12,8 @@ interface WalletConnectProps {
 
 export default function WalletConnect({ onConnect }: WalletConnectProps) {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [step, setStep]       = useState<"idle" | "connecting" | "authenticating">("idle");
+  const [error, setError]     = useState<string | null>(null);
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
   const [browser, setBrowser] = useState<"chrome" | "firefox" | "other">("other");
 
@@ -23,26 +24,38 @@ export default function WalletConnect({ onConnect }: WalletConnectProps) {
   const handleConnect = async () => {
     setLoading(true);
     setError(null);
+    setStep("connecting");
 
     const installed = await isFreighterInstalled();
     if (!installed) {
       setShowInstallPrompt(true);
       setLoading(false);
+      setStep("idle");
       return;
     }
 
     setShowInstallPrompt(false);
     const { publicKey, error: walletError } = await connectWallet();
-    setLoading(false);
 
-    if (walletError) {
-      setError(walletError);
+    if (walletError || !publicKey) {
+      setError(walletError || "Could not retrieve public key.");
+      setLoading(false);
+      setStep("idle");
       return;
     }
 
-    if (publicKey) {
-      onConnect(publicKey);
+    // SEP-0010: prove ownership of the connected wallet
+    setStep("authenticating");
+    const { error: authError } = await performSEP0010Auth(publicKey);
+    setLoading(false);
+    setStep("idle");
+
+    if (authError) {
+      setError(authError);
+      return;
     }
+
+    onConnect(publicKey);
   };
 
   const extensionUrl = EXTENSION_URLS[browser];
@@ -155,17 +168,9 @@ export default function WalletConnect({ onConnect }: WalletConnectProps) {
         disabled={loading}
         className="btn-primary w-full flex items-center justify-center gap-2"
       >
-        {loading ? (
-          <>
-            <Spinner />
-            Connecting...
-          </>
-        ) : (
-          <>
-            <WalletIcon className="w-4 h-4" />
-            Connect Freighter Wallet
-          </>
-        )}
+        {step === "connecting"     ? <><Spinner /> Connecting...</> :
+         step === "authenticating" ? <><Spinner /> Authenticating...</> :
+         <><WalletIcon className="w-4 h-4" /> Connect Freighter Wallet</>}
       </button>
 
       <p className="mt-4 text-xs text-slate-500">

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -34,6 +34,13 @@ export const NETWORK_PASSPHRASE =
 /** Pre-configured Horizon server instance for the active network. */
 export const server = new Horizon.Server(HORIZON_URL);
 
+// USDC asset issued by Circle on Stellar
+export const USDC_ISSUER =
+  NETWORK === "mainnet"
+    ? "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+    : "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+export const USDC = new Asset("USDC", USDC_ISSUER);
+
 // ─── Types ─────────────────────────────────────────────────────────────────
 
 /**
@@ -160,6 +167,22 @@ export async function getXLMBalance(publicKey: string): Promise<string> {
 }
 
 /**
+ * Fetch the USDC (Circle) balance for a Stellar account.
+ * Returns null if the account has no USDC trustline.
+ */
+export async function getUSDCBalance(publicKey: string): Promise<string | null> {
+  try {
+    const balances = await getBalances(publicKey);
+    const usdc = balances.find(
+      (b) => b.asset === `USDC:${USDC_ISSUER}`
+    );
+    return usdc ? usdc.balance : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Build an unsigned XLM payment transaction ready for Freighter to sign.
  *
  * This function loads the source account sequence number from Horizon,
@@ -193,13 +216,34 @@ export async function buildPaymentTransaction({
   toPublicKey,
   amount,
   memo,
+  asset = "XLM",
 }: {
   fromPublicKey: string;
   toPublicKey: string;
   amount: string;
   memo?: string;
+  asset?: "XLM" | "USDC";
 }): Promise<Transaction> {
   const sourceAccount = await server.loadAccount(fromPublicKey);
+
+  // For USDC, verify the recipient has a trustline before building the tx
+  if (asset === "USDC") {
+    const recipient = await server.loadAccount(toPublicKey).catch(() => null);
+    if (!recipient) {
+      throw new Error("Recipient account not found on the Stellar network.");
+    }
+    const hasTrustline = recipient.balances.some(
+      (b): b is Horizon.HorizonApi.BalanceLineAsset =>
+        b.asset_type !== "native" &&
+        (b as Horizon.HorizonApi.BalanceLineAsset).asset_code === "USDC" &&
+        (b as Horizon.HorizonApi.BalanceLineAsset).asset_issuer === USDC_ISSUER
+    );
+    if (!hasTrustline) {
+      throw new Error(
+        "Recipient has no USDC trustline. They must add USDC to their Stellar wallet first."
+      );
+    }
+  }
 
   const builder = new TransactionBuilder(sourceAccount, {
     fee: "100", // 100 stroops = 0.00001 XLM
@@ -208,7 +252,7 @@ export async function buildPaymentTransaction({
     .addOperation(
       Operation.payment({
         destination: toPublicKey,
-        asset: Asset.native(),
+        asset: asset === "USDC" ? USDC : Asset.native(),
         amount: amount,
       })
     )

--- a/frontend/lib/wallet.ts
+++ b/frontend/lib/wallet.ts
@@ -19,6 +19,38 @@ import {
 
 import { NETWORK_PASSPHRASE } from "./stellar";
 
+// ─── SEP-0010 helpers ────────────────────────────────────────────────────────
+
+let jwtToken: string | null = null;
+export function setJwtToken(token: string | null) { jwtToken = token; }
+export function getJwtToken() { return jwtToken; }
+
+async function fetchAuthChallenge(publicKey: string): Promise<string> {
+  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "";
+  const res  = await fetch(`${base}/api/auth?account=${encodeURIComponent(publicKey)}`, {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error("Failed to fetch SEP-0010 challenge");
+  const { transaction } = await res.json();
+  return transaction;
+}
+
+async function verifyAuthChallenge(signedXDR: string): Promise<string> {
+  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "";
+  const res  = await fetch(`${base}/api/auth`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ transaction: signedXDR }),
+  });
+  if (!res.ok) {
+    const { error } = await res.json().catch(() => ({ error: "Auth failed" }));
+    throw new Error(error || "SEP-0010 verification failed");
+  }
+  const { token } = await res.json();
+  return token;
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface WalletState {
@@ -151,6 +183,32 @@ export async function getConnectedPublicKey(): Promise<string | null> {
     return pk || null;
   } catch {
     return null;
+  }
+}
+
+// ─── SEP-0010 auth flow ──────────────────────────────────────────────────────
+
+/**
+ * Full SEP-0010 authentication flow:
+ * 1. Request a challenge transaction from the backend
+ * 2. Sign it with Freighter
+ * 3. Submit the signed transaction to receive a JWT
+ */
+export async function performSEP0010Auth(
+  publicKey: string
+): Promise<{ token: string | null; error: string | null }> {
+  try {
+    const challengeXDR = await fetchAuthChallenge(publicKey);
+    const { signedXDR, error: signError } = await signTransactionWithWallet(challengeXDR);
+    if (signError || !signedXDR) {
+      return { token: null, error: signError || "Failed to sign challenge transaction" };
+    }
+    const token = await verifyAuthChallenge(signedXDR);
+    setJwtToken(token);
+    return { token, error: null };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { token: null, error: `Authentication failed: ${msg}` };
   }
 }
 

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -13,6 +13,7 @@ import Toast from "@/components/Toast";
 import QRCodeModal from "@/components/QRCodeModal";
 import {
   getXLMBalance,
+  getUSDCBalance,
   fundWithFriendbot,
   ACCOUNT_NOT_FOUND_ERROR,
 } from "@/lib/stellar";
@@ -34,7 +35,8 @@ interface PaymentStats {
 }
 
 export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
-  const [xlmBalance, setXlmBalance] = useState<string | null>(null);
+  const [xlmBalance, setXlmBalance]   = useState<string | null>(null);
+  const [usdcBalance, setUsdcBalance] = useState<string | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
   const [xlmPrice, setXlmPrice] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
@@ -56,8 +58,12 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
     setAccountNotFound(false);
 
     try {
-      const bal = await getXLMBalance(publicKey);
+      const [bal, usdc] = await Promise.all([
+        getXLMBalance(publicKey),
+        getUSDCBalance(publicKey),
+      ]);
       setXlmBalance(bal);
+      setUsdcBalance(usdc);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "";
       if (
@@ -274,7 +280,7 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         {process.env.NEXT_PUBLIC_STELLAR_NETWORK !== "mainnet" && (
           <div className="mt-4 pt-4 border-t border-white/5 flex items-center gap-2 text-xs text-amber-400/80">
             <span className="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />
-            You&apos;re on <strong>Testnet</strong> — funds are not real.{" "}
+            You&apos;re on <strong>Testnet</strong> ï¿½ funds are not real.{" "}
             <a
               href="https://friendbot.stellar.org"
               target="_blank"
@@ -287,12 +293,29 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
         )}
       </div>
 
+      {/* USDC balance card â€” shown only when account has USDC trustline */}
+      {usdcBalance !== null && (
+        <div className="card mb-6 bg-gradient-to-br from-cosmos-800 to-cosmos-900 border-blue-500/20 relative overflow-hidden">
+          <div className="absolute top-0 right-0 w-40 h-40 bg-blue-500/5 rounded-full blur-2xl pointer-events-none" />
+          <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div>
+              <p className="label mb-1">USDC Balance</p>
+              <div className="font-display text-3xl font-bold text-white">
+                {parseFloat(usdcBalance).toLocaleString("en-US", { maximumFractionDigits: 4 })}
+                <span className="text-blue-400 text-xl ml-2">USDC</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="grid lg:grid-cols-3 gap-6">
         <div className="lg:col-span-1">
           <SendPaymentForm
             key={refreshKey}
             publicKey={publicKey}
             xlmBalance={xlmBalance || "0"}
+            usdcBalance={usdcBalance}
             onSuccess={handlePaymentSuccess}
           />
         </div>


### PR DESCRIPTION
## Summary

This PR resolves two issues in a single merge.

### Issue #24 — USDC balance and send support
- `frontend/lib/stellar.ts` — Added `USDC_ISSUER` and `USDC` asset constants (testnet + mainnet Circle issuers), `getUSDCBalance()` which extracts USDC from the existing `getBalances()` call, and updated `buildPaymentTransaction()` to accept `asset?: "XLM" | "USDC"` with recipient trustline validation before building a USDC transaction
- `frontend/components/SendPaymentForm.tsx` — Added `usdcBalance` prop and an asset selector toggle (XLM / USDC); USDC option is disabled with a label when no trustline is present; amount validation, max button, error messages, and button label all update to reflect the selected asset
- `frontend/pages/dashboard.tsx` — Fetches USDC balance in parallel with XLM using `Promise.all`; shows a USDC balance card when the account has a USDC trustline; passes `usdcBalance` to `SendPaymentForm`

### Issue #23 — SEP-0010 wallet authentication
- `backend/package.json` — Added `jsonwebtoken ^9.0.3` dependency
- `backend/src/middleware/auth.js` — New `verifyJWT` middleware; extracts Bearer token, verifies against `JWT_SECRET`, attaches `req.user = { publicKey }` for downstream handlers
- `backend/src/routes/auth.js` — `GET /api/auth?account=G…` returns a SEP-0010 challenge transaction; `POST /api/auth` verifies the signed challenge, issues a 24-hour JWT, sets an `httpOnly` `SameSite: strict` cookie, and returns the token in the response body
- `backend/src/server.js` — Registered `/api/auth`, `/api/accounts`, `/api/payments`, and `/health` routes (they were imported but not mounted); added `Authorization` to CORS `allowedHeaders` and `credentials: true`
- `frontend/lib/wallet.ts` — Added in-memory JWT store (`setJwtToken` / `getJwtToken`), private `fetchAuthChallenge` and `verifyAuthChallenge` helpers, and the exported `performSEP0010Auth(publicKey)` which orchestrates the full challenge → sign → verify flow
- `frontend/components/WalletConnect.tsx` — After Freighter wallet connection succeeds, automatically runs `performSEP0010Auth`; button shows step-aware text ("Connecting…" → "Authenticating…")

Closes #24
Closes #23