### PR TITLE
[infra] Add dependabot configuration for npm and Rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Africa/Lagos
+    labels:
+      - infra
+      - dx
+      - security
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Africa/Lagos
+    labels:
+      - infra
+      - dx
+      - security
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: cargo
+    directory: /contracts/stellar-micropay-contract
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Africa/Lagos
+    labels:
+      - infra
+      - dx
+      - security
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Closes #257 

## Summary

Adds GitHub Dependabot configuration to automatically open dependency update PRs for the frontend, backend, and Soroban contract packages.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Changes

- Added `.github/dependabot.yml`
- Configured weekly `npm` dependency checks for `frontend` and `backend`
- Configured weekly `cargo` dependency checks for `contracts/stellar-micropay-contract`
- Applied `infra`, `dx`, and `security` labels to Dependabot PRs
- Limited open Dependabot PRs to 5 per ecosystem entry

## Testing

- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [x] Manually tested UI flow

## Checklist

- [x] My code follows the project style
- [ ] I've updated docs if needed
- [x] No console errors or warnings
- [ ] I've rebased on latest `main`