### PR TITLE
feat: send-form shortcut, testnet friendbot empty state, SDK upgrade & explorer URL validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "stellar-micropay-backend",
       "version": "1.0.0",
       "dependencies": {
-        "@stellar/stellar-sdk": "^12.0.0",
+        "@stellar/stellar-sdk": "^15.1.0",
         "axios": "^1.6.8",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -17,6 +17,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.0",
+        "pino": "^9.0.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1"
       },
@@ -27,7 +28,7 @@
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "20.19.5"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1436,11 +1437,25 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1496,6 +1511,12 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1556,41 +1577,62 @@
       }
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
-      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
-      "license": "Apache-2.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
+      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
+        "@noble/curves": "^1.9.7",
+        "@stellar/js-xdr": "^4.0.0",
         "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^9.3.1",
         "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
+        "sha.js": "^2.4.12"
       },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-15.1.0.tgz",
+      "integrity": "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.1",
-        "axios": "^1.7.7",
-        "bignumber.js": "^9.1.2",
+        "@stellar/stellar-base": "^15.0.0",
+        "axios": "1.15.0",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.3",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
-        "urijs": "^1.19.1"
+        "urijs": "^1.19.11"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2139,6 +2181,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2155,14 +2206,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2270,50 +2321,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
-      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-module-resolve": "^1.10.0",
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -2551,14 +2558,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3573,6 +3580,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4297,6 +4313,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -5742,6 +5770,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5982,6 +6019,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -6108,6 +6182,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6122,10 +6212,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -6197,6 +6290,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6250,17 +6349,13 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/require-addon": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
-      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-addon-resolve": "^1.3.0"
-      },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
       "engines": {
-        "bare": ">=1.10.0"
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-directory": {
@@ -6386,6 +6481,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6625,14 +6729,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
-      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "require-addon": "^1.1.0"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -6654,6 +6757,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -7063,6 +7175,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7129,12 +7250,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7363,13 +7478,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
+      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src/**/*.js"
   },
   "dependencies": {
-    "@stellar/stellar-sdk": "^12.0.0",
+    "@stellar/stellar-sdk": "^15.1.0",
     "axios": "^1.6.8",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/frontend/__tests__/explorerUrl.test.ts
+++ b/frontend/__tests__/explorerUrl.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+import { explorerUrl } from "@/lib/stellar";
+
+const VALID = "a".repeat(64);
+
+describe("explorerUrl (#274)", () => {
+  it("returns a stellar.expert URL for a valid 64-char hex hash", () => {
+    const url = explorerUrl(VALID);
+    expect(url).not.toBeNull();
+    expect(url).toContain(`/tx/${VALID}`);
+    expect(url).toMatch(/^https:\/\/stellar\.expert\/explorer\/(testnet|public)\/tx\//);
+  });
+
+  it("accepts mixed-case hex", () => {
+    expect(explorerUrl("A1b2C3d4".repeat(8))).not.toBeNull();
+  });
+
+  it("returns null for an empty hash", () => {
+    expect(explorerUrl("")).toBeNull();
+  });
+
+  it("returns null for a too-short hash", () => {
+    expect(explorerUrl("abc123")).toBeNull();
+  });
+
+  it("returns null for a non-hex string of the right length", () => {
+    expect(explorerUrl("z".repeat(64))).toBeNull();
+  });
+});

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -144,6 +144,27 @@ export default function SendPaymentForm({
   const detectorRef = useRef<BarcodeDetectorLike | null>(null);
   const frameRequestRef = useRef<number | null>(null);
   const isDetectingRef = useRef(false);
+  const destinationInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Power-user shortcut: press "S" (when not already typing in a field and no
+  // modal is open) to jump focus to the destination input (#264).
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key.toLowerCase() !== "s" || e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
+        return;
+      }
+      if (typeof document !== "undefined" && document.querySelector('[aria-modal="true"]')) {
+        return; // don't steal focus from an open dialog
+      }
+      e.preventDefault();
+      destinationInputRef.current?.focus();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   useEffect(() => {
     const checkSupport = async () => {
@@ -546,14 +567,9 @@ export default function SendPaymentForm({
         </div>
         <h2 className="mb-2 font-display text-2xl font-bold text-white">{successTitle}</h2>
         <p className="mb-6 text-slate-400">{successMessage || "Your payment has been confirmed on the Stellar network."}</p>
-        />
-      </>
-    );
-          </div>
-        </div>
 
         <div className="flex flex-col gap-3">
-          <a href={explorerUrl(txHash)} target="_blank" rel="noopener noreferrer" className="btn-primary flex items-center justify-center gap-2">
+          <a href={explorerUrl(txHash) ?? undefined} target="_blank" rel="noopener noreferrer" className="btn-primary flex items-center justify-center gap-2">
             View on Explorer <ExternalLinkIcon className="h-4 w-4" />
           </a>
 
@@ -662,6 +678,7 @@ export default function SendPaymentForm({
             </div>
             
             <input
+              ref={destinationInputRef}
               type="text"
               value={destination}
               onChange={(e) => setDestination(e.target.value)}
@@ -756,12 +773,7 @@ export default function SendPaymentForm({
         timeoutSeconds={60}
         onClose={closeStatusModal}
       />
-<<<<<<< HEAD
     </>
-=======
-    </div>
-  </>
->>>>>>> caccf0c (fix: Resolve frontend TypeScript compilation errors in CI)
   );
 }
 

--- a/frontend/components/TransactionList.tsx
+++ b/frontend/components/TransactionList.tsx
@@ -293,6 +293,19 @@ export default function TransactionList({
           <p className="text-slate-600 text-xs mt-1">
             Send your first payment to get started
           </p>
+          {process.env.NEXT_PUBLIC_STELLAR_NETWORK !== "mainnet" && (
+            <p className="text-xs mt-3">
+              Need test XLM?{" "}
+              <a
+                href={`https://friendbot.stellar.org/?addr=${publicKey}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-stellar-400 hover:underline"
+              >
+                Fund this account with Friendbot
+              </a>
+            </p>
+          )}
         </div>
       </div>
     );
@@ -431,7 +444,7 @@ export default function TransactionList({
               )}
               
               <a
-                href={explorerUrl(tx.transactionHash)}
+                href={explorerUrl(tx.transactionHash) ?? undefined}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-500 hover:text-stellar-400"

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -21,7 +21,7 @@ import {
   nativeToScVal,
   scValToNative,
   xdr,
-  SorobanRpc,
+  rpc,
   Federation,
 } from "@stellar/stellar-sdk";
 
@@ -206,19 +206,19 @@ export function getSorobanRpcUrl(): string {
 export const SOROBAN_RPC_URL = getSorobanRpcUrl();
 
 /** Pre-configured Soroban RPC server instance. */
-let _sorobanServer: SorobanRpc.Server | null = null;
-export function getSorobanServer(): SorobanRpc.Server {
+let _sorobanServer: rpc.Server | null = null;
+export function getSorobanServer(): rpc.Server {
   const currentUrl = getSorobanRpcUrl();
   if (!_sorobanServer || _sorobanServer.serverURL.toString() !== currentUrl) {
-    _sorobanServer = new SorobanRpc.Server(currentUrl);
+    _sorobanServer = new rpc.Server(currentUrl);
   }
   return _sorobanServer;
 }
 
 // For backwards compatibility
-export const sorobanServer = new Proxy({} as SorobanRpc.Server, {
+export const sorobanServer = new Proxy({} as rpc.Server, {
   get(target, prop) {
-    return getSorobanServer()[prop as keyof SorobanRpc.Server];
+    return getSorobanServer()[prop as keyof rpc.Server];
   },
 });
 
@@ -1027,7 +1027,12 @@ export function isValidStellarAddress(address: string): boolean {
  * // → "https://stellar.expert/explorer/testnet/tx/abc123..."
  * ```
 */
-export function explorerUrl(hash: string): string {
+export function explorerUrl(hash: string): string | null {
+  // A Stellar transaction hash is 64 hex chars. Reject anything else so we
+  // never produce a broken / misleading explorer link (#274).
+  if (!/^[a-f0-9]{64}$/i.test(hash)) {
+    return null;
+  }
   const net = NETWORK === "mainnet" ? "public" : "testnet";
   return `https://stellar.expert/explorer/${net}/tx/${hash}`;
 }
@@ -1086,7 +1091,7 @@ export async function buildSorobanTipTransaction({
   // Preflight: Simulate the transaction to get resources and fees
   const simulated = await sorobanServer.simulateTransaction(tx);
 
-  if (SorobanRpc.Api.isSimulationError(simulated)) {
+  if (rpc.Api.isSimulationError(simulated)) {
     throw new Error(`Simulation failed: ${simulated.error}`);
   }
 
@@ -1121,7 +1126,7 @@ export async function getContractTipTotal(recipient: string): Promise<string> {
 
     const sim = await sorobanServer.simulateTransaction(tx);
 
-    if (SorobanRpc.Api.isSimulationSuccess(sim) && sim.result) {
+    if (rpc.Api.isSimulationSuccess(sim) && sim.result) {
       const value = scValToNative(sim.result.retval);
       return value.toString();
     }
@@ -1179,7 +1184,7 @@ export async function buildReceiptMintTransaction({
 
   const simulated = await sorobanServer.simulateTransaction(tx);
 
-  if (SorobanRpc.Api.isSimulationError(simulated)) {
+  if (rpc.Api.isSimulationError(simulated)) {
     throw new Error(`Receipt simulation failed: ${simulated.error}`);
   }
 
@@ -1204,7 +1209,7 @@ export async function getReceiptCount(payer: string): Promise<number> {
       .build();
 
     const sim = await sorobanServer.simulateTransaction(tx);
-    if (SorobanRpc.Api.isSimulationSuccess(sim) && sim.result) {
+    if (rpc.Api.isSimulationSuccess(sim) && sim.result) {
       const value = scValToNative(sim.result.retval);
       return Number(value);
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
         "@stellar/freighter-api": "^2.0.0",
-        "@stellar/stellar-sdk": "^12.0.0",
+        "@stellar/stellar-sdk": "^15.1.0",
         "axios": "^1.6.8",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -3770,6 +3770,33 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4772,41 +4799,73 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
-      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
-      "license": "Apache-2.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
+      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
+        "@noble/curves": "^1.9.7",
+        "@stellar/js-xdr": "^4.0.0",
         "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^9.3.1",
         "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
+        "sha.js": "^2.4.12"
       },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
-      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-15.1.0.tgz",
+      "integrity": "sha512-GsJUcWx2yboVzYdhTe/LHS3V1wVLSHkUkglC5bBoYWGJt31vzIhbSGno60NP9CdCTNkLJdnrsLJ63oA58Zvh5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.1",
-        "axios": "^1.7.7",
-        "bignumber.js": "^9.1.2",
+        "@stellar/stellar-base": "^15.0.0",
+        "axios": "1.15.0",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.3",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
-        "urijs": "^1.19.1"
+        "urijs": "^1.19.11"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@storybook/addon-a11y": {
@@ -7624,50 +7683,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
-      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-module-resolve": "^1.10.0",
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-semver": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
-      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -10413,6 +10428,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11968,6 +11992,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -15843,19 +15879,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "node_modules/require-addon": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
-      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-addon-resolve": "^1.3.0"
-      },
-      "engines": {
-        "bare": ">=1.10.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -16556,16 +16579,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
-      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "require-addon": "^1.1.0"
       }
     },
     "node_modules/source-map": {
@@ -17816,12 +17829,6 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@stellar/freighter-api": "^2.0.0",
-    "@stellar/stellar-sdk": "^12.0.0",
+    "@stellar/stellar-sdk": "^15.1.0",
     "axios": "^1.6.8",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary

### Keyboard shortcut to focus the send form (closes #264)
- Pressing **`S`** (when not already typing in a field and with no modal open) focuses the destination input in the send form.

### Friendbot link in the transactions empty state (closes #265)
- On non-mainnet networks, the "No transactions yet" empty state now links to **Friendbot** (`https://friendbot.stellar.org/?addr=…`) so new testnet users can fund their account.

### Upgrade @stellar/stellar-sdk ^12 → ^15.1.0 (closes #267)
- Bumped in frontend + backend. The one breaking change affecting our code is the removed **`SorobanRpc`** namespace → renamed to **`rpc`** (migrated in `lib/stellar.ts`: `rpc.Server`, `rpc.Api`). Backend uses only `Horizon.*`, which is unchanged.

### Validate transaction hash in explorerUrl (closes #274)
- `explorerUrl(hash)` now returns **`null`** unless `hash` is a 64-char hex string, so a malformed/empty hash never produces a broken explorer link. The two callers render no `href` when null.

## Tests
- Frontend: `explorerUrl` validation (5 cases). Backend SDK-using tests pass under v15 (29/30; the 1 failure is an unrelated `/.well-known/stellar.toml` route 404, see below).

## Notes (honest disclosure — pre-existing, not caused by this PR)
- **The frontend did not compile on `main`**: `SendPaymentForm.tsx` had an unresolved git merge conflict (`<<<<<<<`/`=======`/`>>>>>>>`) plus a mangled success-view block, both left by an earlier "fix CI TypeScript errors" commit. **This PR repairs that** so the file parses again.
- After the SDK migration, `tsc` shows **no new SDK-related errors**. Remaining frontend `tsc` errors are pre-existing and unrelated to this PR: undefined `TradeAggregation`/`OpenOffer` types in `lib/stellar.ts`/`trade.tsx`, a `disconnectCurrentWallet` typo in `settings.tsx`, and `@testing-library/react` type resolution in some test files.
- The backend `federation.test.js` 404 and the jsdom `TextEncoder` gap in the test env are also pre-existing.
