### PR TITLE
feat: structured logging, clipboard fallback, account auth scoping & payment webhooks

### DIFF
--- a/backend/__tests__/accountsAuth.test.js
+++ b/backend/__tests__/accountsAuth.test.js
@@ -1,0 +1,46 @@
+/**
+ * #278 — account-data routes must require a SEP-10 JWT and only allow access to
+ * the caller's own account.
+ */
+"use strict";
+
+const express = require("express");
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const { JWT_SECRET } = require("../src/middleware/auth");
+const accountRoutes = require("../src/routes/accounts");
+
+const ME = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
+const OTHER = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX";
+
+function appWithAccounts() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/accounts", accountRoutes);
+  return app;
+}
+
+function tokenFor(publicKey) {
+  return jwt.sign({ publicKey }, JWT_SECRET, { expiresIn: "1h" });
+}
+
+describe("account routes authorization (#278)", () => {
+  const app = appWithAccounts();
+
+  it("rejects an unauthenticated account request with 401", async () => {
+    const res = await request(app).get(`/api/accounts/${ME}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects accessing another account's data with 403", async () => {
+    const res = await request(app)
+      .get(`/api/accounts/${OTHER}`)
+      .set("Authorization", `Bearer ${tokenFor(ME)}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects the balance route without a token", async () => {
+    const res = await request(app).get(`/api/accounts/${ME}/balance`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/__tests__/webhookRoutes.test.js
+++ b/backend/__tests__/webhookRoutes.test.js
@@ -1,0 +1,86 @@
+/**
+ * #279 — webhook registration endpoints (auth-gated, own-account).
+ */
+"use strict";
+
+// Avoid opening a real Horizon stream when a webhook is registered.
+jest.mock("../src/services/stellarService", () => ({
+  streamIncomingPayments: jest.fn(() => () => {}),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const { JWT_SECRET } = require("../src/middleware/auth");
+const webhookRoutes = require("../src/routes/webhooks");
+const webhookService = require("../src/services/webhookService");
+
+const ME = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
+
+function app() {
+  const a = express();
+  a.use(express.json());
+  a.use("/api/webhooks", webhookRoutes);
+  return a;
+}
+const auth = () => `Bearer ${jwt.sign({ publicKey: ME }, JWT_SECRET, { expiresIn: "1h" })}`;
+
+beforeEach(() => webhookService._reset());
+
+describe("POST /api/webhooks (#279)", () => {
+  it("requires authentication", async () => {
+    const res = await request(app()).post("/api/webhooks").send({ url: "https://x.test/h", secret: "secret-123" });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an invalid url", async () => {
+    const res = await request(app())
+      .post("/api/webhooks")
+      .set("Authorization", auth())
+      .send({ url: "not-a-url", secret: "secret-123" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a too-short secret", async () => {
+    const res = await request(app())
+      .post("/api/webhooks")
+      .set("Authorization", auth())
+      .send({ url: "https://x.test/h", secret: "short" });
+    expect(res.status).toBe(400);
+  });
+
+  it("registers a webhook for the authenticated account", async () => {
+    const res = await request(app())
+      .post("/api/webhooks")
+      .set("Authorization", auth())
+      .send({ url: "https://x.test/hook", secret: "supersecret" });
+    expect(res.status).toBe(201);
+    expect(res.body.account).toBe(ME);
+    expect(res.body.url).toBe("https://x.test/hook");
+    expect(res.body).not.toHaveProperty("secret");
+  });
+});
+
+describe("GET/DELETE /api/webhooks (#279)", () => {
+  it("lists only the caller's webhooks with secrets redacted", async () => {
+    webhookService.registerWebhook({ account: ME, url: "https://x.test/mine", secret: "secret-mine" });
+    webhookService.registerWebhook({ account: "GOTHER", url: "https://x.test/other", secret: "secret-other" });
+    const res = await request(app()).get("/api/webhooks").set("Authorization", auth());
+    expect(res.status).toBe(200);
+    expect(res.body.webhooks).toHaveLength(1);
+    expect(res.body.webhooks[0]).not.toHaveProperty("secret");
+  });
+
+  it("deletes the caller's own webhook", async () => {
+    const wh = webhookService.registerWebhook({ account: ME, url: "https://x.test/d", secret: "secret-del" });
+    const res = await request(app()).delete(`/api/webhooks/${wh.id}`).set("Authorization", auth());
+    expect(res.status).toBe(204);
+    expect(webhookService.getWebhook(wh.id)).toBeUndefined();
+  });
+
+  it("will not delete another account's webhook", async () => {
+    const wh = webhookService.registerWebhook({ account: "GOTHER", url: "https://x.test/o", secret: "secret-oth" });
+    const res = await request(app()).delete(`/api/webhooks/${wh.id}`).set("Authorization", auth());
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/__tests__/webhookService.test.js
+++ b/backend/__tests__/webhookService.test.js
@@ -1,0 +1,56 @@
+/**
+ * #279 — webhook registry + signed delivery.
+ */
+"use strict";
+
+const webhookService = require("../src/services/webhookService");
+const { verifyWebhookSignature } = require("../src/utils/webhookSignature");
+
+const ACCOUNT = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
+
+beforeEach(() => webhookService._reset());
+
+describe("webhook registry", () => {
+  it("registers and lists webhooks without exposing the secret", () => {
+    webhookService.registerWebhook({ account: ACCOUNT, url: "https://x.test/hook", secret: "supersecret" });
+    const list = webhookService.listWebhooks(ACCOUNT);
+    expect(list).toHaveLength(1);
+    expect(list[0].url).toBe("https://x.test/hook");
+    expect(list[0]).not.toHaveProperty("secret");
+  });
+
+  it("scopes listing to the account and supports removal", () => {
+    const a = webhookService.registerWebhook({ account: ACCOUNT, url: "https://x.test/a", secret: "secret-aaa" });
+    webhookService.registerWebhook({ account: "GOTHER", url: "https://x.test/b", secret: "secret-bbb" });
+    expect(webhookService.listWebhooks(ACCOUNT)).toHaveLength(1);
+    expect(webhookService.removeWebhook(a.id)).toBe(true);
+    expect(webhookService.listWebhooks(ACCOUNT)).toHaveLength(0);
+  });
+});
+
+describe("signed delivery", () => {
+  it("POSTs the payload with a verifiable HMAC signature header", async () => {
+    const wh = { url: "https://x.test/hook", secret: "supersecret" };
+    const payload = { type: "payment.received", amount: "10" };
+    const client = { post: jest.fn().mockResolvedValue({ status: 200 }) };
+
+    await webhookService.deliverWebhook(wh, payload, { client });
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    const [url, sentPayload, opts] = client.post.mock.calls[0];
+    expect(url).toBe(wh.url);
+    expect(sentPayload).toEqual(payload);
+    const sig = opts.headers["X-Webhook-Signature"];
+    expect(verifyWebhookSignature(JSON.stringify(payload), wh.secret, sig)).toBe(true);
+  });
+
+  it("delivers an incoming payment to every webhook for the account", async () => {
+    webhookService.registerWebhook({ account: ACCOUNT, url: "https://x.test/1", secret: "secret-111" });
+    webhookService.registerWebhook({ account: ACCOUNT, url: "https://x.test/2", secret: "secret-222" });
+    const client = { post: jest.fn().mockResolvedValue({ status: 200 }) };
+
+    await webhookService.notifyIncomingPayment(ACCOUNT, { id: "p1", amount: "5" }, { client });
+
+    expect(client.post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.0",
         "pino": "^9.0.0",
+        "pino-http": "^10.3.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1"
       },
@@ -3145,24 +3146,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -4624,7 +4607,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6595,15 +6577,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/on-headers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6889,6 +6862,18 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.5.0.tgz",
+      "integrity": "sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^9.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
       }
     },
     "node_modules/pino-std-serializers": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.0",
     "pino": "^9.0.0",
+    "pino-http": "^10.3.0",
     "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1"
   },

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -9,7 +9,21 @@ const express = require("express");
 const router = express.Router();
 const { strictLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey, sanitizeUsername } = require("../middleware/sanitization");
+const { verifyJWT } = require("../middleware/auth");
 const accountController = require("../controllers/accountController");
+
+/**
+ * Restrict account-data routes to the authenticated account holder (#278).
+ * Runs after verifyJWT (which sets req.user.publicKey from the SEP-10 JWT).
+ */
+function requireOwnAccount(req, res, next) {
+  if (req.user?.publicKey !== req.params.publicKey) {
+    return res
+      .status(403)
+      .json({ error: "Forbidden: you may only access your own account data" });
+  }
+  next();
+}
 
 /**
  * GET /api/accounts/resolve/:username
@@ -22,13 +36,13 @@ router.get("/resolve/:username", strictLimiter, sanitizeUsername, accountControl
  * GET /api/accounts/:publicKey
  * Fetch account info and balances from Horizon.
  */
-router.get("/:publicKey", strictLimiter, sanitizePublicKey, accountController.getAccount);
+router.get("/:publicKey", strictLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getAccount);
 
 /**
  * GET /api/accounts/:publicKey/balance
  * Fetch just the XLM balance for an account.
  */
-router.get("/:publicKey/balance", strictLimiter, sanitizePublicKey, accountController.getBalance);
+router.get("/:publicKey/balance", strictLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getBalance);
 
 /**
  * POST /api/accounts/register

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,0 +1,53 @@
+/**
+ * src/routes/webhooks.js
+ * Webhook registration endpoints (#279). All routes require a SEP-10 JWT and
+ * operate only on the authenticated account.
+ */
+"use strict";
+
+const express = require("express");
+const router = express.Router();
+const { strictLimiter } = require("../middleware/rateLimit");
+const { verifyJWT } = require("../middleware/auth");
+const webhookService = require("../services/webhookService");
+
+const URL_RE = /^https?:\/\/.+/i;
+
+// POST /api/webhooks — register a webhook URL + secret for the caller's account.
+router.post("/", strictLimiter, verifyJWT, (req, res) => {
+  const { url, secret } = req.body || {};
+  if (typeof url !== "string" || !URL_RE.test(url)) {
+    return res.status(400).json({ error: "A valid http(s) url is required" });
+  }
+  if (typeof secret !== "string" || secret.length < 8) {
+    return res.status(400).json({ error: "A secret of at least 8 characters is required" });
+  }
+
+  const record = webhookService.registerWebhook({ account: req.user.publicKey, url, secret });
+  // Begin watching this account's incoming payments on Horizon.
+  webhookService.ensureWatching(req.user.publicKey);
+
+  res.status(201).json({
+    id: record.id,
+    account: record.account,
+    url: record.url,
+    createdAt: record.createdAt,
+  });
+});
+
+// GET /api/webhooks — list the caller's webhooks (secrets redacted).
+router.get("/", strictLimiter, verifyJWT, (req, res) => {
+  res.json({ webhooks: webhookService.listWebhooks(req.user.publicKey) });
+});
+
+// DELETE /api/webhooks/:id — remove one of the caller's webhooks.
+router.delete("/:id", strictLimiter, verifyJWT, (req, res) => {
+  const existing = webhookService.getWebhook(req.params.id);
+  if (!existing || existing.account !== req.user.publicKey) {
+    return res.status(404).json({ error: "Webhook not found" });
+  }
+  webhookService.removeWebhook(req.params.id);
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,7 +8,7 @@
 const express = require("express");
 const cors = require("cors");
 const helmet = require("helmet");
-const morgan = require("morgan");
+const pinoHttp = require("pino-http");
 const rateLimit = require("express-rate-limit");
 require("dotenv").config();
 const Sentry = require("@sentry/node");
@@ -21,6 +21,7 @@ const healthRoutes = require("./routes/health");
 const federationRoutes = require("./routes/federation");
 const turretsRoutes = require("./routes/turrets");
 const tipsRoutes = require("./routes/tips");
+const webhookRoutes = require("./routes/webhooks");
 const swaggerUi = require("swagger-ui-express");
 const swaggerSpec = require("./swagger");
 const { startTurretsServer } = require("./turretsServer");
@@ -42,7 +43,9 @@ Sentry.init({
 // ─── Middleware ───────────────────────────────────────────────────────────────
 
 app.use(helmet());
-app.use(morgan("dev"));
+// Structured JSON request logging (#269) — replaces morgan('dev'); reuses the
+// shared pino logger so HTTP logs are machine-parseable (Datadog/CloudWatch).
+app.use(pinoHttp({ logger }));
 app.use(express.json({ limit: "10kb" }));
 
 // JSON parsing error handler
@@ -68,7 +71,7 @@ app.use(
         callback(new Error(`CORS: origin ${origin} not allowed`));
       }
     },
-    methods: ["GET", "POST"],
+    methods: ["GET", "POST", "DELETE"],
     allowedHeaders: ["Content-Type", "Authorization"],
     credentials: true,
   })
@@ -97,6 +100,7 @@ app.use(limiter);
 app.use("/api/auth",     authRoutes);
 app.use("/api/accounts", accountRoutes);
 app.use("/api/payments", paymentRoutes);
+app.use("/api/webhooks", webhookRoutes);
 app.use("/api/analytics", analyticsRoutes);
 app.use("/api/turrets", turretsRoutes);
 app.use("/api/tips", tipsRoutes);

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -184,4 +184,34 @@ function validatePublicKey(publicKey) {
   }
 }
 
-module.exports = { getAccount, getXLMBalance, getPayments, validatePublicKey };
+/**
+ * Stream incoming payments for an account from Horizon (#279). Invokes
+ * `onPayment` for each new payment credited *to* the account. Returns the
+ * stream's close function.
+ */
+function streamIncomingPayments(publicKey, onPayment) {
+  return server
+    .payments()
+    .forAccount(publicKey)
+    .cursor("now")
+    .stream({
+      onmessage: (payment) => {
+        if (payment.type === "payment" && payment.to === publicKey) {
+          try {
+            onPayment(payment);
+          } catch (err) {
+            logger.error({ err }, "payment stream handler failed");
+          }
+        }
+      },
+      onerror: (err) => logger.error({ err }, "Horizon payment stream error"),
+    });
+}
+
+module.exports = {
+  getAccount,
+  getXLMBalance,
+  getPayments,
+  validatePublicKey,
+  streamIncomingPayments,
+};

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -1,0 +1,99 @@
+/**
+ * src/services/webhookService.js
+ * Webhook registry + delivery for incoming-payment notifications (#279).
+ *
+ * Users register a URL + secret for their account; when an incoming payment is
+ * detected on Horizon, a JSON payload signed with HMAC-SHA256 is POSTed to the
+ * URL so the receiver can verify authenticity.
+ *
+ * Registry is in-memory (single-process). Swap for a persistent store when the
+ * backend is horizontally scaled.
+ */
+"use strict";
+
+const crypto = require("crypto");
+const axios = require("axios");
+const { generateWebhookSignature } = require("../utils/webhookSignature");
+const logger = require("../utils/logger");
+
+const webhooks = new Map(); // id -> { id, account, url, secret, createdAt }
+const watchedAccounts = new Map(); // account -> stream close handle
+
+function registerWebhook({ account, url, secret }) {
+  const id = crypto.randomUUID();
+  const record = { id, account, url, secret, createdAt: new Date().toISOString() };
+  webhooks.set(id, record);
+  return record;
+}
+
+/** Webhooks for an account, with secrets stripped — safe to return to clients. */
+function listWebhooks(account) {
+  return [...webhooks.values()]
+    .filter((w) => !account || w.account === account)
+    .map(({ secret, ...safe }) => safe);
+}
+
+function getWebhook(id) {
+  return webhooks.get(id);
+}
+
+function removeWebhook(id) {
+  return webhooks.delete(id);
+}
+
+/** Test helper — reset registry and watcher state. */
+function _reset() {
+  webhooks.clear();
+  watchedAccounts.clear();
+}
+
+/** POST a signed payload to a single webhook. `client` is injectable for tests. */
+async function deliverWebhook(webhook, payload, { client = axios } = {}) {
+  const body = JSON.stringify(payload);
+  const signature = generateWebhookSignature(body, webhook.secret);
+  return client.post(webhook.url, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      "X-Webhook-Signature": signature,
+    },
+    timeout: 5000,
+  });
+}
+
+/** Deliver an incoming-payment event to every webhook registered for `account`. */
+async function notifyIncomingPayment(account, payment, opts = {}) {
+  const targets = [...webhooks.values()].filter((w) => w.account === account);
+  await Promise.all(
+    targets.map((w) =>
+      deliverWebhook(w, { type: "payment.received", account, payment }, opts).catch((err) =>
+        logger.error({ err: err.message, webhookId: w.id }, "webhook delivery failed"),
+      ),
+    ),
+  );
+}
+
+/**
+ * Ensure a Horizon payment stream is running for `account` (idempotent). Lazily
+ * requires stellarService so this module stays unit-testable without Horizon.
+ */
+function ensureWatching(account) {
+  if (watchedAccounts.has(account)) return;
+  // eslint-disable-next-line global-require
+  const stellarService = require("./stellarService");
+  if (typeof stellarService.streamIncomingPayments !== "function") return;
+  const close = stellarService.streamIncomingPayments(account, (payment) =>
+    notifyIncomingPayment(account, payment),
+  );
+  watchedAccounts.set(account, close || (() => {}));
+}
+
+module.exports = {
+  registerWebhook,
+  listWebhooks,
+  getWebhook,
+  removeWebhook,
+  deliverWebhook,
+  notifyIncomingPayment,
+  ensureWatching,
+  _reset,
+};

--- a/frontend/__tests__/copyToClipboard.test.ts
+++ b/frontend/__tests__/copyToClipboard.test.ts
@@ -1,0 +1,48 @@
+import { copyToClipboard } from "@/utils/format";
+
+describe("copyToClipboard (#275)", () => {
+  const originalClipboard = navigator.clipboard;
+
+  // jsdom does not implement execCommand, so it must be defined before spying.
+  const originalExec = (document as unknown as { execCommand?: unknown }).execCommand;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+    (document as unknown as { execCommand?: unknown }).execCommand = originalExec;
+    jest.restoreAllMocks();
+  });
+
+  function setExecCommand(result: boolean) {
+    (document as unknown as { execCommand: unknown }).execCommand = jest
+      .fn()
+      .mockReturnValue(result);
+    return (document as unknown as { execCommand: jest.Mock }).execCommand;
+  }
+
+  function setClipboard(value: unknown) {
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value });
+  }
+
+  it("uses the Clipboard API in secure contexts", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when navigator.clipboard is unavailable (HTTP)", async () => {
+    setClipboard(undefined);
+    const exec = setExecCommand(true);
+    await expect(copyToClipboard("hi")).resolves.toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  it("returns false when both the Clipboard API and execCommand fail", async () => {
+    setClipboard({ writeText: jest.fn().mockRejectedValue(new Error("denied")) });
+    setExecCommand(false);
+    await expect(copyToClipboard("x")).resolves.toBe(false);
+  });
+});

--- a/frontend/utils/format.ts
+++ b/frontend/utils/format.ts
@@ -110,12 +110,39 @@ export function formatDate(dateString: string): string {
  * Copy text to clipboard and return success boolean.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
+  // Preferred path: the async Clipboard API, only available in secure contexts
+  // (HTTPS or localhost).
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or transient failure — fall back to execCommand below.
+    }
   }
+
+  // Fallback for non-secure (HTTP) contexts where navigator.clipboard is
+  // undefined. Returns the real success state so callers don't show a false
+  // "Copied!" confirmation.
+  if (typeof document !== "undefined" && typeof document.execCommand === "function") {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    try {
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

### Structured JSON request logging (closes #269)
- The main backend now logs HTTP requests via **`pino-http`** (reusing the shared pino logger) instead of `morgan('dev')`, so logs are machine-parseable for Datadog/CloudWatch. (`turretsServer` keeps morgan.)

### Clipboard fallback in non-secure contexts (closes #275)
- `copyToClipboard` now falls back to **`document.execCommand('copy')`** when `navigator.clipboard` is unavailable (HTTP) and returns the **real** success boolean, so the UI no longer shows a false "Copied!".

### Account-data authorization (closes #278)
- The SEP-10 challenge/verify endpoints and `verifyJWT` middleware already existed in `main` (commit `7ce0192`) but **weren't enforced** on the data routes. This PR applies `verifyJWT` + an own-account check to `GET /api/accounts/:publicKey` and `/:publicKey/balance` — **401** when unauthenticated, **403** when requesting another account. (So the auth *layer* existed; this closes the gap of actually gating account data behind it.)

### Payment webhooks (closes #279)
- `POST/GET/DELETE /api/webhooks` — register a URL + secret for your account (auth-gated, own-account, secrets redacted on read).
- New incoming payments are detected via a **Horizon `payments().forAccount().cursor('now').stream()`** watcher and delivered as a JSON payload signed with **HMAC-SHA256** (`X-Webhook-Signature`), reusing the existing `webhookSignature` util.

## Tests
- Frontend: `copyToClipboard` (Clipboard API / execCommand fallback / failure).
- Backend: account auth scoping (401/403), webhook registry + signed delivery, webhook routes (auth, validation, list-redaction, delete). 17 tests, all green.

## Notes
- The frontend has a pre-existing storybook peer-dependency conflict (`addon-a11y@10` vs `addon-essentials@8`); `npm install` needs `--legacy-peer-deps`. Unrelated to this PR.
