### PR TITLE
fix/feat: truncated wallet address, balance flash animation, exponential input guard

### DIFF
--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -342,7 +342,11 @@ export default function SendPaymentForm({
   const isUsernameDestination = /^@?[a-zA-Z0-9]{3,20}$/.test(destination) && !isValidStellarAddress(destination);
   
   const MIN_STROOP = 0.0000001;
-  const isValidAmt = !Number.isNaN(amountNum) && amountNum >= MIN_STROOP && amountNum <= maxSend;
+  const isValidAmt =
+    !Number.isNaN(amountNum) &&
+    amountNum >= MIN_STROOP &&
+    amountNum <= maxSend &&
+    !/[eE]/.test(amount);
   
   const canSubmit = (isValidDest || (isUsernameDestination && !isResolvingUsername && !usernameResolutionError)) && 
     isValidAmt && status === "idle" && destination !== publicKey;
@@ -702,6 +706,9 @@ export default function SendPaymentForm({
               type="number"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "e" || e.key === "E") e.preventDefault();
+              }}
               placeholder="0.0000000"
               className={clsx("input-field", amount && !isValidAmt && "border-red-500/50")}
               disabled={status !== "idle"}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -135,6 +135,8 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
   const [staleBalanceAt, setStaleBalanceAt] = useState<number | null>(null);
   const [xlmPrice, setXlmPrice] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
+  const [addressExpanded, setAddressExpanded] = useState(false);
+  const [balanceFlash, setBalanceFlash] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [refreshCountdown, setRefreshCountdown] = useState(AUTO_REFRESH_SECONDS);
   const [isRefreshingBalance, setIsRefreshingBalance] = useState(false);
@@ -233,7 +235,13 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
         getUSDCBalance(publicKey),
         getAccountReserveInfo(publicKey),
       ]);
-      setXlmBalance(bal);
+      setXlmBalance((prev) => {
+        if (prev !== null && prev !== bal) {
+          setBalanceFlash(true);
+          setTimeout(() => setBalanceFlash(false), 800);
+        }
+        return bal;
+      });
       setUsdcBalance(usdc);
       setReserveInfo(reserve);
       setStaleBalanceAt(null);
@@ -821,23 +829,38 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
         <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div>
             <p className="label mb-1">Wallet Address</p>
-            <span className="font-mono text-sm text-slate-300 break-all select-text cursor-text">
-              {publicKey}
-            </span>
             <button
-              onClick={handleCopyAddress}
-              className="mt-2 text-xs text-stellar-400 hover:text-stellar-300 transition-colors flex items-center gap-1.5 cursor-pointer"
+              onClick={() => setAddressExpanded((x) => !x)}
+              className="font-mono text-sm text-slate-300 select-text cursor-pointer hover:text-white transition-colors text-left break-all"
+              title={addressExpanded ? "Click to collapse" : "Click to show full address"}
             >
-              {copied ? (
-                <>
-                  <CheckIcon className="w-3.5 h-3.5" /> Copied!
-                </>
-              ) : (
-                <>
-                  <CopyIcon className="w-3.5 h-3.5" /> Copy address
-                </>
-              )}
+              {addressExpanded
+                ? publicKey
+                : `${publicKey.slice(0, 6)}…${publicKey.slice(-6)}`}
             </button>
+            <div className="mt-2 flex items-center gap-3">
+              <button
+                onClick={handleCopyAddress}
+                className="text-xs text-stellar-400 hover:text-stellar-300 transition-colors flex items-center gap-1.5 cursor-pointer"
+              >
+                {copied ? (
+                  <>
+                    <CheckIcon className="w-3.5 h-3.5" /> Copied!
+                  </>
+                ) : (
+                  <>
+                    <CopyIcon className="w-3.5 h-3.5" /> Copy address
+                  </>
+                )}
+              </button>
+              <span className="text-slate-600 text-xs">·</span>
+              <button
+                onClick={() => setAddressExpanded((x) => !x)}
+                className="text-xs text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+              >
+                {addressExpanded ? "Collapse" : "Show full"}
+              </button>
+            </div>
           </div>
 
           <div className="sm:text-right flex-shrink-0">
@@ -846,7 +869,7 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
               <div className="h-8 w-36 bg-white/10 rounded-lg animate-pulse" />
             ) : xlmBalance !== null ? (
               <div>
-                <div className="font-display text-3xl font-bold text-white">
+                <div className={`font-display text-3xl font-bold text-white ${balanceFlash ? "balance-flash" : ""}`}>
                   {parseFloat(xlmBalance).toLocaleString("en-US", {
                     maximumFractionDigits: 4,
                   })}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -258,3 +258,15 @@
 @media (prefers-reduced-motion: reduce) {
   .confetti__piece { animation: none; opacity: 0; }
 }
+
+@keyframes balance-flash {
+  0%   { color: #fff; }
+  30%  { color: #7dd3fc; text-shadow: 0 0 12px rgba(125,211,252,0.6); }
+  100% { color: inherit; text-shadow: none; }
+}
+.balance-flash {
+  animation: balance-flash 0.8s ease-out forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .balance-flash { animation: none; }
+}


### PR DESCRIPTION
Closes #262
Closes #266
Closes #270
Closes #276

## What changed

### #262 — Truncated wallet address with click-to-expand (`frontend/pages/dashboard.tsx`)
- Added `addressExpanded` state (default `false`)
- Wallet address now renders as `GABCD…WXYZ` (first 6 + last 6 chars) by default — no more 56-char overflow on mobile
- Clicking the address text or the new "Show full" / "Collapse" button toggles full/truncated display
- The "Copy address" button remains unchanged and always copies the full key

### #266 — Balance flash animation after payment (`frontend/pages/dashboard.tsx` + `frontend/styles/globals.css`)
- Added `balanceFlash` state; triggered for 800 ms whenever `xlmBalance` updates to a **new** value (skips initial load from cache to avoid spurious flashes)
- `balance-flash` CSS keyframe: white → stellar-sky-blue glow over 800 ms, then resets
- Respects `prefers-reduced-motion` — animation is disabled for users with that preference

### #270 — `.next` build artefacts (`frontend/.gitignore`)
- Confirmed `frontend/.next/` is already present in `.gitignore` and no `.next` files are tracked in the git index (`git ls-files` returned nothing)
- No file changes needed; including this in the PR to confirm the issue is resolved

### #276 — Block exponential notation in amount input (`frontend/components/SendPaymentForm.tsx`)
- `isValidAmt` now includes `!/[eE]/.test(amount)` — values like `1e5` fail validation even though `parseFloat('1e5') === 100000`
- Added `onKeyDown` handler that calls `e.preventDefault()` when `e` or `E` is pressed, blocking exponential entry at the keyboard level

## Why
- 56-char public keys overflow wallet cards on mobile screens
- Without a visual cue, users don't notice their balance changed after a payment completes
- `<input type="number">` silently accepts `1e5`, which can bypass balance validation

## How to test
- **#262**: Open the dashboard on a narrow viewport; confirm address shows as `GABCD…WXYZ`; click to expand; click again to collapse
- **#266**: Send a payment; when the balance refreshes (2 s delay), the number should briefly glow blue
- **#270**: Run `git ls-files frontend/.next` — should return nothing
- **#276**: Type `1e5` in the Send amount field; confirm validation error shows and the submit button stays disabled