### PR TITLE
build creator tip page

### DIFF
--- a/frontend/__tests__/TipWidget.test.tsx
+++ b/frontend/__tests__/TipWidget.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TipWidget from "@/components/TipWidget";
+import { getXLMBalance } from "@/lib/stellar";
+
+const mockSendPaymentForm = jest.fn();
+
+jest.mock("@/components/SendPaymentForm", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockSendPaymentForm(props);
+
+    return (
+      <div data-testid="send-payment-form">
+        <div data-testid="prefill-amount">{props.prefill?.amount}</div>
+        <button type="button" onClick={props.onSuccess}>
+          Complete tip
+        </button>
+      </div>
+    );
+  },
+}));
+
+jest.mock("@/components/WalletConnect", () => ({
+  __esModule: true,
+  default: ({ onConnect }: { onConnect: (publicKey: string) => void }) => (
+    <button type="button" onClick={() => onConnect(`G${"B".repeat(55)}`)}>
+      Mock wallet connect
+    </button>
+  ),
+}));
+
+jest.mock("@/lib/stellar", () => ({
+  getXLMBalance: jest.fn(),
+  shortenAddress: (address: string) => `${address.slice(0, 6)}...${address.slice(-6)}`,
+}));
+
+describe("TipWidget", () => {
+  const destination = `G${"A".repeat(55)}`;
+
+  beforeEach(() => {
+    mockSendPaymentForm.mockClear();
+    (getXLMBalance as jest.Mock).mockResolvedValue("25.5000000");
+  });
+
+  it("shows the wallet connect prompt only after an unconnected user clicks the tip CTA", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TipWidget
+        creatorUsername="alice"
+        destination={destination}
+        publicKey={null}
+        onConnect={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Mock wallet connect")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /connect wallet to tip 0.5 xlm/i }));
+
+    expect(screen.getByText("Mock wallet connect")).toBeInTheDocument();
+  });
+
+  it("uses preset and custom amounts to prefill the existing send form", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TipWidget
+        creatorUsername="alice"
+        destination={destination}
+        publicKey={`G${"C".repeat(55)}`}
+        onConnect={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSendPaymentForm).toHaveBeenCalled();
+    });
+
+    expect(screen.getByTestId("prefill-amount")).toHaveTextContent("0.5");
+
+    await user.click(screen.getByRole("button", { name: /\$20 tip/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("prefill-amount")).toHaveTextContent("10");
+    });
+
+    const customAmountInput = screen.getByLabelText(/custom amount/i);
+    await user.clear(customAmountInput);
+    await user.type(customAmountInput, "3.25");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("prefill-amount")).toHaveTextContent("3.25");
+    });
+  });
+
+  it("shows a success banner after a completed tip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TipWidget
+        creatorUsername="alice"
+        destination={destination}
+        publicKey={`G${"D".repeat(55)}`}
+        onConnect={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /complete tip/i }));
+
+    expect(screen.getByText("Tip sent to @alice")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/tip-page.test.tsx
+++ b/frontend/__tests__/tip-page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import TipPage from "@/pages/tip/[username]";
+import { useRouter } from "next/router";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@/components/TipWidget", () => ({
+  __esModule: true,
+  default: ({
+    creatorUsername,
+    destination,
+  }: {
+    creatorUsername: string;
+    destination: string;
+  }) => (
+    <div data-testid="tip-widget">
+      {creatorUsername}:{destination}
+    </div>
+  ),
+}));
+
+describe("tip page", () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({
+      isReady: true,
+      query: { username: "alice" },
+    });
+
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("loads the tip widget for a resolved username", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          username: "alice",
+          publicKey: `G${"A".repeat(55)}`,
+        },
+      }),
+    });
+
+    render(<TipPage publicKey={null} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tip-widget")).toHaveTextContent(`alice:G${"A".repeat(55)}`);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/accounts/resolve/alice")
+    );
+  });
+
+  it("shows a friendly not-found state for an invalid username", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        error: "Username not found",
+      }),
+    });
+
+    render(<TipPage publicKey={null} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Creator not found")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Username not found")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -24,6 +24,16 @@ interface SendPaymentFormProps {
   xlmBalance: string;
   usdcBalance?: string | null;
   onSuccess?: () => void;
+  title?: string;
+  submitLabel?: string;
+  successTitle?: string;
+  successMessage?: string;
+  assetOptions?: AssetType[];
+  hideAssetSelector?: boolean;
+  hideDestinationField?: boolean;
+  destinationReadOnly?: boolean;
+  hideAmountField?: boolean;
+  hideMemoField?: boolean;
   // FIX: Added prefill to interface to stop the "Property does not exist" error
   prefill?: {
     destination: string;
@@ -44,6 +54,16 @@ export default function SendPaymentForm({
   usdcBalance,
   onSuccess,
   prefill,
+  title = "Send Payment",
+  submitLabel,
+  successTitle = "Payment sent!",
+  successMessage,
+  assetOptions = ["XLM", "USDC"],
+  hideAssetSelector = false,
+  hideDestinationField = false,
+  destinationReadOnly = false,
+  hideAmountField = false,
+  hideMemoField = false,
 }: SendPaymentFormProps) {
   const [selectedAsset, setSelectedAsset] = useState<AssetType>("XLM");
   const [destination, setDestination] = useState("");
@@ -63,6 +83,12 @@ export default function SendPaymentForm({
       if (prefill.memo) setMemo(prefill.memo);
     }
   }, [prefill]);
+
+  useEffect(() => {
+    if (!assetOptions.includes(selectedAsset)) {
+      setSelectedAsset(assetOptions[0] || "XLM");
+    }
+  }, [assetOptions, selectedAsset]);
 
   const xlmBal  = parseFloat(xlmBalance);
   const usdcBal = usdcBalance ? parseFloat(usdcBalance) : 0;
@@ -159,10 +185,10 @@ export default function SendPaymentForm({
           <CheckIcon className="w-7 h-7 text-emerald-400" />
         </div>
         <h3 className="font-display text-lg font-semibold text-white mb-1">
-          {`Payment sent!`}
+          {successTitle}
         </h3>
         <p className="text-slate-400 text-sm mb-4">
-          {formatXLM(amount)} {`sent successfully`}
+          {successMessage || `${formatXLM(amount)} sent successfully`}
         </p>
 
         <a
@@ -182,58 +208,64 @@ export default function SendPaymentForm({
     <div className="card animate-fade-in">
       <h2 className="font-display text-lg font-semibold text-white mb-6 flex items-center gap-2">
         <SendIcon className="w-5 h-5 text-stellar-400" />
-        {`Send Payment`}
+        {title}
       </h2>
 
       <div className="space-y-5">
         {/* Asset selector */}
-        <div className="flex gap-2">
-          {(["XLM", "USDC"] as AssetType[]).map((a) => (
-            <button
-              key={a}
-              type="button"
-              onClick={() => { setSelectedAsset(a); setAmount(""); }}
-              disabled={a === "USDC" && !usdcBalance}
-              className={clsx(
-                "px-4 py-1.5 rounded-full text-sm font-medium border transition-all",
-                selectedAsset === a
-                  ? "bg-stellar-500/15 text-stellar-300 border-stellar-500/30"
-                  : "text-slate-400 border-white/10 hover:border-white/20",
-                a === "USDC" && !usdcBalance && "opacity-40 cursor-not-allowed"
-              )}
-            >
-              {a}
-              {a === "USDC" && !usdcBalance && (
-                <span className="ml-1 text-xs">(no trustline)</span>
-              )}
-            </button>
-          ))}
-        </div>
+        {!hideAssetSelector && (
+          <div className="flex gap-2">
+            {assetOptions.map((a) => (
+              <button
+                key={a}
+                type="button"
+                onClick={() => { setSelectedAsset(a); setAmount(""); }}
+                disabled={a === "USDC" && !usdcBalance}
+                className={clsx(
+                  "px-4 py-1.5 rounded-full text-sm font-medium border transition-all",
+                  selectedAsset === a
+                    ? "bg-stellar-500/15 text-stellar-300 border-stellar-500/30"
+                    : "text-slate-400 border-white/10 hover:border-white/20",
+                  a === "USDC" && !usdcBalance && "opacity-40 cursor-not-allowed"
+                )}
+              >
+                {a}
+                {a === "USDC" && !usdcBalance && (
+                  <span className="ml-1 text-xs">(no trustline)</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Destination */}
-        <div>
-          <label className="label">{`Recipient Address`}</label>
-          <input
-            type="text"
-            value={destination}
-            onChange={(e) => setDestination(e.target.value.trim())}
-            placeholder="G... (Stellar public key)"
-            className={clsx(
-              "input-field",
-              destination.length > 0 && !isValidDest && "border-red-500/50"
+        {!hideDestinationField && (
+          <div>
+            <label className="label">{`Recipient Address`}</label>
+            <input
+              type="text"
+              value={destination}
+              onChange={(e) => setDestination(e.target.value.trim())}
+              placeholder="G... (Stellar public key)"
+              className={clsx(
+                "input-field",
+                destination.length > 0 && !isValidDest && "border-red-500/50"
+              )}
+              disabled={destinationReadOnly || status !== "idle"}
+              readOnly={destinationReadOnly}
+            />
+            {destination.length > 0 && !isValidDest && (
+              <p className="mt-1 text-xs text-red-400">{`Invalid Stellar address`}</p>
             )}
-            disabled={status !== "idle"}
-          />
-          {destination.length > 0 && !isValidDest && (
-            <p className="mt-1 text-xs text-red-400">{`Invalid Stellar address`}</p>
-          )}
-          {destination === publicKey && (
-            <p className="mt-1 text-xs text-amber-400">{`You cannot send to yourself`}</p>
-          )}
-        </div>
+            {destination === publicKey && (
+              <p className="mt-1 text-xs text-amber-400">{`You cannot send to yourself`}</p>
+            )}
+          </div>
+        )}
 
         {/* Amount */}
-        <div>
+        {!hideAmountField && (
+          <div>
           <div className="flex items-center justify-between mb-2">
             <label className="label mb-0">{`Amount (${selectedAsset})`}</label>
 
@@ -297,10 +329,12 @@ export default function SendPaymentForm({
                 : `Minimum amount is 0.0000001 ${selectedAsset} (1 stroop)`}
             </p>
           )}
-        </div>
+          </div>
+        )}
 
         {/* Memo (optional) */}
-        <div>
+        {!hideMemoField && (
+          <div>
           <label className="label">{`Memo (optional)`}</label>
           <input
             type="text"
@@ -312,7 +346,8 @@ export default function SendPaymentForm({
             disabled={status !== "idle"}
           />
           <p className="mt-1 text-xs text-slate-500">{`${memo.length}/28 characters`}</p>
-        </div>
+          </div>
+        )}
 
         {/* Record as Tip On-Chain (Soroban) */}
         {CONTRACT_ID && (
@@ -357,7 +392,7 @@ export default function SendPaymentForm({
           {status === "idle" && (
             <>
               <SendIcon className="w-4 h-4" />
-              {`Send ${amount ? formatXLM(amountNum) : ""} ${selectedAsset}`.trim()}
+              {submitLabel || `Send ${amount ? formatXLM(amountNum) : ""} ${selectedAsset}`.trim()}
             </>
           )}
           {status === "error" && "Retry"}

--- a/frontend/components/TipWidget.tsx
+++ b/frontend/components/TipWidget.tsx
@@ -1,0 +1,362 @@
+import clsx from "clsx";
+import { useEffect, useRef, useState } from "react";
+import SendPaymentForm from "@/components/SendPaymentForm";
+import WalletConnect from "@/components/WalletConnect";
+import { getXLMBalance, shortenAddress } from "@/lib/stellar";
+import { formatXLM } from "@/utils/format";
+
+interface TipWidgetProps {
+  creatorUsername: string;
+  destination: string;
+  publicKey: string | null;
+  onConnect: (publicKey: string) => void;
+}
+
+const PRESET_TIPS = [
+  { label: "$1", amount: "0.5" },
+  { label: "$5", amount: "2" },
+  { label: "$20", amount: "10" },
+] as const;
+
+const MIN_TIP_AMOUNT = 0.0000001;
+
+export default function TipWidget({
+  creatorUsername,
+  destination,
+  publicKey,
+  onConnect,
+}: TipWidgetProps) {
+  const [amount, setAmount] = useState<string>(PRESET_TIPS[0].amount);
+  const [showConnectPrompt, setShowConnectPrompt] = useState(false);
+  const [xlmBalance, setXlmBalance] = useState("0");
+  const [isBalanceLoading, setIsBalanceLoading] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
+  const [formVersion, setFormVersion] = useState(0);
+  const connectPromptRef = useRef<HTMLDivElement | null>(null);
+
+  const parsedAmount = parseFloat(amount);
+  const hasValidAmount = !Number.isNaN(parsedAmount) && parsedAmount >= MIN_TIP_AMOUNT;
+  const selectedPreset = PRESET_TIPS.find((tip) => tip.amount === amount)?.amount ?? null;
+
+  useEffect(() => {
+    if (!publicKey) {
+      setXlmBalance("0");
+      return;
+    }
+
+    let isActive = true;
+    setIsBalanceLoading(true);
+
+    getXLMBalance(publicKey)
+      .then((balance) => {
+        if (isActive) setXlmBalance(balance);
+      })
+      .catch(() => {
+        if (isActive) setXlmBalance("0");
+      })
+      .finally(() => {
+        if (isActive) setIsBalanceLoading(false);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [publicKey]);
+
+  useEffect(() => {
+    if (!showConnectPrompt) return;
+    if (typeof connectPromptRef.current?.scrollIntoView === "function") {
+      connectPromptRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [showConnectPrompt]);
+
+  const handlePresetClick = (presetAmount: string) => {
+    setAmount(presetAmount);
+  };
+
+  const handleCustomAmountChange = (value: string) => {
+    setAmount(value);
+  };
+
+  const handleTipIntent = () => {
+    if (!hasValidAmount) return;
+    if (!publicKey) {
+      setShowConnectPrompt(true);
+    }
+  };
+
+  const handleConnect = (connectedPublicKey: string) => {
+    setShowConnectPrompt(false);
+    onConnect(connectedPublicKey);
+  };
+
+  const handleSuccess = () => {
+    setShowCelebration(true);
+    setFormVersion((current) => current + 1);
+    window.setTimeout(() => setShowCelebration(false), 4200);
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-cosmos-900/80 shadow-2xl shadow-stellar-950/30">
+      {showCelebration && <ConfettiBurst />}
+
+      <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-stellar-500/15 to-transparent pointer-events-none" />
+
+      <div className="relative p-6 sm:p-8 space-y-8">
+        <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stellar-300/80">
+                Public tip page
+              </p>
+              <h1 className="mt-3 font-display text-3xl font-bold text-white">
+                Tip @{creatorUsername}
+              </h1>
+              <p className="mt-2 max-w-xl text-sm leading-7 text-slate-300">
+                Send a fast XLM tip straight to this creator&apos;s Stellar wallet. Pick a preset or
+                choose your own amount, then confirm in Freighter.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-stellar-500/20 bg-stellar-500/10 px-4 py-3 text-sm text-stellar-100">
+              <p className="text-xs uppercase tracking-[0.2em] text-stellar-300/80">Wallet</p>
+              <p className="mt-1 font-mono text-sm text-white" title={destination}>
+                {shortenAddress(destination)}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="font-display text-xl font-semibold text-white">Choose a tip</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  Fixed presets from the issue spec, plus any custom XLM amount you want.
+                </p>
+              </div>
+              <div className="hidden sm:flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1.5 text-xs text-emerald-300">
+                <SparkIcon className="h-3.5 w-3.5" />
+                No account required to view
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-3">
+              {PRESET_TIPS.map((tip) => {
+                const isActive = selectedPreset === tip.amount;
+
+                return (
+                  <button
+                    key={tip.amount}
+                    type="button"
+                    onClick={() => handlePresetClick(tip.amount)}
+                    className={clsx(
+                      "rounded-2xl border px-4 py-4 text-left transition-all",
+                      isActive
+                        ? "border-stellar-400 bg-stellar-500/15 text-white shadow-lg shadow-stellar-950/20"
+                        : "border-white/10 bg-cosmos-950/40 text-slate-200 hover:border-stellar-400/50 hover:bg-white/[0.05]"
+                    )}
+                  >
+                    <span className="block text-sm font-semibold">{tip.label} tip</span>
+                    <span className="mt-1 block font-display text-2xl text-white">
+                      {tip.amount}
+                      <span className="ml-1 text-base text-stellar-300">XLM</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-6">
+              <label htmlFor="tip-amount" className="label">
+                Custom amount
+              </label>
+              <div className="relative mt-2">
+                <input
+                  id="tip-amount"
+                  type="number"
+                  value={amount}
+                  onChange={(event) => handleCustomAmountChange(event.target.value)}
+                  min="0.0000001"
+                  step="0.0000001"
+                  placeholder="0.5000000"
+                  className="input-field pr-16"
+                />
+                <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-sm font-medium text-stellar-300">
+                  XLM
+                </span>
+              </div>
+              {!hasValidAmount && (
+                <p className="mt-2 text-sm text-amber-300">
+                  Enter at least 0.0000001 XLM to continue.
+                </p>
+              )}
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-white/10 bg-cosmos-950/50 px-4 py-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Selected tip</p>
+                  <p className="mt-2 font-display text-3xl font-semibold text-white">
+                    {hasValidAmount ? formatXLM(parsedAmount) : "0 XLM"}
+                  </p>
+                  <p className="mt-2 text-sm text-slate-400">
+                    Recipient: <span className="font-semibold text-slate-200">@{creatorUsername}</span>
+                  </p>
+                </div>
+
+                {publicKey ? (
+                  <div className="text-right">
+                    <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Connected wallet</p>
+                    <p className="mt-2 font-mono text-sm text-slate-200">{shortenAddress(publicKey)}</p>
+                    <p className="mt-2 text-xs text-slate-500">
+                      {isBalanceLoading ? "Checking balance..." : `Balance: ${formatXLM(xlmBalance)}`}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-right text-xs text-amber-200">
+                    Connect only when you are ready to send
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {!publicKey && (
+              <button
+                type="button"
+                onClick={handleTipIntent}
+                disabled={!hasValidAmount}
+                className="btn-primary mt-6 flex w-full items-center justify-center gap-2 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <WalletIcon className="h-4 w-4" />
+                {hasValidAmount ? `Connect wallet to tip ${formatXLM(parsedAmount)}` : "Enter an amount"}
+              </button>
+            )}
+          </div>
+
+          <div className="space-y-5">
+            {showCelebration && (
+              <div className="rounded-3xl border border-emerald-500/20 bg-emerald-500/10 px-5 py-4 text-emerald-100 animate-slide-up">
+                <p className="font-display text-lg font-semibold">Tip sent to @{creatorUsername}</p>
+                <p className="mt-1 text-sm text-emerald-100/80">
+                  Your support is on the way, and the confetti is doing its job.
+                </p>
+              </div>
+            )}
+
+            {!publicKey && showConnectPrompt && (
+              <div ref={connectPromptRef} className="rounded-3xl border border-stellar-500/20 bg-white/[0.03] p-1">
+                <div className="rounded-[22px] border border-white/10 bg-cosmos-950/50 p-5">
+                  <p className="text-sm text-slate-400 mb-4">
+                    Connect your wallet to send {hasValidAmount ? formatXLM(parsedAmount) : "this tip"} to
+                    {" "}@{creatorUsername}.
+                  </p>
+                  <WalletConnect onConnect={handleConnect} />
+                </div>
+              </div>
+            )}
+
+            {publicKey && (
+              <div className="space-y-4">
+                <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-4">
+                  <p className="text-sm text-slate-300">
+                    You are tipping <span className="font-semibold text-white">@{creatorUsername}</span> at{" "}
+                    <span className="font-mono text-slate-200">{shortenAddress(destination)}</span>.
+                  </p>
+                </div>
+
+                <SendPaymentForm
+                  key={`${destination}-${amount}-${formVersion}`}
+                  publicKey={publicKey}
+                  xlmBalance={xlmBalance}
+                  onSuccess={handleSuccess}
+                  prefill={{ destination, amount }}
+                  title={`Send a tip to @${creatorUsername}`}
+                  submitLabel={hasValidAmount ? `Send ${formatXLM(parsedAmount)} tip` : "Send tip"}
+                  successTitle={`Tip sent to @${creatorUsername}!`}
+                  successMessage={hasValidAmount ? `${formatXLM(parsedAmount)} is on the way.` : undefined}
+                  assetOptions={["XLM"]}
+                  hideAssetSelector
+                  hideDestinationField
+                  hideAmountField
+                  hideMemoField
+                />
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function ConfettiBurst() {
+  const pieces = [
+    { left: "8%", delay: 0, duration: 1800, rotate: -18, color: "#34d399" },
+    { left: "14%", delay: 90, duration: 1600, rotate: 22, color: "#38bdf8" },
+    { left: "22%", delay: 140, duration: 1750, rotate: -12, color: "#f59e0b" },
+    { left: "31%", delay: 50, duration: 1650, rotate: 28, color: "#a78bfa" },
+    { left: "39%", delay: 180, duration: 1700, rotate: -25, color: "#fb7185" },
+    { left: "47%", delay: 30, duration: 1500, rotate: 12, color: "#facc15" },
+    { left: "54%", delay: 120, duration: 1850, rotate: -30, color: "#22c55e" },
+    { left: "61%", delay: 70, duration: 1580, rotate: 18, color: "#60a5fa" },
+    { left: "69%", delay: 150, duration: 1780, rotate: -20, color: "#f97316" },
+    { left: "76%", delay: 110, duration: 1680, rotate: 26, color: "#2dd4bf" },
+    { left: "84%", delay: 40, duration: 1720, rotate: -16, color: "#f472b6" },
+    { left: "91%", delay: 130, duration: 1620, rotate: 20, color: "#eab308" },
+  ];
+
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+      {pieces.map((piece, index) => (
+        <span
+          key={`${piece.left}-${index}`}
+          className="absolute top-0 h-3 w-2 rounded-full opacity-90"
+          style={{
+            left: piece.left,
+            backgroundColor: piece.color,
+            animation: `tip-confetti-fall ${piece.duration}ms ease-out ${piece.delay}ms forwards`,
+            transform: `translateY(-20px) rotate(${piece.rotate}deg)`,
+          }}
+        />
+      ))}
+
+      <style>{`
+        @keyframes tip-confetti-fall {
+          0% {
+            opacity: 0;
+            transform: translateY(-18px) scale(0.8) rotate(0deg);
+          }
+          12% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0;
+            transform: translateY(420px) scale(1) rotate(260deg);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function WalletIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 7.5A2.5 2.5 0 015.5 5h11A2.5 2.5 0 0119 7.5V9H7.75A2.75 2.75 0 005 11.75v.5A2.75 2.75 0 007.75 15H19v1.5A2.5 2.5 0 0116.5 19h-11A2.5 2.5 0 013 16.5v-9zm16 1.5h1.25A1.75 1.75 0 0122 10.75v2.5A1.75 1.75 0 0120.25 15H19V9zm-9 3h.01"
+      />
+    </svg>
+  );
+}
+
+function SparkIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3l1.4 4.6L18 9l-4.6 1.4L12 15l-1.4-4.6L6 9l4.6-1.4L12 3zM18.5 16l.7 2.3 2.3.7-2.3.7-.7 2.3-.7-2.3-2.3-.7 2.3-.7.7-2.3zM5.5 15l.9 2.8 2.8.9-2.8.9-.9 2.8-.9-2.8-2.8-.9 2.8-.9.9-2.8z" />
+    </svg>
+  );
+}

--- a/frontend/pages/tip/[username].tsx
+++ b/frontend/pages/tip/[username].tsx
@@ -1,0 +1,243 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+import TipWidget from "@/components/TipWidget";
+
+interface TipPageProps {
+  publicKey: string | null;
+  onConnect: (publicKey: string) => void;
+}
+
+interface ResolvedAccount {
+  username: string;
+  publicKey: string;
+}
+
+type ResolveState =
+  | { status: "loading"; message?: string }
+  | { status: "ready"; account: ResolvedAccount }
+  | { status: "not-found"; message: string }
+  | { status: "error"; message: string };
+
+export default function TipPage({ publicKey, onConnect }: TipPageProps) {
+  const router = useRouter();
+  const routeUsername = useMemo(() => {
+    const raw = router.query.username;
+    return typeof raw === "string" ? raw : null;
+  }, [router.query.username]);
+
+  const [resolveState, setResolveState] = useState<ResolveState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    if (!routeUsername) {
+      setResolveState({
+        status: "not-found",
+        message: "We could not figure out which creator tip page you were trying to open.",
+      });
+      return;
+    }
+
+    let isActive = true;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "";
+
+    setResolveState({
+      status: "loading",
+      message: `Looking up @${routeUsername}...`,
+    });
+
+    fetch(`${apiBase}/api/accounts/resolve/${encodeURIComponent(routeUsername)}`)
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null);
+
+        if (response.status === 404) {
+          throw new ResolveError(
+            "not-found",
+            payload?.error || `@${routeUsername} does not have a public tip page yet.`
+          );
+        }
+
+        if (!response.ok) {
+          throw new ResolveError(
+            "error",
+            payload?.error || "We could not load this tip page right now."
+          );
+        }
+
+        const account = payload?.data;
+        if (!payload?.success || !account?.publicKey || !account?.username) {
+          throw new ResolveError("error", "The tip page response was incomplete.");
+        }
+
+        return {
+          username: account.username,
+          publicKey: account.publicKey,
+        } satisfies ResolvedAccount;
+      })
+      .then((account) => {
+        if (!isActive) return;
+        setResolveState({ status: "ready", account });
+      })
+      .catch((error: unknown) => {
+        if (!isActive) return;
+
+        if (error instanceof ResolveError) {
+          setResolveState({ status: error.kind, message: error.message });
+          return;
+        }
+
+        setResolveState({
+          status: "error",
+          message: "Something went wrong while loading this creator. Please try again.",
+        });
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [routeUsername, router.isReady]);
+
+  const pageTitle =
+    resolveState.status === "ready"
+      ? `Tip @${resolveState.account.username} | Stellar MicroPay`
+      : routeUsername
+        ? `Tip @${routeUsername} | Stellar MicroPay`
+        : "Tip Creator | Stellar MicroPay";
+
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+
+      <div className="relative min-h-[calc(100vh-88px)] overflow-hidden px-4 py-10 sm:px-6">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute left-1/2 top-0 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-stellar-500/10 blur-3xl" />
+          <div className="absolute bottom-0 right-0 h-[320px] w-[320px] rounded-full bg-emerald-500/10 blur-3xl" />
+        </div>
+
+        <div className="relative mx-auto max-w-6xl">
+          {resolveState.status === "loading" && (
+            <LoadingState message={resolveState.message || "Loading tip page..."} />
+          )}
+
+          {resolveState.status === "not-found" && (
+            <FriendlyErrorState
+              title="Creator not found"
+              message={resolveState.message}
+              accent="amber"
+            />
+          )}
+
+          {resolveState.status === "error" && (
+            <FriendlyErrorState
+              title="Tip page unavailable"
+              message={resolveState.message}
+              accent="red"
+            />
+          )}
+
+          {resolveState.status === "ready" && (
+            <TipWidget
+              creatorUsername={resolveState.account.username}
+              destination={resolveState.account.publicKey}
+              publicKey={publicKey}
+              onConnect={onConnect}
+            />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function LoadingState({ message }: { message: string }) {
+  return (
+    <div className="rounded-[32px] border border-white/10 bg-cosmos-900/70 p-8 shadow-2xl shadow-stellar-950/20">
+      <div className="grid gap-6 lg:grid-cols-[1fr_1.05fr]">
+        <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+          <div className="h-3 w-28 rounded-full bg-white/10 animate-pulse" />
+          <div className="mt-4 h-10 w-48 rounded-full bg-white/10 animate-pulse" />
+          <div className="mt-4 space-y-2">
+            <div className="h-4 w-full rounded-full bg-white/10 animate-pulse" />
+            <div className="h-4 w-5/6 rounded-full bg-white/10 animate-pulse" />
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
+          <div className="h-6 w-36 rounded-full bg-white/10 animate-pulse" />
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            {[0, 1, 2].map((item) => (
+              <div key={item} className="h-24 rounded-2xl bg-white/10 animate-pulse" />
+            ))}
+          </div>
+          <div className="mt-6 h-12 rounded-2xl bg-white/10 animate-pulse" />
+        </div>
+      </div>
+
+      <p className="mt-6 text-center text-sm text-slate-400">{message}</p>
+    </div>
+  );
+}
+
+function FriendlyErrorState({
+  title,
+  message,
+  accent,
+}: {
+  title: string;
+  message: string;
+  accent: "amber" | "red";
+}) {
+  const accentClasses =
+    accent === "amber"
+      ? "border-amber-500/20 bg-amber-500/10 text-amber-200"
+      : "border-red-500/20 bg-red-500/10 text-red-200";
+
+  return (
+    <div className="mx-auto max-w-2xl rounded-[32px] border border-white/10 bg-cosmos-900/70 p-8 text-center shadow-2xl shadow-stellar-950/20">
+      <div className={["mx-auto flex h-20 w-20 items-center justify-center rounded-full border", accentClasses].join(" ")}>
+        <PlanetIcon className="h-10 w-10" />
+      </div>
+
+      <h1 className="mt-6 font-display text-4xl font-bold text-white">{title}</h1>
+      <p className="mx-auto mt-4 max-w-xl text-base leading-8 text-slate-300">{message}</p>
+
+      <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <Link href="/" className="btn-primary px-8 py-3">
+          Back to home
+        </Link>
+        <button
+          type="button"
+          onClick={() => window.history.back()}
+          className="btn-secondary px-8 py-3"
+        >
+          Go back
+        </button>
+      </div>
+    </div>
+  );
+}
+
+class ResolveError extends Error {
+  kind: "not-found" | "error";
+
+  constructor(kind: "not-found" | "error", message: string) {
+    super(message);
+    this.kind = kind;
+  }
+}
+
+function PlanetIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 21a8 8 0 100-16 8 8 0 000 16zm0 0c3.4 0 6.7-1.1 9.4-3.2.4-.3.4-.9 0-1.2-2.7-2.1-6-3.2-9.4-3.2s-6.7 1.1-9.4 3.2c-.4.3-.4.9 0 1.2C5.3 19.9 8.6 21 12 21zm0-16c2.9 0 5.7-.8 8.2-2.2.5-.3.6-.9.2-1.3-.9-.9-2.1-1.5-3.4-1.5H7c-1.3 0-2.5.6-3.4 1.5-.4.4-.3 1 .2 1.3C6.3 4.2 9.1 5 12 5z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
closes #22 

**PR Title**

`feat(frontend): add public creator tip page with username resolution`

**PR Description**


This PR adds a public tip experience at `/tip/[username]` so anyone can send XLM to a creator using their username.

## What Changed

- added a new dynamic Next.js route at `/tip/[username]`
- resolved creator wallet addresses via `GET /api/accounts/resolve/:username`
- created a reusable `TipWidget` for the public tipping flow
- added preset tip buttons for `0.5 XLM`, `2 XLM`, and `10 XLM`
- added support for entering a custom XLM amount
- reused the existing `SendPaymentForm` transaction flow instead of duplicating payment logic
- showed an inline wallet connect prompt when an unconnected viewer tries to tip
- added a celebratory success state with confetti after a successful tip
- added a friendly 404-style error state for invalid usernames
- added frontend tests for the tip widget and tip page behavior

## Why

This enables creators to have a simple shareable public tipping page while keeping the actual payment flow consistent with the app’s existing send-payment logic.

## Files Changed

- `frontend/pages/tip/[username].tsx`
- `frontend/components/TipWidget.tsx`
- `frontend/components/SendPaymentForm.tsx`
- `frontend/__tests__/TipWidget.test.tsx`
- `frontend/__tests__/tip-page.test.tsx`

## Notes

- preset buttons are labeled by the issue’s dollar tiers and use the issue-specified XLM values:
  - `$1` -> `0.5 XLM`
  - `$5` -> `2 XLM`
  - `$20` -> `10 XLM`
- the tip page works without the viewer being connected; wallet connection is only requested on tip intent
- the payment flow continues to use the existing `SendPaymentForm` logic under the hood

## Testing

- `npm.cmd run type-check`
- `npm.cmd test -- --runInBand`

## Acceptance Criteria Covered

- `/tip/alice` loads a public tip page for `alice`
- preset tip buttons pre-fill the amount
- custom amount input works
- tipping flow uses existing `SendPaymentForm` logic
- unconnected users see a wallet connect prompt
- invalid usernames show a friendly error state
```
