### PR TITLE
fix(a11y): aria-label on icon-only buttons + list semantics in TransactionList

### DIFF
--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -686,12 +686,19 @@ export default function SendPaymentForm({
                     }}
                     className="text-stellar-400 hover:text-stellar-300"
                     title={favourites.some((f) => f.address === destination) ? "Remove favourite" : "Add favourite"}
+                    aria-label={favourites.some((f) => f.address === destination) ? "Remove address from favourites" : "Add address to favourites"}
                   >
                     <StarIcon className="h-5 w-5" filled={favourites.some((f) => f.address === destination)} />
                   </button>
                 )}
                 {isScannerSupported && status === "idle" && (
-                  <button type="button" onClick={openScanner} className="text-slate-400 hover:text-white" title="Scan QR Code">
+                  <button
+                    type="button"
+                    onClick={openScanner}
+                    className="text-slate-400 hover:text-white"
+                    title="Scan QR Code"
+                    aria-label="Scan QR code to fill destination address"
+                  >
                     <QrCodeIcon className="h-5 w-5" />
                   </button>
                 )}

--- a/frontend/components/TransactionList.tsx
+++ b/frontend/components/TransactionList.tsx
@@ -360,10 +360,15 @@ export default function TransactionList({
             <span>Keyboard navigation: ↑ ↓ to navigate, Enter to copy address</span>
           </div>
           
-          <div className="space-y-2">
+          <div
+            role="list"
+            aria-label="Payment history"
+            className="space-y-2"
+          >
         {visiblePayments.map((tx, index) => (
           <div
             key={tx.id}
+            role="listitem"
             tabIndex={focusedIndex === index ? 0 : -1}
             onKeyDown={(e) => {
               if (e.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary
This PR addresses four assigned a11y / infra issues in one batch.

- **#250 — `aria-label` on icon-only buttons in `SendPaymentForm`**: implemented.
- **#251 — `role="list"` / `role="listitem"` on `TransactionList`**: implemented.
- **#254 — production `docker-compose` (no volume mounts)**: **already resolved on `main`** by PR #182 (merged 2026-04-29) — see note below. No code change is needed; `closes #254` is included so the issue auto-closes.
- **#256 — nginx reverse proxy service in docker-compose**: **already resolved on `main`** by the same PR #182 — see note below. No code change is needed; `closes #256` is included so the issue auto-closes.

closes #250
closes #251
closes #254
closes #256

---

## Per-issue detail

### closes #250 — aria-label on icon-only buttons (`SendPaymentForm.tsx`)

Two interactive elements in `frontend/components/SendPaymentForm.tsx` were rendered as icon-only buttons (no visible text). They had `title=…` tooltips, but screen readers do not reliably announce `title` on buttons, and visually impaired users had no way to know what the controls do.

Added `aria-label` to both:

1. **QR-code scan button** (visible only when `BarcodeDetector` is supported and the form is idle). Renders only `<QrCodeIcon />`. Added `aria-label="Scan QR code to fill destination address"`.
2. **Favourite-star toggle button** (visible when the entered destination is a valid Stellar address). Renders only `<StarIcon />`. Added a dynamic `aria-label` that flips with state:
   - When the address is already a favourite: `"Remove address from favourites"`.
   - When it is not: `"Add address to favourites"`.

Other interactive controls in the form (asset selector, destination input, amount input, memo input, send button, confirmation modal buttons, success-state buttons, memo template chips) already expose visible text, so no further `aria-label`s were needed. The `title` attributes are kept for sighted hover tooltips.

### closes #251 — list semantics on `TransactionList`

In `frontend/components/TransactionList.tsx`, transaction items were rendered as `<div>` children inside a `<div className="space-y-2">`, so screen readers had no way to announce the number of items in the list. The issue allowed either semantic `<ul>/<li>` or explicit ARIA roles.

Chose explicit ARIA roles to avoid any default-list styling regression and to keep the existing Tailwind layout untouched:
- Outer container: added `role="list"` and `aria-label="Payment history"`.
- Each transaction row: added `role="listitem"`.

The per-row `aria-label` (e.g. `"Sent 1.23 XLM to G…"`), keyboard navigation (`ArrowUp`/`ArrowDown`/`Enter` to copy), and per-row `tabIndex` behaviour are preserved unchanged.

### closes #254 — production docker-compose file (already done)

**No file change in this PR.** The work this issue describes — a `docker-compose.prod.yml` that runs built images with no source-mount volumes and `NODE_ENV=production` — is already present on `main`, added in PR #182 ("feat: add production Docker deployment and fix CI errors", merged 2026-04-29, commit `ee02f37`).

Verified on the current `main`:
- `docker-compose.prod.yml` exists.
- `backend` service uses `Dockerfile.prod` with `NODE_ENV=production` and `STELLAR_NETWORK=mainnet`; no source-bind mount.
- `frontend` service uses `Dockerfile.prod`; no source-bind mount. (It writes the built static output into a named `frontend_static` volume that nginx mounts read-only — this is the standard pattern for serving a Next.js export through nginx and is not a development source mount.)
- All services have healthchecks and `restart: always`.

Including `closes #254` in this PR body so the issue is auto-linked and closed on merge, matching the assignment.

### closes #256 — nginx reverse proxy (already done)

**No file change in this PR.** The nginx reverse-proxy service this issue describes — `/api/*` → backend, everything else → frontend, eliminating cross-origin calls — is already present on `main`, also added in PR #182.

Verified on the current `main`:
- `docker-compose.prod.yml` declares an `nginx` service on `nginx:alpine`, exposes port 80, mounts `./nginx/nginx.conf` read-only, depends on the `frontend` and `backend` services being healthy, and has its own healthcheck.
- `nginx/nginx.conf` defines a single `server` block on port 80 with:
  - `location /` serving the static frontend from `/usr/share/nginx/html` with SPA fallback (`try_files $uri $uri/ /index.html`).
  - `location /api/` reverse-proxying to `http://backend:4000/` with the usual `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, `Upgrade`/`Connection` headers and HTTP/1.1.
  - `location /health` returning `200 OK`.
- Gzip and security headers (`X-Frame-Options`, `X-XSS-Protection`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`) are configured globally.

Including `closes #256` in this PR body so the issue is auto-linked and closed on merge, matching the assignment.

---

## What's covered

- **Manual code review of `SendPaymentForm.tsx`**: confirmed the QR-scan and favourite-star buttons were the only icon-only interactive elements; all other controls in the form expose visible text.
- **Manual code review of `TransactionList.tsx`**: confirmed the change only adds ARIA roles and an `aria-label`; no rendering, focus, or layout logic was modified.
- **Manual check of `main`**: confirmed `docker-compose.prod.yml` and `nginx/nginx.conf` already satisfy issues #254 and #256.

## Honest caveats

- **Not built or unit-tested locally.** My environment can't run the project's `npm install` / Jest / Next.js build, so I'm relying on CI to flag any regression. The changes are scoped to JSX attribute additions only — no logic, hook, render-order, or type surface was changed — so the risk of breaking the existing `SendPaymentForm.test.tsx` (which queries by `getByRole('button', { name: /…/i })`) or any TS check is very low.
- **#254 and #256 carry no code in this PR by design** — they were resolved by PR #182 a month before the issues were assigned. If the maintainer would prefer separate confirmation (e.g. a comment on each issue instead of `closes`), happy to adjust.
