### PR TITLE
Fix dashboard refresh UX, send fee estimate, disconnect guard, and FAQ accordion

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -31,6 +31,7 @@ export default function Navbar({
   onDisconnect,
 }: NavbarProps) {
   const router = useRouter();
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
   const config = getNetworkConfig();
   const isMainnet = config.network === "mainnet";
   const networkLabel = config.network === "custom" ? "Custom" : (isMainnet ? "Mainnet" : "Testnet");
@@ -59,6 +60,16 @@ export default function Navbar({
     const interval = setInterval(() => void load(), 60_000);
     return () => { cancelled = true; clearInterval(interval); };
   }, []);
+
+  useEffect(() => {
+    if (!showDisconnectConfirm) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setShowDisconnectConfirm(false);
+    }, 5000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [showDisconnectConfirm]);
 
   return (
     <nav className="sticky top-0 z-50 border-b border-[rgba(14,165,233,0.12)] bg-white/80 dark:bg-cosmos-900/80 backdrop-blur-xl transition-colors duration-300">
@@ -177,11 +188,31 @@ export default function Navbar({
                 <span>{shortenAddress(publicKey)}</span>
               </div>
               <button
-                onClick={onDisconnect}
+                onClick={() => setShowDisconnectConfirm(true)}
                 className="text-xs text-slate-500 hover:text-slate-300 transition-colors px-2 py-1"
               >
                 Disconnect
               </button>
+              {showDisconnectConfirm && (
+                <div className="flex items-center gap-1 rounded-lg border border-amber-400/30 bg-amber-400/10 px-2 py-1">
+                  <span className="text-[11px] text-amber-300">Disconnect wallet?</span>
+                  <button
+                    onClick={() => {
+                      setShowDisconnectConfirm(false);
+                      onDisconnect();
+                    }}
+                    className="rounded px-1.5 py-0.5 text-[11px] text-red-300 hover:bg-red-500/20"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setShowDisconnectConfirm(false)}
+                    className="rounded px-1.5 py-0.5 text-[11px] text-slate-200 hover:bg-white/10"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
             </div>
           ) : (
             <button

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -16,6 +16,7 @@ import {
   buildSorobanTipTransaction,
   CONTRACT_ID,
   explorerUrl,
+  fetchNetworkFeeStats,
   isValidStellarAddress,
   server,
   submitTransaction,
@@ -143,6 +144,7 @@ export default function SendPaymentForm({
   const [isScannerSupported, setIsScannerSupported] = useState(false);
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [scannerError, setScannerError] = useState<string | null>(null);
+  const [networkFeeXlm, setNetworkFeeXlm] = useState(0.00001);
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -191,6 +193,33 @@ export default function SendPaymentForm({
   };
 
   useEffect(() => {
+    let cancelled = false;
+
+    const loadFee = async () => {
+      try {
+        const feeStats = await fetchNetworkFeeStats();
+        if (!cancelled) {
+          setNetworkFeeXlm(feeStats.baseFeeXlm || 0.00001);
+        }
+      } catch {
+        if (!cancelled) {
+          setNetworkFeeXlm(0.00001);
+        }
+      }
+    };
+
+    void loadFee();
+    const intervalId = window.setInterval(() => {
+      void loadFee();
+    }, 60_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!prefill) return;
 
     if (prefill.destination) setDestination(prefill.destination);
@@ -205,6 +234,8 @@ export default function SendPaymentForm({
   const maxSend = selectedAsset === "XLM" ? Math.max(0, xlmBal - 1) : usdcBal;
 
   const amountNum = parseFloat(amount);
+  const hasAmount = Number.isFinite(amountNum) && amountNum > 0;
+  const estimatedTotalDeducted = hasAmount ? amountNum + networkFeeXlm : null;
   const isValidDest = destination.length > 0 && isValidStellarAddress(destination);
   
   // Check if destination is a username (@username format)
@@ -1127,6 +1158,24 @@ export default function SendPaymentForm({
                     : `Insufficient USDC balance`
                   : `Minimum amount is 0.0000001 ${selectedAsset} (1 stroop)`}
               </p>
+            )}
+            {selectedAsset === "XLM" && (
+              <div className="mt-2 rounded-lg border border-stellar-500/20 bg-stellar-500/5 px-3 py-2 text-xs text-slate-300">
+                <p>
+                  Network fee:{" "}
+                  <span className="font-medium text-stellar-300">
+                    ~{networkFeeXlm.toFixed(7)} XLM
+                  </span>
+                </p>
+                {estimatedTotalDeducted !== null && (
+                  <p className="mt-1">
+                    Total deducted:{" "}
+                    <span className="font-medium text-white">
+                      ~{estimatedTotalDeducted.toFixed(7)} XLM
+                    </span>
+                  </p>
+                )}
+              </div>
             )}
           </div>
 

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -71,6 +71,7 @@ interface PaymentStats {
 }
 
 export default function Dashboard({ publicKey, onConnect, stellarURI }: DashboardProps) {
+  const AUTO_REFRESH_SECONDS = 30;
   const [xlmBalance, setXlmBalance]   = useState<string | null>(null);
   const [reserveInfo, setReserveInfo] = useState<AccountReserveInfo | null>(null);
   const [usdcBalance, setUsdcBalance] = useState<string | null>(null);
@@ -78,6 +79,8 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
   const [xlmPrice, setXlmPrice] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [refreshCountdown, setRefreshCountdown] = useState(AUTO_REFRESH_SECONDS);
+  const [isRefreshingBalance, setIsRefreshingBalance] = useState(false);
   const { visible: toastVisible, message: toastMessage, showToast } = useToast();
   const [showQRModal, setShowQRModal] = useState(false);
   const [showOnboardingTour, setShowOnboardingTour] = useState(false);
@@ -177,6 +180,17 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
       setBalanceLoading(false);
     }
   }, [publicKey]);
+
+  const refreshBalance = useCallback(async () => {
+    if (!publicKey) return;
+    setIsRefreshingBalance(true);
+    setRefreshCountdown(AUTO_REFRESH_SECONDS);
+    try {
+      await fetchBalance();
+    } finally {
+      setIsRefreshingBalance(false);
+    }
+  }, [publicKey, fetchBalance]);
 
   const fetchPaymentStats = useCallback(async () => {
     if (!publicKey) return;
@@ -318,6 +332,22 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
   useEffect(() => {
     fetchBalance();
   }, [fetchBalance, refreshKey]);
+
+  useEffect(() => {
+    if (!publicKey) return;
+
+    const intervalId = window.setInterval(() => {
+      setRefreshCountdown((current) => {
+        if (current <= 1) {
+          void refreshBalance();
+          return AUTO_REFRESH_SECONDS;
+        }
+        return current - 1;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [publicKey, refreshBalance]);
 
   useEffect(() => {
     setFriendbotSuccessMessage(null);
@@ -716,11 +746,15 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
                   </div>
                 )}
                 <button
-                  onClick={fetchBalance}
+                  onClick={() => void refreshBalance()}
                   className="mt-1 text-xs text-slate-500 hover:text-stellar-400 transition-colors flex items-center gap-1 sm:justify-end cursor-pointer"
                 >
-                  <RefreshIcon className="w-3 h-3" /> Refresh
+                  <RefreshIcon className={`w-3 h-3 ${isRefreshingBalance ? "animate-spin" : ""}`} />
+                  {isRefreshingBalance ? "Refreshing..." : "Refresh"}
                 </button>
+                <p className="mt-1 text-[11px] text-slate-500 sm:text-right">
+                  Refreshing in {refreshCountdown}s
+                </p>
               </div>
             ) : accountNotFound && isTestnet ? (
               <div className="sm:text-right">

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -157,10 +157,10 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
             </div>
 
             <div className="space-y-4">
-              <details className="card cursor-default">
+              <details className="card cursor-default group">
                 <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-left text-white font-semibold">
                   <span>What is Stellar?</span>
-                  <span className="text-stellar-400 text-xl">+</span>
+                  <span className="text-stellar-400 text-xl transition-transform duration-200 group-open:rotate-45">+</span>
                 </summary>
                 <div className="mt-4 text-sm leading-relaxed text-slate-400 space-y-3">
                   <p>
@@ -176,10 +176,10 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
                 </div>
               </details>
 
-              <details className="card cursor-default">
+              <details className="card cursor-default group">
                 <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-left text-white font-semibold">
                   <span>What is XLM?</span>
-                  <span className="text-stellar-400 text-xl">+</span>
+                  <span className="text-stellar-400 text-xl transition-transform duration-200 group-open:rotate-45">+</span>
                 </summary>
                 <div className="mt-4 text-sm leading-relaxed text-slate-400 space-y-3">
                   <p>
@@ -195,10 +195,10 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
                 </div>
               </details>
 
-              <details className="card cursor-default">
+              <details className="card cursor-default group">
                 <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-left text-white font-semibold">
                   <span>How fast is it?</span>
-                  <span className="text-stellar-400 text-xl">+</span>
+                  <span className="text-stellar-400 text-xl transition-transform duration-200 group-open:rotate-45">+</span>
                 </summary>
                 <div className="mt-4 text-sm leading-relaxed text-slate-400 space-y-3">
                   <p>
@@ -214,10 +214,10 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
                 </div>
               </details>
 
-              <details className="card cursor-default">
+              <details className="card cursor-default group">
                 <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-left text-white font-semibold">
                   <span>How much does it cost?</span>
-                  <span className="text-stellar-400 text-xl">+</span>
+                  <span className="text-stellar-400 text-xl transition-transform duration-200 group-open:rotate-45">+</span>
                 </summary>
                 <div className="mt-4 text-sm leading-relaxed text-slate-400 space-y-3">
                   <p>
@@ -233,10 +233,10 @@ export default function Home({ publicKey, onConnect }: HomeProps) {
                 </div>
               </details>
 
-              <details className="card cursor-default">
+              <details className="card cursor-default group">
                 <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-left text-white font-semibold">
                   <span>Is it safe?</span>
-                  <span className="text-stellar-400 text-xl">+</span>
+                  <span className="text-stellar-400 text-xl transition-transform duration-200 group-open:rotate-45">+</span>
                 </summary>
                 <div className="mt-4 text-sm leading-relaxed text-slate-400 space-y-3">
                   <p>


### PR DESCRIPTION
## Summary
- add a 30-second XLM balance auto-refresh cycle on dashboard with visible countdown and manual-refresh reset behavior
- add inline disconnect confirmation in navbar with confirm/cancel actions and 5-second auto-dismiss safeguard
- show pre-send estimated network fee from Horizon `/fee_stats` and a live `amount + fee` total in the send form
- improve home FAQ accordion UX using CSS-only open-state affordance for all five Stellar explainer items

## Validation
- `npm ci`
- `npm run type-check` ❌ fails due pre-existing syntax errors in repository files (`frontend/components/SendPaymentForm.tsx`, `frontend/components/TransactionList.tsx`, `frontend/pages/dashboard.tsx`, `frontend/pages/index.tsx`)
- `npm run lint` blocked by the type-check/parser failures above

## Closes
- Closes #173
- Closes #174
- Closes #179
- Closes #181