### PR TITLE
feat: add balance sparkline chart to dashboard (#68 #37)

### DIFF
--- a/frontend/__tests__/dashboard-payment-stats.test.tsx
+++ b/frontend/__tests__/dashboard-payment-stats.test.tsx
@@ -22,6 +22,8 @@ jest.mock("@/lib/stellar", () => ({
   fundWithFriendbot: jest.fn(),
   ACCOUNT_NOT_FOUND_ERROR: "ACCOUNT_NOT_FOUND",
   streamPayments: jest.fn(() => jest.fn()),
+  getRecentPaymentsForSparkline: jest.fn().mockResolvedValue([]),
+  getPaymentHistory: jest.fn().mockResolvedValue({ records: [], hasMore: false }),
 }));
 
 const PUBLIC_KEY = "GABC1234567890ABCDEF";
@@ -42,6 +44,8 @@ describe("Dashboard payment stats widget", () => {
     stellar.getXLMBalance.mockResolvedValue("500.0000000");
     stellar.getUSDCBalance.mockResolvedValue(null);
     stellar.streamPayments.mockImplementation(() => jest.fn());
+    stellar.getRecentPaymentsForSparkline.mockResolvedValue([]);
+    stellar.getPaymentHistory.mockResolvedValue({ records: [], hasMore: false });
   });
 
   afterEach(() => {

--- a/frontend/__tests__/dashboard-sparkline.test.tsx
+++ b/frontend/__tests__/dashboard-sparkline.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Tests for the balance sparkline chart on the Dashboard.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Dashboard from "@/pages/dashboard";
+
+jest.mock("next/router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("@/components/WalletConnect", () => () => <div>Wallet Connect</div>);
+jest.mock("@/components/TransactionList", () => () => <div>Transactions</div>);
+jest.mock("@/components/Toast", () => () => null);
+jest.mock("@/components/QRCodeModal", () => () => null);
+jest.mock("@/components/SendPaymentForm", () => ({
+  __esModule: true,
+  default: () => <div>Send Payment</div>,
+}));
+jest.mock("@/components/PaymentLinkGenerator", () => () => <div>Payment Link</div>);
+
+const mockGetRecentPaymentsForSparkline = jest.fn();
+
+jest.mock("@/lib/stellar", () => ({
+  getXLMBalance: jest.fn().mockResolvedValue("500.0000000"),
+  getUSDCBalance: jest.fn().mockResolvedValue(null),
+  fundWithFriendbot: jest.fn(),
+  ACCOUNT_NOT_FOUND_ERROR: "ACCOUNT_NOT_FOUND",
+  streamPayments: jest.fn(() => jest.fn()),
+  isValidStellarAddress: jest.fn().mockReturnValue(true),
+  shortenAddress: jest.fn((pk: string) => pk.slice(0, 6)),
+  explorerUrl: jest.fn((hash: string) => `https://stellar.expert/tx/${hash}`),
+  getRecentPaymentsForSparkline: (...args: unknown[]) =>
+    mockGetRecentPaymentsForSparkline(...args),
+}));
+
+jest.mock("@/lib/wallet", () => ({
+  signTransactionWithWallet: jest.fn(),
+}));
+
+const PUBLIC_KEY = "GABC1234567890ABCDEF";
+
+function makePayment(
+  id: string,
+  type: "sent" | "received",
+  amount: string
+) {
+  return {
+    id,
+    type,
+    amount,
+    asset: "XLM",
+    from: type === "sent" ? PUBLIC_KEY : "GOTHER",
+    to: type === "received" ? PUBLIC_KEY : "GOTHER",
+    createdAt: new Date().toISOString(),
+    transactionHash: `hash${id}`,
+  };
+}
+
+function setupFetch(statsOk = true) {
+  global.fetch = jest.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("coingecko")) {
+      return Promise.resolve({ json: async () => ({ stellar: { usd: 0.3 } }) } as Response);
+    }
+    if (url.includes("/api/payments/")) {
+      return Promise.resolve({
+        ok: statsOk,
+        json: async () =>
+          statsOk
+            ? {
+                success: true,
+                data: {
+                  publicKey: PUBLIC_KEY,
+                  totalSentXLM: "10.0000000",
+                  totalReceivedXLM: "20.0000000",
+                  sentCount: 1,
+                  receivedCount: 2,
+                  totalTransactions: 3,
+                },
+              }
+            : { success: false },
+      } as Response);
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as jest.Mock;
+}
+
+describe("Dashboard balance sparkline", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const stellar = require("@/lib/stellar");
+    stellar.getXLMBalance.mockResolvedValue("500.0000000");
+    stellar.getUSDCBalance.mockResolvedValue(null);
+    stellar.streamPayments.mockImplementation(() => jest.fn());
+  });
+
+  it("renders sparkline SVG when transaction history is available", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockResolvedValue([
+      makePayment("1", "received", "10"),
+      makePayment("2", "sent", "3"),
+      makePayment("3", "received", "5"),
+    ]);
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /balance trend/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows upward trend label when net balance increases", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockResolvedValue([
+      makePayment("1", "received", "10"),
+      makePayment("2", "received", "5"),
+    ]);
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/upward trend/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows downward trend label when net balance decreases", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockResolvedValue([
+      makePayment("1", "sent", "10"),
+      makePayment("2", "sent", "5"),
+    ]);
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/downward trend/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does not render sparkline when there are no transactions", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockResolvedValue([]);
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    // Give time for async effects to settle
+    await waitFor(() => {
+      expect(screen.queryByRole("img", { name: /balance trend/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders correctly with fewer than 10 transactions", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockResolvedValue([
+      makePayment("1", "received", "2"),
+      makePayment("2", "sent", "1"),
+    ]);
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /balance trend/i })).toBeInTheDocument();
+    });
+  });
+
+  it("does not crash when sparkline fetch fails", async () => {
+    setupFetch();
+    mockGetRecentPaymentsForSparkline.mockRejectedValue(new Error("Network error"));
+
+    render(<Dashboard publicKey={PUBLIC_KEY} onConnect={jest.fn()} />);
+
+    // Should still render the balance without sparkline
+    await waitFor(() => {
+      expect(screen.queryByRole("img", { name: /balance trend/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/__tests__/dashboard-usd.test.tsx
+++ b/frontend/__tests__/dashboard-usd.test.tsx
@@ -16,6 +16,8 @@ jest.mock("@/lib/stellar", () => ({
   fundWithFriendbot: jest.fn(),
   ACCOUNT_NOT_FOUND_ERROR: "ACCOUNT_NOT_FOUND",
   streamPayments: jest.fn(() => jest.fn()),
+  getRecentPaymentsForSparkline: jest.fn().mockResolvedValue([]),
+  getPaymentHistory: jest.fn().mockResolvedValue({ records: [], hasMore: false }),
   isValidStellarAddress: jest.fn().mockReturnValue(true),
   shortenAddress: jest.fn((pk: string) => pk.slice(0, 6)),
   explorerUrl: jest.fn((hash: string) => `https://stellar.expert/tx/${hash}`),
@@ -35,6 +37,8 @@ describe("Dashboard USD price display", () => {
     stellar.getXLMBalance.mockResolvedValue("500.0000000");
     stellar.getUSDCBalance.mockResolvedValue(null);
     stellar.streamPayments.mockImplementation(() => jest.fn());
+    stellar.getRecentPaymentsForSparkline.mockResolvedValue([]);
+    stellar.getPaymentHistory.mockResolvedValue({ records: [], hasMore: false });
     stellar.isValidStellarAddress.mockReturnValue(true);
     stellar.shortenAddress.mockImplementation((pk: string) => pk.slice(0, 6));
   });

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -587,6 +587,24 @@ export async function getContractTipTotal(recipient: string): Promise<string> {
 }
 
 /**
+ * Fetch the last N payment transactions for sparkline chart rendering.
+ * Returns records in chronological order (oldest first) so the chart
+ * reads left-to-right over time.
+ *
+ * @param publicKey - Stellar public key (G...) of the account.
+ * @param limit - Number of recent payments to fetch. Defaults to `10`.
+ * @returns Array of {@link PaymentRecord} sorted oldest → newest.
+ */
+export async function getRecentPaymentsForSparkline(
+  publicKey: string,
+  limit = 10
+): Promise<PaymentRecord[]> {
+  const { records } = await getPaymentHistory(publicKey, limit);
+  // getPaymentHistory returns newest-first; reverse for chronological order
+  return records.slice().reverse();
+}
+
+/**
  * Start a server-sent events (SSE) stream of payment operations for an account.
  *
  * Uses Horizon's streaming support under the hood via the JS SDK. New payment

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -17,6 +17,7 @@ import {
   fundWithFriendbot,
   ACCOUNT_NOT_FOUND_ERROR,
   streamPayments,
+  getRecentPaymentsForSparkline,
   PaymentRecord,
 } from "@/lib/stellar";
 import { formatUSD, copyToClipboard } from "@/utils/format";
@@ -53,6 +54,8 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   const [paymentStatsLoading, setPaymentStatsLoading] = useState(false);
   const [paymentStatsError, setPaymentStatsError] = useState<string | null>(null);
   const [incomingPayment, setIncomingPayment] = useState<PaymentRecord | null>(null);
+  const [sparklineData, setSparklineData] = useState<number[]>([]);
+  const [sparklineLoading, setSparklineLoading] = useState(false);
 
   const fetchBalance = useCallback(async () => {
     if (!publicKey) return;
@@ -128,6 +131,32 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
     }
   }, [publicKey]);
 
+  const fetchSparklineData = useCallback(async () => {
+    if (!publicKey) return;
+    setSparklineLoading(true);
+    try {
+      const records = await getRecentPaymentsForSparkline(publicKey, 10);
+      if (records.length === 0) {
+        setSparklineData([]);
+        return;
+      }
+      // Build running balance from oldest to newest.
+      // We don't know the exact starting balance, so we use relative deltas
+      // anchored at 0 and let the chart show the trend shape.
+      let running = 0;
+      const points = records.map((r) => {
+        const amt = parseFloat(r.amount);
+        running += r.type === "received" ? amt : -amt;
+        return running;
+      });
+      setSparklineData(points);
+    } catch {
+      setSparklineData([]);
+    } finally {
+      setSparklineLoading(false);
+    }
+  }, [publicKey]);
+
   const handleFriendbot = async () => {
     if (!publicKey) return;
 
@@ -150,6 +179,10 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
   useEffect(() => {
     fetchPaymentStats();
   }, [fetchPaymentStats, refreshKey]);
+
+  useEffect(() => {
+    fetchSparklineData();
+  }, [fetchSparklineData, refreshKey]);
 
   useEffect(() => {
     fetch("https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd")
@@ -271,6 +304,11 @@ export default function Dashboard({ publicKey, onConnect }: DashboardProps) {
                   <p className="text-sm text-slate-400 mt-0.5">
                     {formatUSD(parseFloat(xlmBalance) * xlmPrice)}
                   </p>
+                )}
+                {!sparklineLoading && sparklineData.length > 0 && (
+                  <div className="mt-3">
+                    <BalanceSparkline data={sparklineData} />
+                  </div>
                 )}
                 <button
                   onClick={fetchBalance}
@@ -486,6 +524,103 @@ function formatStatsXLM(amount: string, suffix = "sent") {
     minimumFractionDigits: 2,
     maximumFractionDigits: 7,
   })} XLM ${suffix}`;
+}
+
+// ─── Sparkline chart ─────────────────────────────────────────────────────────
+
+/**
+ * Inline SVG sparkline showing balance change over the last N transactions.
+ * Green when the overall trend is upward, red when downward.
+ * Hover tooltip shows the running balance delta at each data point.
+ */
+function BalanceSparkline({ data }: { data: number[] }) {
+  const W = 160;
+  const H = 40;
+  const PAD = 4;
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1; // avoid division by zero for flat lines
+
+  const points = data.map((v, i) => {
+    const x = PAD + (i / Math.max(data.length - 1, 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - min) / range) * (H - PAD * 2);
+    return { x, y, value: v };
+  });
+
+  const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
+
+  const trend = data[data.length - 1] >= data[0];
+  const color = trend ? "#22c55e" : "#ef4444"; // green-500 / red-500
+  const fillColor = trend ? "rgba(34,197,94,0.12)" : "rgba(239,68,68,0.12)";
+
+  // Closed path for the fill area under the line
+  const fillPath =
+    `M ${points[0].x},${H - PAD} ` +
+    points.map((p) => `L ${p.x},${p.y}`).join(" ") +
+    ` L ${points[points.length - 1].x},${H - PAD} Z`;
+
+  return (
+    <div className="relative inline-block" aria-label="Balance sparkline chart">
+      <svg
+        width={W}
+        height={H}
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label={`Balance trend: ${trend ? "upward" : "downward"}`}
+      >
+        {/* Fill area */}
+        <path d={fillPath} fill={fillColor} />
+        {/* Line */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        {/* Interactive dots with tooltips */}
+        {points.map((p, i) => (
+          <g key={i} className="group">
+            <circle
+              cx={p.x}
+              cy={p.y}
+              r={5}
+              fill="transparent"
+              className="cursor-pointer"
+            />
+            <circle
+              cx={p.x}
+              cy={p.y}
+              r={2.5}
+              fill={color}
+              className="opacity-0 group-hover:opacity-100 transition-opacity"
+            />
+            {/* SVG foreignObject tooltip */}
+            <foreignObject
+              x={Math.min(p.x - 36, W - 76)}
+              y={p.y < H / 2 ? p.y + 6 : p.y - 30}
+              width={72}
+              height={24}
+              className="pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity overflow-visible"
+            >
+              <div
+                className="bg-cosmos-900 border border-white/10 rounded px-1.5 py-0.5 text-xs text-white whitespace-nowrap text-center"
+                style={{ fontSize: "10px" }}
+              >
+                {p.value >= 0 ? "+" : ""}
+                {p.value.toFixed(4)} XLM
+              </div>
+            </foreignObject>
+          </g>
+        ))}
+      </svg>
+      <p className="text-xs mt-0.5" style={{ color, fontSize: "10px" }}>
+        {trend ? "▲ Upward trend" : "▼ Downward trend"}
+      </p>
+    </div>
+  );
 }
 
 function CheckIcon({ className }: { className?: string }) {


### PR DESCRIPTION
closes #68 

## Summary

Adds a sparkline chart to the XLM balance card on the dashboard, showing the balance trend over the last 10 payment transactions.

## Changes

### `frontend/lib/stellar.ts`
- Added `getRecentPaymentsForSparkline(publicKey, limit)` — fetches the last N payments and returns them chronologically for left-to-right chart rendering.

### `frontend/pages/dashboard.tsx`
- Added `sparklineData` state + `fetchSparklineData` callback building a running balance delta array.
- Added `BalanceSparkline` component: pure inline SVG with fill area, polyline, and per-point hover tooltips (no library).
- Trend colour: green when last ≥ first, red otherwise.
- Graceful empty state when no transactions exist.

### `frontend/__tests__/dashboard-sparkline.test.tsx` (new)
- 6 tests: SVG renders, upward trend, downward trend, empty state, <10 transactions, fetch failure resilience.

### Existing test fixes
- Added `getRecentPaymentsForSparkline` + `getPaymentHistory` to stellar mocks in `dashboard-usd` and `dashboard-payment-stats` tests, eliminating pre-existing console.error noise.

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Sparkline chart appears in the balance card | ✅ |
| Chart reflects real transaction history | ✅ |
| Trend colour accurate (green up, red down) | ✅ |
| Hover tooltip shows balance value | ✅ |
| Renders correctly with fewer than 10 transactions | ✅ |

## Tests
16/16 passing, 0 console errors.
