### PR TITLE
Add offline Jest unit tests for stellarService and fix backend test blockers

### DIFF
--- a/backend/__tests__/stellarService.test.js
+++ b/backend/__tests__/stellarService.test.js
@@ -1,0 +1,201 @@
+/**
+ * __tests__/stellarService.test.js
+ * Unit tests for Stellar service with mocked Horizon SDK.
+ */
+
+"use strict";
+
+const mockLoadAccount = jest.fn();
+const mockPaymentsCall = jest.fn();
+const mockPaymentsCursor = jest.fn();
+const mockPaymentsOrder = jest.fn();
+const mockPaymentsLimit = jest.fn();
+const mockPaymentsForAccount = jest.fn();
+const mockPayments = jest.fn();
+
+jest.mock("@stellar/stellar-sdk", () => {
+  mockPaymentsCursor.mockImplementation(() => ({ call: mockPaymentsCall }));
+  mockPaymentsOrder.mockImplementation(() => ({ cursor: mockPaymentsCursor, call: mockPaymentsCall }));
+  mockPaymentsLimit.mockImplementation(() => ({ order: mockPaymentsOrder }));
+  mockPaymentsForAccount.mockImplementation(() => ({ limit: mockPaymentsLimit }));
+  mockPayments.mockImplementation(() => ({ forAccount: mockPaymentsForAccount }));
+
+  return {
+    Horizon: {
+      Server: jest.fn(() => ({
+        loadAccount: mockLoadAccount,
+        payments: mockPayments,
+      })),
+    },
+  };
+});
+
+const stellarService = require("../src/services/stellarService");
+
+describe("stellarService", () => {
+  const validPublicKey = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPaymentsCursor.mockImplementation(() => ({ call: mockPaymentsCall }));
+    mockPaymentsOrder.mockImplementation(() => ({ cursor: mockPaymentsCursor, call: mockPaymentsCall }));
+    mockPaymentsLimit.mockImplementation(() => ({ order: mockPaymentsOrder }));
+    mockPaymentsForAccount.mockImplementation(() => ({ limit: mockPaymentsLimit }));
+    mockPayments.mockImplementation(() => ({ forAccount: mockPaymentsForAccount }));
+  });
+
+  describe("validatePublicKey", () => {
+    it("accepts a valid Stellar public key", () => {
+      expect(() => stellarService.validatePublicKey(validPublicKey)).not.toThrow();
+    });
+
+    it("throws on an empty public key", () => {
+      expect(() => stellarService.validatePublicKey("")).toThrow(
+        "Invalid Stellar public key format"
+      );
+    });
+
+    it("throws on an invalid prefix", () => {
+      const invalidPrefix = `S${validPublicKey.slice(1)}`;
+      expect(() => stellarService.validatePublicKey(invalidPrefix)).toThrow(
+        "Invalid Stellar public key format"
+      );
+    });
+  });
+
+  describe("getXLMBalance", () => {
+    it("returns native XLM balance for a valid account", async () => {
+      mockLoadAccount.mockResolvedValue({
+        sequence: "12345",
+        subentry_count: 2,
+        balances: [
+          { asset_type: "credit_alphanum4", asset_code: "USDC", balance: "10.50" },
+          { asset_type: "native", balance: "42.1234567" },
+        ],
+      });
+
+      const balance = await stellarService.getXLMBalance(validPublicKey);
+
+      expect(balance).toBe("42.1234567");
+      expect(mockLoadAccount).toHaveBeenCalledWith(validPublicKey);
+    });
+
+    it("returns 0 when account has no native balance entry", async () => {
+      mockLoadAccount.mockResolvedValue({
+        sequence: "12345",
+        subentry_count: 2,
+        balances: [{ asset_type: "credit_alphanum4", asset_code: "USDC", balance: "10.50" }],
+      });
+
+      const balance = await stellarService.getXLMBalance(validPublicKey);
+
+      expect(balance).toBe("0");
+    });
+
+    it("throws a friendly 404 error for unfunded accounts", async () => {
+      mockLoadAccount.mockRejectedValue({ response: { status: 404 } });
+
+      await expect(stellarService.getXLMBalance(validPublicKey)).rejects.toMatchObject({
+        status: 404,
+      });
+      await expect(stellarService.getXLMBalance(validPublicKey)).rejects.toThrow(
+        "Account not found. It may not be funded yet. Use Friendbot on testnet."
+      );
+    });
+  });
+
+  describe("getPayments", () => {
+    it("returns correctly shaped payment objects and filters non-payment ops", async () => {
+      const textMemoTransaction = jest.fn().mockResolvedValue({ memo_type: "text", memo: "hello" });
+      const noMemoTransaction = jest.fn().mockResolvedValue({ memo_type: "none" });
+
+      mockPaymentsCall.mockResolvedValue({
+        records: [
+          {
+            id: "op-1",
+            type: "payment",
+            amount: "5.0000000",
+            asset_type: "native",
+            from: validPublicKey,
+            to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBC",
+            created_at: "2026-03-27T10:00:00Z",
+            transaction_hash: "txhash1",
+            paging_token: "pt1",
+            transaction: textMemoTransaction,
+          },
+          {
+            id: "op-2",
+            type: "create_account",
+            amount: "1.0000000",
+            asset_type: "native",
+            from: validPublicKey,
+            to: validPublicKey,
+            created_at: "2026-03-27T10:01:00Z",
+            transaction_hash: "txhash2",
+            paging_token: "pt2",
+            transaction: noMemoTransaction,
+          },
+          {
+            id: "op-3",
+            type: "payment",
+            amount: "2.5000000",
+            asset_type: "credit_alphanum4",
+            asset_code: "USDC",
+            from: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+            to: validPublicKey,
+            created_at: "2026-03-27T10:02:00Z",
+            transaction_hash: "txhash3",
+            paging_token: "pt3",
+            transaction: noMemoTransaction,
+          },
+        ],
+      });
+
+      const result = await stellarService.getPayments(validPublicKey, { limit: 10 });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "op-1",
+        type: "sent",
+        amount: "5.0000000",
+        asset: "XLM",
+        from: validPublicKey,
+        to: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBC",
+        memo: "hello",
+        createdAt: "2026-03-27T10:00:00Z",
+        transactionHash: "txhash1",
+        pagingToken: "pt1",
+      });
+      expect(result[1]).toEqual({
+        id: "op-3",
+        type: "received",
+        amount: "2.5000000",
+        asset: "USDC",
+        from: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+        to: validPublicKey,
+        memo: undefined,
+        createdAt: "2026-03-27T10:02:00Z",
+        transactionHash: "txhash3",
+        pagingToken: "pt3",
+      });
+      expect(mockPaymentsForAccount).toHaveBeenCalledWith(validPublicKey);
+      expect(mockPaymentsLimit).toHaveBeenCalledWith(10);
+      expect(mockPaymentsOrder).toHaveBeenCalledWith("desc");
+    });
+
+    it("uses cursor when provided", async () => {
+      mockPaymentsCall.mockResolvedValue({ records: [] });
+
+      await stellarService.getPayments(validPublicKey, { limit: 5, cursor: "12345" });
+
+      expect(mockPaymentsCursor).toHaveBeenCalledWith("12345");
+    });
+
+    it("throws on invalid public key before any Horizon call", async () => {
+      await expect(stellarService.getPayments("invalid-key")).rejects.toThrow(
+        "Invalid Stellar public key format"
+      );
+      expect(mockPayments).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.19.2",
         "express-rate-limit": "^7.3.1",
         "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.0"
       },
       "devDependencies": {
@@ -58,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1911,6 +1913,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2381,6 +2384,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2428,6 +2432,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2947,6 +2957,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3080,6 +3099,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5076,6 +5096,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5133,11 +5196,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -6156,7 +6261,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.3.1",
     "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.0"
   },
   "devDependencies": {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,6 +13,7 @@ const rateLimit = require("express-rate-limit");
 require("dotenv").config();
 
 const accountRoutes = require("./routes/accounts");
+const authRoutes = require("./routes/auth");
 const paymentRoutes = require("./routes/payments");
 const healthRoutes = require("./routes/health");
 const federationRoutes = require("./routes/federation");

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -128,4 +128,4 @@ function validatePublicKey(publicKey) {
   }
 }
 
-module.exports = { getAccount, getXLMBalance, getPayments };
+module.exports = { getAccount, getXLMBalance, getPayments, validatePublicKey };


### PR DESCRIPTION
## Summary
- Add `backend/__tests__/stellarService.test.js` with unit tests for:
  - `getXLMBalance()` happy path and unfunded/404 path
  - `validatePublicKey()` valid and invalid formats
  - `getPayments()` mapping/shape output, filtering, cursor behavior, and invalid key handling
- Mock `@stellar/stellar-sdk` `Horizon.Server` and chained payment query methods to avoid real network calls.
- Export `validatePublicKey` from `backend/src/services/stellarService.js` for direct unit testing.
- Fix existing backend test blockers discovered while running suite:
  - import `authRoutes` in `backend/src/server.js`
  - add missing `jsonwebtoken` dependency in backend package files

## Why
The backend service layer lacked unit tests and relied on live Horizon interactions indirectly. This PR adds deterministic, offline tests for core Stellar service behavior and ensures the current backend suite is runnable.

## Test plan
- [x] Run `npm install` in `backend`
- [x] Run `npm test` in `backend`
- [x] Confirm all test suites pass
- [x] Confirm no real Horizon network calls are made by stellar service tests (SDK fully mocked)

## Result
- Test suites: 2 passed
- Tests: 17 passed



Closes: #14 