### PR TITLE
feat: implement issues #162, #167, #163, #170

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -43,6 +43,28 @@ export default function Navbar({
   // Issue #19 — Add dark/light mode toggle | Emmy123222/Stellar-MicroPay
   const { theme, toggleTheme } = useTheme();
 
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+  const [disconnectTimeout, setDisconnectTimeout] = useState<NodeJS.Timeout | null>(null);
+
+  const handleDisconnectClick = () => {
+    setShowDisconnectConfirm(true);
+    const timeout = setTimeout(() => {
+      setShowDisconnectConfirm(false);
+    }, 5000);
+    setDisconnectTimeout(timeout);
+  };
+
+  const handleConfirmDisconnect = () => {
+    if (disconnectTimeout) clearTimeout(disconnectTimeout);
+    setShowDisconnectConfirm(false);
+    onDisconnect();
+  };
+
+  const handleCancelDisconnect = () => {
+    if (disconnectTimeout) clearTimeout(disconnectTimeout);
+    setShowDisconnectConfirm(false);
+  };
+
   // Issue #168 — Network status indicator
   const [feeLevel, setFeeLevel] = useState<FeeLevel | null>(null);
   useEffect(() => {
@@ -176,12 +198,30 @@ export default function Navbar({
                 <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
                 <span>{shortenAddress(publicKey)}</span>
               </div>
-              <button
-                onClick={onDisconnect}
-                className="text-xs text-slate-500 hover:text-slate-300 transition-colors px-2 py-1"
-              >
-                Disconnect
-              </button>
+              {showDisconnectConfirm ? (
+                <div className="flex items-center gap-1.5 text-xs">
+                  <span className="text-slate-400">Disconnect?</span>
+                  <button
+                    onClick={handleConfirmDisconnect}
+                    className="text-emerald-400 hover:text-emerald-300 transition-colors"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={handleCancelDisconnect}
+                    className="text-slate-500 hover:text-slate-300 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={handleDisconnectClick}
+                  className="text-xs text-slate-500 hover:text-slate-300 transition-colors px-2 py-1"
+                >
+                  Disconnect
+                </button>
+              )}
             </div>
           ) : (
             <button

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -19,6 +19,7 @@ import {
   isValidStellarAddress,
   server,
   submitTransaction,
+  fetchNetworkFeeStats,
 } from "@/lib/stellar";
 import { signTransactionWithWallet } from "@/lib/wallet";
 import { formatXLM, parseAddressBookCSV } from "@/utils/format";
@@ -143,6 +144,7 @@ export default function SendPaymentForm({
   const [isScannerSupported, setIsScannerSupported] = useState(false);
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [scannerError, setScannerError] = useState<string | null>(null);
+  const [networkFee, setNetworkFee] = useState<string | null>(null);
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -197,6 +199,18 @@ export default function SendPaymentForm({
     if (prefill.amount) setAmount(prefill.amount);
     if (prefill.memo) setMemo(prefill.memo);
   }, [prefill]);
+
+  useEffect(() => {
+    const fetchFee = async () => {
+      try {
+        const stats = await fetchNetworkFeeStats();
+        setNetworkFee(stats.baseFeeXlm.toFixed(5));
+      } catch {
+        setNetworkFee(null);
+      }
+    };
+    fetchFee();
+  }, []);
 
   const xlmBal = parseFloat(xlmBalance);
   const usdcBal = usdcBalance ? parseFloat(usdcBalance) : 0;
@@ -1127,6 +1141,14 @@ export default function SendPaymentForm({
                     : `Insufficient USDC balance`
                   : `Minimum amount is 0.0000001 ${selectedAsset} (1 stroop)`}
               </p>
+            )}
+            {networkFee && amount && isValidAmt && (
+              <div className="mt-2 space-y-1 text-xs text-slate-400">
+                <p>Network fee: ~{networkFee} XLM</p>
+                <p className="text-slate-300">
+                  Total deducted: {(amountNum + parseFloat(networkFee)).toFixed(5)} XLM
+                </p>
+              </div>
             )}
           </div>
 

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -78,6 +78,7 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
   const [xlmPrice, setXlmPrice] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [countdown, setCountdown] = useState(30);
   const { visible: toastVisible, message: toastMessage, showToast } = useToast();
   const [showQRModal, setShowQRModal] = useState(false);
   const [showOnboardingTour, setShowOnboardingTour] = useState(false);
@@ -320,6 +321,20 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
   }, [fetchBalance, refreshKey]);
 
   useEffect(() => {
+    if (!publicKey) return;
+    const interval = setInterval(() => {
+      setCountdown((c) => {
+        if (c <= 1) {
+          fetchBalance();
+          return 30;
+        }
+        return c - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [publicKey, fetchBalance]);
+
+  useEffect(() => {
     setFriendbotSuccessMessage(null);
   }, [publicKey]);
 
@@ -368,6 +383,11 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
     if (ok) showToast("Address copied!");
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleManualRefresh = () => {
+    setCountdown(30);
+    fetchBalance();
   };
 
   // Onboarding tour logic
@@ -716,10 +736,16 @@ export default function Dashboard({ publicKey, onConnect, stellarURI }: Dashboar
                   </div>
                 )}
                 <button
-                  onClick={fetchBalance}
+                  onClick={handleManualRefresh}
                   className="mt-1 text-xs text-slate-500 hover:text-stellar-400 transition-colors flex items-center gap-1 sm:justify-end cursor-pointer"
+                  disabled={balanceLoading}
                 >
-                  <RefreshIcon className="w-3 h-3" /> Refresh
+                  {balanceLoading ? (
+                    <SpinnerIcon className="w-3 h-3 animate-spin" />
+                  ) : (
+                    <RefreshIcon className="w-3 h-3" />
+                  )}
+                  {balanceLoading ? `Refreshing...` : `Refresh (${countdown}s)`}
                 </button>
               </div>
             ) : accountNotFound && isTestnet ? (


### PR DESCRIPTION
- #162: Add balance refresh countdown (30s auto-refresh with countdown display)
- #167: Add estimated network fee display in send form (fee fetched from Horizon /fee_stats)
- #163: Add wallet disconnect confirmation dialog (with 5s auto-dismiss)
- #170: FAQ section already exists on home page (verified)

closes #162
closes #167
closes #163
closes #170