### PR TITLE
feat: memo colour warning, particle animation, send again prefill, network status (#161 #165 #166 #168)

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -5,8 +5,8 @@
 
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { shortenAddress } from "@/lib/stellar";
-import { getNetworkConfig } from "@/lib/stellar";
+import { useEffect, useState } from "react";
+import { shortenAddress, getNetworkConfig, fetchNetworkFeeStats, type FeeLevel } from "@/lib/stellar";
 import clsx from "clsx";
 import { useTheme } from "@/pages/_app";
 
@@ -41,8 +41,24 @@ export default function Navbar({
       : "border-amber-400/35 bg-amber-400/10 text-amber-300");
 
   // Issue #19 — Add dark/light mode toggle | Emmy123222/Stellar-MicroPay
-  // Consumes ThemeContext to read current theme and trigger toggle
   const { theme, toggleTheme } = useTheme();
+
+  // Issue #168 — Network status indicator
+  const [feeLevel, setFeeLevel] = useState<FeeLevel | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const stats = await fetchNetworkFeeStats();
+        if (!cancelled) setFeeLevel(stats.feeLevel);
+      } catch {
+        // silently ignore — dot simply won't show on error
+      }
+    };
+    void load();
+    const interval = setInterval(() => void load(), 60_000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, []);
 
   return (
     <nav className="sticky top-0 z-50 border-b border-[rgba(14,165,233,0.12)] bg-white/80 dark:bg-cosmos-900/80 backdrop-blur-xl transition-colors duration-300">
@@ -66,6 +82,20 @@ export default function Navbar({
           >
             {networkLabel}
           </span>
+
+          {/* Network fee status dot */}
+          {feeLevel && (
+            <span
+              title={`Network: ${feeLevel.charAt(0).toUpperCase() + feeLevel.slice(1)}`}
+              aria-label={`Network fee status: ${feeLevel}`}
+              className={clsx(
+                "hidden md:inline-block w-2.5 h-2.5 rounded-full border transition-colors",
+                feeLevel === "normal"   && "bg-emerald-400 border-emerald-400/50",
+                feeLevel === "elevated" && "bg-amber-400 border-amber-400/50",
+                feeLevel === "high"     && "bg-red-400 border-red-400/50",
+              )}
+            />
+          )}
 
           {/* Nav links */}
           <div className="hidden md:flex items-center gap-1">

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -46,6 +46,8 @@ interface SendPaymentFormProps {
     amount: string;
     memo?: string;
     validUntil?: number;
+    /** True when pre-filled from the "Send again" action in transaction history. */
+    fromHistory?: boolean;
   } | null;
   // AI Assistant prefill
   aiPrefill?: {
@@ -948,11 +950,12 @@ export default function SendPaymentForm({
 
 
         {/* Pre-fill notice */}
-          {prefill && (
+        {prefill?.fromHistory && (
           <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-stellar-500/10 border border-stellar-500/20 text-stellar-400 text-xs">
-         <InfoIcon className="w-3.5 h-3.5 flex-shrink-0" />
-           Pre-filled from transaction history
-         </div>)}
+            <InfoIcon className="w-3.5 h-3.5 flex-shrink-0" />
+            Pre-filled from transaction history
+          </div>
+        )}
 
         {/* Destination */}
         {!hideDestinationField && (
@@ -1125,13 +1128,29 @@ export default function SendPaymentForm({
             <input
               type="text"
               value={memo}
-              onChange={(e) => setMemo(e.target.value)}
+              onChange={(e) => setMemo(e.target.value.slice(0, 28))}
               placeholder="Payment note..."
               maxLength={28}
               className="input-field"
               disabled={status !== "idle"}
             />
-            <p className="mt-1 text-xs text-slate-500">{`${memo.length}/28 characters`}</p>
+            <p
+              className={clsx(
+                "mt-1 text-xs",
+                memo.length >= 28
+                  ? "text-red-400"
+                  : memo.length >= 25
+                  ? "text-red-400"
+                  : memo.length >= 20
+                  ? "text-amber-400"
+                  : "text-slate-500"
+              )}
+              title="Stellar memos are limited to 28 bytes"
+            >
+              {memo.length >= 28
+                ? "Max reached (28 chars)"
+                : `${memo.length}/28 characters`}
+            </p>
           </div>
             disabled={status !== "idle"}
           />
@@ -1151,15 +1170,24 @@ export default function SendPaymentForm({
         {!hideMemoField && (
           <div>
           <label className="label">{`Memo (optional)`}</label>
-          <input
-            type="text"
-            value={memo}
-            onChange={(e) => handleMemoChange(e.target.value)}
-            placeholder="Payment note..."
-            maxLength={28}
-            className="input-field"
-            disabled={status !== "idle"}
-          />
+          <div className="relative">
+            <input
+              type="text"
+              value={memo}
+              onChange={(e) => handleMemoChange(e.target.value.slice(0, 28))}
+              placeholder="Payment note..."
+              maxLength={28}
+              className="input-field pr-10"
+              disabled={status !== "idle"}
+            />
+            <span
+              title="Stellar memos are limited to 28 bytes — this keeps transactions compatible with the Stellar network."
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 cursor-help select-none"
+              aria-label="Stellar memo byte limit info"
+            >
+              ℹ
+            </span>
+          </div>
 
           <div className="mt-3 flex flex-wrap gap-2">
             {memoTemplates.map((template) => {
@@ -1184,7 +1212,22 @@ export default function SendPaymentForm({
             })}
           </div>
 
-          <p className="mt-3 text-xs text-slate-500">{`${memo.length}/28 characters`}</p>
+          <p
+            className={clsx(
+              "mt-1 text-xs",
+              memo.length >= 28
+                ? "text-red-400"
+                : memo.length >= 25
+                ? "text-red-400"
+                : memo.length >= 20
+                ? "text-amber-400"
+                : "text-slate-500"
+            )}
+          >
+            {memo.length >= 28
+              ? "Max reached (28 chars)"
+              : `${memo.length}/28 characters`}
+          </p>
         </div>
 
         {/* Record as Tip On-Chain (Soroban) */}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -1016,3 +1016,50 @@ export async function resolveFederationAddress(
     );
   }
 }
+
+// ── Network fee status (#168) ──────────────────────────────────────────────
+
+export type FeeLevel = "normal" | "elevated" | "high";
+
+export interface NetworkFeeStats {
+  feeLevel: FeeLevel;
+  /** Most-recent base fee in XLM (e.g. 0.00001) */
+  baseFeeXlm: number;
+}
+
+/**
+ * Fetches the current network fee statistics from Horizon and classifies
+ * the fee level for the network status indicator.
+ *
+ * Thresholds (mode base fee in stroops):
+ *   normal   — < 100 stroops (< 0.00001 XLM)
+ *   elevated — 100–1000 stroops
+ *   high     — > 1000 stroops
+ */
+export async function fetchNetworkFeeStats(): Promise<NetworkFeeStats> {
+  const config = getNetworkConfig();
+  const url = `${config.horizonUrl}/fee_stats`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Horizon fee_stats returned ${res.status}`);
+  }
+
+  const data = await res.json() as {
+    fee_charged: { mode: string };
+  };
+
+  const modeStroops = parseInt(data.fee_charged?.mode ?? "100", 10);
+  const baseFeeXlm = modeStroops / 10_000_000;
+
+  let feeLevel: FeeLevel;
+  if (modeStroops < 100) {
+    feeLevel = "normal";
+  } else if (modeStroops <= 1000) {
+    feeLevel = "elevated";
+  } else {
+    feeLevel = "high";
+  }
+
+  return { feeLevel, baseFeeXlm };
+}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -86,14 +86,21 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
   const router = useRouter();
   const [activePaymentTab, setActivePaymentTab] = useState<"single" | "batch">("single");
 
-  // Build prefill object from query parameters (e.g., from contacts page)
-  const prefill = router.query.prefillDestination
-    ? {
-        destination: router.query.prefillDestination as string,
-        amount: "",
-        memo: "",
-      }
-    : null;
+  // Build prefill object from query parameters.
+  // Supports legacy ?prefillDestination= (contacts page) and
+  // new ?to=&amount= (Send Again from transaction history).
+  const { prefillDestination, to, amount: queryAmount } = router.query;
+  const prefill =
+    prefillDestination
+      ? { destination: prefillDestination as string, amount: "", memo: "" }
+      : to
+      ? {
+          destination: to as string,
+          amount: typeof queryAmount === "string" ? queryAmount : "",
+          memo: "",
+          fromHistory: true,
+        }
+      : null;
   const [friendbotLoading, setFriendbotLoading] = useState(false);
   const [friendbotSuccessMessage, setFriendbotSuccessMessage] = useState<string | null>(null);
   const [paymentStats, setPaymentStats] = useState<PaymentStats | null>(null);

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -41,6 +41,44 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-stellar-500/5 rounded-full blur-3xl pointer-events-none" />
       <div className="absolute top-20 right-0 w-[300px] h-[300px] bg-stellar-600/5 rounded-full blur-2xl pointer-events-none" />
 
+      {/* Star particle animation — CSS-only, respects prefers-reduced-motion */}
+      <div className="hero-particles" aria-hidden="true">
+        {[
+          { top: "8%",  left: "12%", sz: "2px", op: "0.7", dur: "7s",  delay: "0s"   },
+          { top: "15%", left: "80%", sz: "3px", op: "0.5", dur: "9s",  delay: "1s"   },
+          { top: "25%", left: "35%", sz: "2px", op: "0.6", dur: "6s",  delay: "2s"   },
+          { top: "40%", left: "90%", sz: "2px", op: "0.4", dur: "8s",  delay: "0.5s" },
+          { top: "55%", left: "5%",  sz: "3px", op: "0.6", dur: "11s", delay: "1.5s" },
+          { top: "60%", left: "60%", sz: "2px", op: "0.5", dur: "7s",  delay: "3s"   },
+          { top: "70%", left: "25%", sz: "2px", op: "0.4", dur: "9s",  delay: "0.8s" },
+          { top: "80%", left: "70%", sz: "3px", op: "0.6", dur: "6s",  delay: "2.2s" },
+          { top: "5%",  left: "50%", sz: "2px", op: "0.5", dur: "8s",  delay: "1.8s" },
+          { top: "35%", left: "18%", sz: "2px", op: "0.7", dur: "10s", delay: "0.3s" },
+          { top: "50%", left: "45%", sz: "3px", op: "0.4", dur: "7s",  delay: "2.5s" },
+          { top: "88%", left: "88%", sz: "2px", op: "0.6", dur: "9s",  delay: "1.1s" },
+          { top: "20%", left: "65%", sz: "2px", op: "0.5", dur: "6s",  delay: "3.5s" },
+          { top: "75%", left: "40%", sz: "3px", op: "0.4", dur: "11s", delay: "0.7s" },
+          { top: "45%", left: "78%", sz: "2px", op: "0.6", dur: "8s",  delay: "1.4s" },
+          { top: "12%", left: "95%", sz: "2px", op: "0.3", dur: "7s",  delay: "2.8s" },
+          { top: "65%", left: "8%",  sz: "3px", op: "0.5", dur: "9s",  delay: "0.6s" },
+          { top: "92%", left: "22%", sz: "2px", op: "0.4", dur: "6s",  delay: "1.9s" },
+          { top: "30%", left: "52%", sz: "2px", op: "0.6", dur: "10s", delay: "3.1s" },
+          { top: "85%", left: "55%", sz: "3px", op: "0.5", dur: "8s",  delay: "0.4s" },
+        ].map((p, i) => (
+          <span
+            key={i}
+            data-p=""
+            style={{
+              top: p.top, left: p.left,
+              ["--sz" as string]: p.sz,
+              ["--op" as string]: p.op,
+              ["--dur" as string]: p.dur,
+              ["--delay" as string]: p.delay,
+            }}
+          />
+        ))}
+      </div>
+
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-20">
         <div className="text-center mb-20 animate-fade-in">
           <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-stellar-500/25 bg-stellar-500/8 text-stellar-400 text-xs font-medium mb-8">

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -177,3 +177,48 @@
       );
   }
 }
+
+/* ── Hero particle animation (#165) ───────────────────────────────────── */
+@keyframes particle-float {
+  0%   { transform: translateY(0) translateX(0) scale(1); opacity: 0.6; }
+  33%  { transform: translateY(-18px) translateX(6px) scale(1.1); opacity: 0.9; }
+  66%  { transform: translateY(-8px) translateX(-4px) scale(0.9); opacity: 0.5; }
+  100% { transform: translateY(0) translateX(0) scale(1); opacity: 0.6; }
+}
+
+.hero-particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-particles::before,
+.hero-particles::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(14, 165, 233, 0.55);
+  animation: particle-float linear infinite;
+}
+
+/* Particle spread via nth-child-like selectors using CSS custom properties */
+.hero-particles [data-p] {
+  position: absolute;
+  width: var(--sz, 3px);
+  height: var(--sz, 3px);
+  border-radius: 50%;
+  background: rgba(14, 165, 233, var(--op, 0.5));
+  animation: particle-float var(--dur, 6s) var(--delay, 0s) ease-in-out infinite;
+  top: var(--top, 50%);
+  left: var(--left, 50%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-particles [data-p],
+  .hero-particles::before,
+  .hero-particles::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Fixes #161
Fixes #165
Fixes #166
Fixes #168

## What changed

### #161 — Memo character limit colour warning
**`frontend/components/SendPaymentForm.tsx`**
- Both memo counter lines (inline form and modal form) updated with colour logic: `text-amber-400` at ≥20 chars, `text-red-400` at ≥25 chars
- Shows **"Max reached (28 chars)"** when the limit is reached
- Input capped at 28 characters via `.slice(0, 28)` on every change (blocks typing beyond limit)
- Tooltip `ℹ` icon added to the memo input with the text: *"Stellar memos are limited to 28 bytes — this keeps transactions compatible with the Stellar network."*

### #165 — Hero background particle animation
**`frontend/styles/globals.css`** — Added `@keyframes particle-float` (3-keyframe float animation) and `.hero-particles [data-p]` rule using CSS custom properties for per-particle position/size/opacity/duration/delay. Total new CSS: ~55 lines. `@media (prefers-reduced-motion: reduce)` block disables all animation.

**`frontend/pages/index.tsx`** — Added `.hero-particles` container with 20 `<span data-p>` elements each configured via inline CSS custom properties. Container has `z-index:0` and `pointer-events:none` to keep particles behind hero text and non-interactive.

### #166 — Send Again pre-fills payment form
**`frontend/pages/dashboard.tsx`** — Extended the prefill logic to also read `?to=` and `?amount=` query params (generated by the existing "Send again" button in `TransactionList.tsx`). The prefill object gains a `fromHistory: true` flag when built from these params.

**`frontend/components/SendPaymentForm.tsx`** — Added `fromHistory?: boolean` to the prefill interface. The "Pre-filled from transaction history" notice now renders **only when `fromHistory` is true**, not for all prefill sources (avoids showing the notice for SEP-0007 URI prefills or contact prefills).

### #168 — Network status indicator in Navbar
**`frontend/lib/stellar.ts`** — Added `fetchNetworkFeeStats()`: calls Horizon `/fee_stats`, reads `fee_charged.mode` in stroops, classifies as `"normal"` (<100 stroops), `"elevated"` (100–1000), or `"high"` (>1000). Exports `FeeLevel` type and `NetworkFeeStats` interface.

**`frontend/components/Navbar.tsx`** — Added a `useState<FeeLevel | null>` + `useEffect` that calls `fetchNetworkFeeStats` on mount and every 60 seconds. Renders a 10×10px dot next to the network badge: green (normal), amber (elevated), red (high). Hover tooltip shows `"Network: Normal"` etc. Silently hides the dot if the fetch fails.