### PR TITLE
feat: add full account history export (JSON/CSV)

### DIFF
--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -248,6 +248,12 @@ export interface PaymentHistoryResponse {
   nextCursor?: string | (() => any);
 }
 
+export interface FetchAllPaymentsProgress {
+  fetchedRecords: number;
+  fetchedPages: number;
+  done: boolean;
+}
+
 /**
  * Handle function invoked for each streamed payment operation.
  */
@@ -784,6 +790,87 @@ export async function getPaymentHistory(
     hasMore: operations.records.length === limit && !!operations.next,
     nextCursor: operations.next ? operations.next.toString() : undefined,
   };
+}
+
+/**
+ * Fetches full payment history by following Horizon paging cursors until exhausted.
+ * Use this for exports that must include complete account history.
+ */
+export async function fetchAllPayments(
+  publicKey: string,
+  options: {
+    pageSize?: number;
+    maxPages?: number;
+    onProgress?: (progress: FetchAllPaymentsProgress) => void;
+  } = {}
+): Promise<PaymentRecord[]> {
+  const pageSize = Math.max(1, Math.min(options.pageSize ?? 200, 200));
+  const maxPages = Math.max(1, options.maxPages ?? 1000);
+
+  let cursor: string | undefined;
+  let pageCount = 0;
+  const allRecords: PaymentRecord[] = [];
+
+  while (pageCount < maxPages) {
+    let operationsBuilder = server
+      .operations()
+      .forAccount(publicKey)
+      .limit(pageSize)
+      .order("desc");
+
+    if (cursor) {
+      operationsBuilder = operationsBuilder.cursor(cursor);
+    }
+
+    const operations = await operationsBuilder.call();
+    pageCount += 1;
+
+    let pageRecordsCount = 0;
+    for (const op of operations.records) {
+      if (op.type !== "payment") continue;
+
+      const payment = op as Horizon.HorizonApi.PaymentOperationResponse;
+      const assetCode =
+        payment.asset_type === "native" ? "XLM" : payment.asset_code || "???";
+
+      allRecords.push({
+        id: payment.id,
+        type: payment.from === publicKey ? "sent" : "received",
+        amount: payment.amount,
+        asset: assetCode,
+        from: payment.from,
+        to: payment.to,
+        createdAt: payment.created_at,
+        transactionHash: payment.transaction_hash,
+        pagingToken: payment.paging_token,
+        category: TransactionCategory.Payment,
+      });
+      pageRecordsCount += 1;
+    }
+
+    const lastRecord = operations.records[operations.records.length - 1];
+    if (!lastRecord || !("paging_token" in lastRecord)) {
+      options.onProgress?.({
+        fetchedRecords: allRecords.length,
+        fetchedPages: pageCount,
+        done: true,
+      });
+      break;
+    }
+
+    cursor = String(lastRecord.paging_token);
+    const reachedEnd = operations.records.length < pageSize || pageRecordsCount === 0;
+
+    options.onProgress?.({
+      fetchedRecords: allRecords.length,
+      fetchedPages: pageCount,
+      done: reachedEnd || pageCount >= maxPages,
+    });
+
+    if (reachedEnd) break;
+  }
+
+  return allRecords;
 }
 
 // ─── Utilities ────────────────────────────────────────────────────────────────

--- a/frontend/pages/transactions.tsx
+++ b/frontend/pages/transactions.tsx
@@ -10,8 +10,8 @@ import TransactionList, {
   TransactionDirectionFilter,
   TransactionFilters,
 } from "@/components/TransactionList";
-import { shortenAddress, PaymentRecord } from "@/lib/stellar";
-import { exportToCSV } from "@/utils/format";
+import { fetchAllPayments, NETWORK, shortenAddress, PaymentRecord } from "@/lib/stellar";
+import { exportToCSV, exportToJSON, formatDate, formatXLM } from "@/utils/format";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const TRANSACTION_FILTERS_STORAGE_KEY = "stellar-micropay:transaction-filters";
@@ -37,10 +37,13 @@ function isDirectionFilter(value: unknown): value is TransactionDirectionFilter 
 export default function Transactions({ publicKey, onConnect }: TransactionsProps) {
   const [payments, setPayments] = useState<PaymentRecord[]>([]);
   const [exporting, setExporting] = useState(false);
+  const [exportCount, setExportCount] = useState(0);
+  const [exportFormat, setExportFormat] = useState<"csv" | "json" | null>(null);
   const [directionFilter, setDirectionFilter] =
     useState<TransactionDirectionFilter>("all");
   const [minimumAmount, setMinimumAmount] = useState("");
   const [filtersReady, setFiltersReady] = useState(false);
+  const [receiptPayment, setReceiptPayment] = useState<PaymentRecord | null>(null);
 
   const transactionFilters = useMemo<TransactionFilters>(
     () => ({
@@ -59,6 +62,7 @@ export default function Transactions({ publicKey, onConnect }: TransactionsProps
     (directionFilter !== "all" ? 1 : 0) + (minimumAmount.trim() !== "" ? 1 : 0);
   const hasActiveFilters = activeFilterCount > 0;
   const exportPayments = filteredPayments;
+  const networkLabel = NETWORK === "mainnet" ? "Mainnet" : "Testnet";
 
   // Receives the latest payments array from the list whenever it changes
   const handlePaymentsChange = useCallback((records: PaymentRecord[]) => {
@@ -106,14 +110,28 @@ export default function Transactions({ publicKey, onConnect }: TransactionsProps
     setMinimumAmount("");
   };
 
-  const handleExport = () => {
-    if (exportPayments.length === 0) return;
+  const handleExport = async (format: "csv" | "json") => {
+    if (!publicKey) return;
     setExporting(true);
+    setExportFormat(format);
+    setExportCount(0);
     try {
-      exportToCSV(exportPayments);
+      const allPayments = await fetchAllPayments(publicKey, {
+        onProgress: ({ fetchedRecords }) => setExportCount(fetchedRecords),
+      });
+      if (allPayments.length === 0) return;
+
+      if (format === "csv") {
+        exportToCSV(allPayments);
+      } else {
+        exportToJSON(allPayments);
+      }
     } finally {
       // Small delay so the button flash feels intentional
-      setTimeout(() => setExporting(false), 800);
+      setTimeout(() => {
+        setExporting(false);
+        setExportFormat(null);
+      }, 800);
     }
   };
 
@@ -191,12 +209,12 @@ export default function Transactions({ publicKey, onConnect }: TransactionsProps
         <div className="flex items-center gap-2 shrink-0 pt-1">
           {/* Download CSV */}
           <button
-            onClick={handleExport}
-            disabled={exportPayments.length === 0 || exporting}
+            onClick={() => void handleExport("csv")}
+            disabled={exportPayments.length === 0 || exporting || !publicKey}
             title={
               exportPayments.length === 0
                 ? "No transactions to export"
-                : `Export ${exportPayments.length} transaction${exportPayments.length !== 1 ? "s" : ""} as CSV`
+                : "Export full history as CSV"
             }
             className={[
               "inline-flex items-center gap-1.5 text-sm font-medium px-3.5 py-2 rounded-lg",
@@ -206,7 +224,7 @@ export default function Transactions({ publicKey, onConnect }: TransactionsProps
                 : "border-stellar-500/30 text-stellar-400 hover:bg-stellar-500/10 hover:border-stellar-500/50 cursor-pointer",
             ].join(" ")}
           >
-            {exporting ? (
+            {exporting && exportFormat === "csv" ? (
               <>
                 <div className="w-3.5 h-3.5 border-2 border-stellar-400 border-t-transparent rounded-full animate-spin" />
                 {`Exporting…`}
@@ -232,11 +250,55 @@ export default function Transactions({ publicKey, onConnect }: TransactionsProps
             )}
           </button>
 
+          <button
+            onClick={() => void handleExport("json")}
+            disabled={exportPayments.length === 0 || exporting || !publicKey}
+            title={
+              exportPayments.length === 0
+                ? "No transactions to export"
+                : "Export full history as JSON"
+            }
+            className={[
+              "inline-flex items-center gap-1.5 text-sm font-medium px-3.5 py-2 rounded-lg",
+              "border transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar-400/60",
+              exportPayments.length === 0 || exporting
+                ? "border-white/10 text-slate-600 cursor-not-allowed"
+                : "border-stellar-500/30 text-stellar-400 hover:bg-stellar-500/10 hover:border-stellar-500/50 cursor-pointer",
+            ].join(" ")}
+          >
+            {exporting && exportFormat === "json" ? (
+              <>
+                <div className="w-3.5 h-3.5 border-2 border-stellar-400 border-t-transparent rounded-full animate-spin" />
+                {`Exporting…`}
+              </>
+            ) : (
+              <>
+                <svg
+                  className="w-3.5 h-3.5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 17h6m-6-4h6m-6-4h6M6.75 3h10.5A2.25 2.25 0 0119.5 5.25v13.5A2.25 2.25 0 0117.25 21H6.75A2.25 2.25 0 014.5 18.75V5.25A2.25 2.25 0 016.75 3z" />
+                </svg>
+                {`Download JSON`}
+              </>
+            )}
+          </button>
+
           <Link href="/dashboard" className="btn-secondary text-sm py-2 px-4 cursor-pointer">
             {`← Dashboard`}
           </Link>
         </div>
       </div>
+
+      {exporting && (
+        <p className="mb-4 text-xs text-slate-400">
+          {`Preparing full account history export… ${exportCount} records processed.`}
+        </p>
+      )}
 
       {/* Export hint */}
       <div className="mb-5 p-3 rounded-xl bg-stellar-500/5 border border-stellar-500/15 flex items-center justify-between">

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -169,6 +169,21 @@ function csvCell(value: string | number | undefined | null): string {
   // Escape double-quotes by doubling them, then wrap the whole cell
   return `"${str.replace(/"/g, '""')}"`;
 }
+
+function triggerDownload(contents: string, filename: string, type: string): void {
+  const blob = new Blob([contents], { type });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("download", filename);
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
  
 /**
  * Convert an array of PaymentRecords to a CSV string and trigger a browser
@@ -204,22 +219,17 @@ export function exportToCSV(payments: PaymentRecord[]): void {
     ...rows.map((r) => r.join(",")),
   ].join("\r\n");
  
-  // Build a date stamp for the filename  e.g. "2024-11-03"
   const dateStamp = format(new Date(), "yyyy-MM-dd");
   const filename = `stellar-micropay-transactions-${dateStamp}.csv`;
- 
-  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
- 
-  const link = document.createElement("a");
-  link.setAttribute("href", url);
-  link.setAttribute("download", filename);
-  link.style.display = "none";
-  document.body.appendChild(link);
-  link.click();
- 
-  // Clean up
-  document.body.removeChild(link);
-  // Small delay so the browser has time to start the download before revocation
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  triggerDownload(csv, filename, "text/csv;charset=utf-8;");
+}
+
+/**
+ * Convert PaymentRecords to pretty-printed JSON and trigger a browser download.
+ */
+export function exportToJSON(payments: PaymentRecord[]): void {
+  const dateStamp = format(new Date(), "yyyy-MM-dd");
+  const filename = `stellar-micropay-transactions-${dateStamp}.json`;
+  const json = JSON.stringify(payments, null, 2);
+  triggerDownload(json, filename, "application/json;charset=utf-8;");
 }


### PR DESCRIPTION
Closes #175
  Closes #176
  Closes #177
  Closes #178

  ## Summary
  - add paginated full-history fetch helper for transaction export
  - add JSON export utility and reuse shared browser download helper
  - update Transactions page with full-history CSV/JSON export buttons and progress feedback

  ## Validation
  - not run here (frontend dependencies are not installed in this environment)