### PR TITLE
fix: path payments, health rate-limit, compact empty state, mobile grid

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -63,12 +63,10 @@ app.use(
   })
 );
 
-// ─── Routes ───────────────────────────────────────────────────────────────────
+// ─── Health route (exempt from rate limiting) ─────────────────────────────────
 
-app.use("/api/auth",     authRoutes);
-app.use("/api/accounts", accountRoutes);
-app.use("/api/payments", paymentRoutes);
 app.use("/health",       healthRoutes);
+app.use("/api/health",   healthRoutes);
 
 // Global rate limiting — 100 requests per 15 minutes per IP.
 // standardHeaders: true  → emits RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset (RFC 6585 draft-7).
@@ -85,10 +83,10 @@ app.use(limiter);
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
+app.use("/api/auth",     authRoutes);
 app.use("/api/accounts", accountRoutes);
 app.use("/api/payments", paymentRoutes);
 app.use("/api/analytics", analyticsRoutes);
-app.use("/api/health", healthRoutes);
 app.use("/api/turrets", turretsRoutes);
 app.use("/api/tips", tipsRoutes);
 app.use("/federation", federationRoutes);

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -88,11 +88,29 @@ async function getPayments(publicKey, { limit = 20, cursor } = {}) {
 
   const payments = [];
 
-  for (const op of result.records) {
-    if (op.type !== "payment") continue;
+  const PAYMENT_TYPES = new Set([
+    "payment",
+    "path_payment_strict_send",
+    "path_payment_strict_receive",
+  ]);
 
-    const assetCode =
-      op.asset_type === "native" ? "XLM" : op.asset_code || "UNKNOWN";
+  for (const op of result.records) {
+    if (!PAYMENT_TYPES.has(op.type)) continue;
+
+    // path_payment ops expose dest_asset_* and dest_amount for the received side
+    const isPathPayment = op.type !== "payment";
+    const isSent = op.from === publicKey;
+
+    let assetCode;
+    if (isPathPayment && !isSent) {
+      assetCode =
+        op.dest_asset_type === "native" ? "XLM" : op.dest_asset_code || "UNKNOWN";
+    } else {
+      assetCode =
+        op.asset_type === "native" ? "XLM" : op.asset_code || "UNKNOWN";
+    }
+
+    const amount = isPathPayment && !isSent ? op.dest_amount : op.amount;
 
     let memo;
     try {
@@ -107,8 +125,8 @@ async function getPayments(publicKey, { limit = 20, cursor } = {}) {
 
     payments.push({
       id: op.id,
-      type: op.from === publicKey ? "sent" : "received",
-      amount: op.amount,
+      type: isSent ? "sent" : "received",
+      amount,
       asset: assetCode,
       from: op.from,
       to: op.to,

--- a/frontend/components/TransactionList.tsx
+++ b/frontend/components/TransactionList.tsx
@@ -283,8 +283,9 @@ export default function TransactionList({
   }
 
   if (payments.length === 0) {
+    if (compact) return null;
     return (
-      <div className={compact ? "" : "card"}>
+      <div className="card">
         <div className="text-center py-12">
           <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-white/5 flex items-center justify-center">
             <HistoryIcon className="w-6 h-6 text-slate-500" />

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1050,8 +1050,8 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
         />
       )}
 
-      <div className="grid lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-1">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-1 order-1 lg:order-none">
           <div className="card mb-6 bg-cosmos-950/80 border-white/10">
             <div className="flex gap-2 p-2 rounded-3xl bg-white/5">
               <button
@@ -1108,7 +1108,7 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
           </div>
         </div>
 
-        <div className="lg:col-span-1">
+        <div className="lg:col-span-1 order-2 lg:order-none">
           <div className="card h-full">
             <div className="flex items-center justify-between mb-5">
               <h2 className="font-display text-lg font-semibold text-white flex items-center gap-2">


### PR DESCRIPTION
Closes #271
Closes #272
Closes #273
Closes #263

## Changes

- **#271** (`stellarService.js`): `getPayments` now includes `path_payment_strict_send` and `path_payment_strict_receive` ops alongside plain `payment`. Uses `dest_asset_*` and `dest_amount` for the received side of path payments.
- **#273** (`server.js`): `healthRoutes` registered before the global rate limiter so `/health` and `/api/health` are never rate-limited. Removed duplicate route registrations.
- **#272** (`TransactionList.tsx`): When `compact=true` and payments array is empty, returns `null` instead of an unstyled empty wrapper div.
- **#263** (`dashboard.tsx`): Dashboard grid is now `grid-cols-1 lg:grid-cols-3` so cards stack cleanly on mobile. Send form uses `order-1` to stay at the top on small screens.