### PR TITLE
docs: complete API reference for all backend routes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,12 +1,69 @@
 # API Documentation — Stellar MicroPay
 
-Base URL: `http://localhost:4000`
+**Base URL:** `http://localhost:4000` (default; override with `PORT`)
 
-All responses follow the format:
+**Interactive docs:** [Swagger UI](http://localhost:4000/api/docs) · [OpenAPI JSON](http://localhost:4000/api/docs.json)
+
+---
+
+## Response conventions
+
+Most JSON endpoints use one of these shapes:
+
+**Success (typical)**
 ```json
-{ "success": true, "data": { ... } }
-{ "success": false, "error": "message" }
+{ "success": true, "data": { } }
 ```
+
+**Success with message**
+```json
+{ "success": true, "data": { }, "message": "..." }
+```
+
+**Error**
+```json
+{ "error": "Human-readable message" }
+```
+
+Some endpoints (health, federation, auth challenge, webhooks list) return a flat object without the `success` / `data` wrapper. Each route below shows the actual response shape.
+
+**Authentication:** Account detail routes require a JWT from [SEP-0010 auth](#authentication). Send:
+
+```
+Authorization: Bearer <token>
+```
+
+---
+
+## Rate limiting
+
+| Limiter | Window | Limit | Applies to |
+|---------|--------|-------|------------|
+| Global | 15 minutes | 100 req/IP | All routes **except** `/health` and `/api/health` |
+| Strict | 1 minute | 20 req/IP | `/api/accounts/*`, `/api/payments/*`, `/api/analytics/*`, `/api/tips/*`, `/api/turrets/*`, `/federation` |
+
+Responses include `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers.
+
+| Status | Body |
+|--------|------|
+| 429 (global) | `{ "error": "Too many requests, please try again later." }` |
+| 429 (strict) | `{ "error": "Too many requests to sensitive routes, please wait 1 minute." }` |
+
+---
+
+## Table of contents
+
+- [Health](#health)
+- [API documentation](#api-documentation)
+- [Authentication](#authentication)
+- [Stellar federation](#stellar-federation)
+- [Accounts](#accounts)
+- [Payments](#payments)
+- [Analytics](#analytics)
+- [Tips](#tips)
+- [Turrets (txFunctions)](#turrets-txfunctions)
+- [Webhooks](#webhooks)
+- [Global errors](#global-errors)
 
 ---
 
@@ -14,9 +71,11 @@ All responses follow the format:
 
 ### `GET /health`
 
-Check that the API server is running.
+### `GET /api/health`
 
-**Response**
+Liveness probe. **Not** subject to global rate limiting.
+
+**Response `200`**
 ```json
 {
   "status": "ok",
@@ -26,112 +85,286 @@ Check that the API server is running.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| status | string | Always `"ok"` when healthy |
+| service | string | Service identifier |
+| network | string | `STELLAR_NETWORK` env or `"testnet"` |
+| timestamp | string (ISO 8601) | Server time |
+
 ---
 
-## Stellar Federation
+## API documentation
+
+### `GET /api/docs`
+
+Serves Swagger UI (HTML).
+
+### `GET /api/docs.json`
+
+Returns the OpenAPI 3.0 specification as JSON.
+
+**Response `200`** — OpenAPI document (large JSON object).
+
+---
+
+## Authentication
+
+SEP-0010 Stellar Web Authentication.
+
+### `GET /api/auth`
+
+Issue a challenge transaction for the client to sign.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| account | string | yes | Stellar public key (`G` + 55 alphanumerics) |
+
+**Response `200`**
+```json
+{
+  "transaction": "<base64 XDR>",
+  "networkPassphrase": "Test SDF Network ; September 2015"
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Missing account query parameter" }` |
+| 400 | `{ "error": "<validation message>" }` |
+
+---
+
+### `POST /api/auth`
+
+Verify a signed challenge and issue a JWT (also set as `httpOnly` cookie `jwt`).
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| transaction | string | yes | Signed challenge XDR (base64) |
+
+**Example request**
+```json
+{
+  "transaction": "AAAAAgAAAAC..."
+}
+```
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Missing transaction in request body" }` |
+| 401 | `{ "error": "Unauthorized: <reason>" }` |
+
+---
+
+## Stellar federation
 
 ### `GET /.well-known/stellar.toml`
 
-Expose the SEP-0001 discovery document used by Stellar wallets to find this app's federation server.
+SEP-0001 discovery document (TOML, not JSON).
 
-**Response (TOML)**
+**Response `200`** (`Content-Type: application/toml`)
 ```toml
-FEDERATION_SERVER="https://stellarmicropay.io/federation"
+# Stellar MicroPay federation discovery
+FEDERATION_SERVER="http://localhost:4000/federation"
 ```
 
 ---
 
 ### `GET /federation`
 
-Resolve Stellar Federation addresses such as `alice*stellarmicropay.io` per SEP-0002.
+SEP-0002 federation resolver. Subject to **strict** rate limit.
 
 **Query parameters**
-| Name | Type | Description |
-|------|------|-------------|
-| q | string | Federation query. For `type=name`, use `username*domain`; for `type=id`, use a Stellar public key |
-| type | string | `name` or `id` |
 
-**Response**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| q | string | yes | For `type=name`: `username*domain`; for `type=id`: Stellar account ID (`G...`) |
+| type | string | yes | `"name"` or `"id"` |
+
+**Response `200` (type=name)**
 ```json
 {
   "stellar_address": "alice*stellarmicropay.io",
-  "account_id": "GABC...XYZ"
+  "account_id": "GABC1234567890123456789012345678901234567890123456789012345"
+}
+```
+
+**Response `200` (type=id)**
+```json
+{
+  "stellar_address": "alice*stellarmicropay.io",
+  "account_id": "GABC1234567890123456789012345678901234567890123456789012345"
 }
 ```
 
 **Errors**
-| Status | Meaning |
-|--------|---------|
-| 400 | Missing parameters, invalid type, or invalid address format |
-| 404 | Username or account ID not found |
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Missing required parameters: q and type" }` |
+| 400 | `{ "error": "Invalid required parameters: q and type must be strings" }` |
+| 400 | `{ "error": "Invalid type parameter. Must be 'name' or 'id'" }` |
+| 400 | `{ "error": "Invalid stellar address format" }` |
+| 404 | `{ "error": "Not found" }` |
+| 404 | `{ "error": "Account ID not found" }` |
 
 ---
 
 ## Accounts
 
-### `GET /api/accounts/:publicKey`
+### `GET /api/accounts/resolve/:username`
 
-Fetch account info and all token balances.
+Resolve a registered username to a public key. Subject to **strict** rate limit.
 
-**Parameters**
+**Path parameters**
+
 | Name | Type | Description |
 |------|------|-------------|
-| publicKey | string | Stellar G... public key |
+| username | string | 3–20 alphanumeric characters (trimmed and lowercased) |
 
-**Response**
+**Response `200`**
 ```json
 {
   "success": true,
   "data": {
-    "publicKey": "GABC...XYZ",
+    "username": "alice",
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345"
+  }
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Username is required" }` |
+| 400 | `{ "error": "Username must be 3-20 characters long and contain only letters and numbers" }` |
+| 404 | `{ "error": "Username not found" }` |
+
+---
+
+### `POST /api/accounts/register`
+
+Register a username for a Stellar public key. Subject to **strict** rate limit.
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| username | string | yes | 3–20 alphanumeric characters |
+| publicKey | string | yes | Stellar `G...` public key (56 chars) |
+
+**Example request**
+```json
+{
+  "username": "alice",
+  "publicKey": "GABC1234567890123456789012345678901234567890123456789012345"
+}
+```
+
+**Response `201`**
+```json
+{
+  "success": true,
+  "data": {
+    "username": "alice",
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345"
+  },
+  "message": "Username registered successfully"
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "success": false, "error": "Username and public key are required" }` |
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+| 409 | `{ "error": "Username already registered" }` |
+| 409 | `{ "error": "Public key already registered to another username" }` |
+
+---
+
+### `GET /api/accounts/:publicKey`
+
+Fetch account info and balances from Horizon. Requires JWT; caller may only access their own key. Subject to **strict** rate limit.
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| publicKey | string | Stellar `G...` public key (56 chars) |
+
+**Headers**
+
+| Name | Value |
+|------|-------|
+| Authorization | `Bearer <jwt>` |
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
     "sequence": "12345678",
     "subentryCount": 0,
     "balances": [
-      { "assetCode": "XLM", "balance": "9999.9999900", "asset_type": "native" }
+      {
+        "assetCode": "XLM",
+        "balance": "9999.9999900",
+        "asset_type": "native"
+      }
     ]
   }
 }
 ```
 
 **Errors**
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid public key format |
-| 404 | Account not found / unfunded |
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+| 401 | `{ "error": "Unauthorized: missing or invalid token" }` |
+| 401 | `{ "error": "Unauthorized: invalid or expired token" }` |
+| 403 | `{ "error": "Forbidden: you may only access your own account data" }` |
+| 404 | `{ "error": "Account not found. It may not be funded yet. Use Friendbot on testnet." }` |
 
 ---
 
 ### `GET /api/accounts/:publicKey/balance`
 
-Fetch only the native XLM balance.
+Fetch native XLM balance only. Same auth and rate-limit rules as `GET /api/accounts/:publicKey`.
 
-**Response**
+**Response `200`**
 ```json
 {
   "success": true,
   "data": {
-    "publicKey": "GABC...XYZ",
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
     "xlm": "9999.9999900"
   }
 }
 ```
 
----
-
-### `GET /api/accounts/resolve/:username`
-
-Resolve a username (e.g. `alice`) to a Stellar public key.
-
-**Response**
-```json
-{
-  "success": true,
-  "data": {
-    "username": "alice",
-    "publicKey": "GABC...XYZ"
-  }
-}
-```
+**Errors** — Same as `GET /api/accounts/:publicKey`.
 
 ---
 
@@ -139,16 +372,22 @@ Resolve a username (e.g. `alice`) to a Stellar public key.
 
 ### `GET /api/payments/:publicKey`
 
-Fetch payment history for an account.
+Payment history from Horizon. Subject to **strict** rate limit.
 
-**Parameters**
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| publicKey | string | Stellar `G...` public key |
+
+**Query parameters**
+
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| publicKey | path | — | Stellar public key |
-| limit | query | 20 | Max results (max 100) |
-| cursor | query | — | Pagination cursor |
+| limit | integer | 20 | Max results (capped at 100) |
+| cursor | string | — | Horizon pagination cursor |
 
-**Response**
+**Response `200`**
 ```json
 {
   "success": true,
@@ -160,8 +399,8 @@ Fetch payment history for an account.
       "asset": "XLM",
       "from": "GABC...SENDER",
       "to": "GXYZ...RECIPIENT",
-      "memo": "Coffee ☕",
-      "createdAt": "2025-01-01T12:00:00Z",
+      "memo": "Coffee",
+      "createdAt": "2025-01-01T12:00:00.000Z",
       "transactionHash": "abc123...",
       "pagingToken": "..."
     }
@@ -169,18 +408,30 @@ Fetch payment history for an account.
 }
 ```
 
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+
 ---
 
 ### `GET /api/payments/:publicKey/stats`
 
-Return aggregate statistics for an account.
+Aggregate payment statistics (computed from up to 100 recent payments).
 
-**Response**
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| publicKey | string | Stellar `G...` public key |
+
+**Response `200`**
 ```json
 {
   "success": true,
   "data": {
-    "publicKey": "GABC...XYZ",
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
     "totalSentXLM": "150.0000000",
     "totalReceivedXLM": "75.0000000",
     "sentCount": 12,
@@ -190,25 +441,592 @@ Return aggregate statistics for an account.
 }
 ```
 
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+
 ---
 
-## Rate Limiting
+## Analytics
 
-All endpoints are rate limited to **100 requests per 15 minutes** per IP address.
+All analytics routes use a 5-minute in-memory cache per public key. Subject to **strict** rate limit.
 
-When exceeded, the API returns:
+### `GET /api/analytics/:publicKey/summary`
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| publicKey | string | Stellar `G...` public key |
+
+**Response `200`**
 ```json
-{ "error": "Too many requests, please try again later." }
+{
+  "success": true,
+  "data": {
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+    "totalSentXLM": "150.0000000",
+    "totalReceivedXLM": "75.0000000",
+    "uniqueCounterparties": 8,
+    "averageTransactionSize": "15.0000000",
+    "totalTransactions": 17
+  }
+}
 ```
 
 ---
 
-## Error Codes
+### `GET /api/analytics/:publicKey/top-recipients`
 
-| HTTP Status | Meaning |
-|-------------|---------|
-| 400 | Bad request (invalid input) |
-| 404 | Resource not found |
-| 429 | Rate limit exceeded |
-| 500 | Internal server error |
-| 501 | Feature not yet implemented |
+Top 5 recipients by total XLM sent.
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+    "topRecipients": [
+      {
+        "address": "GXYZ...RECIPIENT",
+        "totalXLMSent": "50.0000000"
+      }
+    ],
+    "count": 1
+  }
+}
+```
+
+---
+
+### `GET /api/analytics/:publicKey/activity`
+
+Payment counts grouped by day of week (UTC).
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+    "activityByDay": [
+      { "day": "Sunday", "dayIndex": 0, "transactionCount": 2 },
+      { "day": "Monday", "dayIndex": 1, "transactionCount": 5 }
+    ]
+  }
+}
+```
+
+**Errors (all analytics routes)**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+
+---
+
+## Tips
+
+In-memory tip ledger (v1). Subject to **strict** rate limit.
+
+### `POST /api/tips`
+
+Record a tip after an on-chain payment.
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| senderPublicKey | string | yes | Sender `G...` key |
+| creatorPublicKey | string | yes | Creator `G...` key |
+| amount | string | yes | Positive numeric amount |
+| asset | string | no | Asset code (default `"XLM"`) |
+| memo | string | no | Optional message |
+| txHash | string | no | Stellar transaction hash |
+
+**Example request**
+```json
+{
+  "senderPublicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+  "creatorPublicKey": "GXYZ1234567890123456789012345678901234567890123456789012345",
+  "amount": "5.0",
+  "asset": "XLM",
+  "memo": "Great stream!",
+  "txHash": "a1b2c3..."
+}
+```
+
+**Response `201`**
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "senderPublicKey": "GABC...",
+    "creatorPublicKey": "GXYZ...",
+    "amount": "5.0",
+    "asset": "XLM",
+    "memo": "Great stream!",
+    "txHash": "a1b2c3...",
+    "timestamp": "2025-01-01T12:00:00.000Z"
+  },
+  "message": "Tip recorded successfully"
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "senderPublicKey is required, creatorPublicKey is required, ..." }` (combined validation messages) |
+| 400 | `{ "error": "Invalid sender public key format" }` |
+| 400 | `{ "error": "amount must be a positive number" }` |
+
+---
+
+### `GET /api/tips/received/:creatorPublicKey`
+
+Tips received by a creator, with embedded stats.
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| creatorPublicKey | string | Creator `G...` key |
+
+**Query parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| limit | integer | 50 | Page size |
+| offset | integer | 0 | Skip count |
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "tips": [
+      {
+        "id": 1,
+        "senderPublicKey": "GABC...",
+        "creatorPublicKey": "GXYZ...",
+        "amount": "5.0",
+        "asset": "XLM",
+        "memo": "",
+        "txHash": "",
+        "timestamp": "2025-01-01T12:00:00.000Z"
+      }
+    ],
+    "total": 1,
+    "limit": 50,
+    "offset": 0,
+    "stats": {
+      "totalTips": 1,
+      "totalByAsset": {
+        "XLM": { "count": 1, "amount": "5" }
+      },
+      "averageTip": "5",
+      "largestTip": "5",
+      "smallestTip": "5"
+    }
+  }
+}
+```
+
+---
+
+### `GET /api/tips/stats/:creatorPublicKey`
+
+Tip statistics for a creator.
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "totalTips": 10,
+    "totalByAsset": {
+      "XLM": { "count": 10, "amount": "50" }
+    },
+    "averageTip": "5",
+    "largestTip": "20",
+    "smallestTip": "1"
+  }
+}
+```
+
+---
+
+### `GET /api/tips/sent/:senderPublicKey`
+
+Tips sent by a user.
+
+**Query parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| limit | integer | 50 | Page size |
+| offset | integer | 0 | Skip count |
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "tips": [],
+    "total": 0,
+    "limit": 50,
+    "offset": 0
+  }
+}
+```
+
+---
+
+## Turrets (txFunctions)
+
+Automated transaction functions (DCA, stop-loss, escrow release). Subject to **strict** rate limit (20 req/min).
+
+Supported `type` values: `dca`, `stop_loss`, `escrow_release`.
+
+### `GET /api/turrets`
+
+List deployments.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| ownerPublicKey | string | no | Filter by owner `G...` key |
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "ownerPublicKey": "GABC...",
+      "type": "dca",
+      "status": "active",
+      "config": { "intervalMinutes": 60, "amountQuote": 10, "quoteAssetCode": "USDC", "quoteAssetIssuer": null },
+      "deploymentHash": "abc123...",
+      "createdAt": "2025-01-01T12:00:00.000Z",
+      "nextRunAt": "2025-01-01T13:00:00.000Z",
+      "lastExecutedAt": null,
+      "lastCheckedAt": null,
+      "lastObservedPriceUsd": null,
+      "lastError": null
+    }
+  ]
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+
+---
+
+### `POST /api/turrets/challenge`
+
+Create a signing challenge (ManageData transaction XDR).
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| ownerPublicKey | string | yes | Owner `G...` key |
+| type | string | yes | `dca`, `stop_loss`, or `escrow_release` |
+| config | object | yes | Type-specific configuration |
+
+**Example request (DCA)**
+```json
+{
+  "ownerPublicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+  "type": "dca",
+  "config": {
+    "intervalMinutes": 60,
+    "amountQuote": 10,
+    "quoteAssetCode": "USDC",
+    "quoteAssetIssuer": "GBBD47IF6LOC7NNYVK5WQCCFNNBX2L5TBRW2NTRU3OBMKENZ5YKF3NPS"
+  }
+}
+```
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": {
+    "challengeXDR": "AAAAAgAAAAC...",
+    "deploymentHash": "a1b2c3d4e5f6...",
+    "normalizedConfig": {
+      "intervalMinutes": 60,
+      "amountQuote": 10,
+      "quoteAssetCode": "USDC",
+      "quoteAssetIssuer": "GBBD47IF6LOC7NNYVK5WQCCFNNBX2L5TBRW2NTRU3OBMKENZ5YKF3NPS"
+    },
+    "networkPassphrase": "Test SDF Network ; September 2015"
+  }
+}
+```
+
+**Errors**
+
+| Status | Body (examples) |
+|--------|-------------------|
+| 400 | `{ "error": "Invalid Stellar public key format" }` |
+| 400 | `{ "error": "Unsupported txFunction type. Use 'dca', 'stop_loss', or 'escrow_release'." }` |
+| 400 | `{ "error": "DCA intervalMinutes must be at least 1" }` |
+
+---
+
+### `POST /api/turrets/deploy`
+
+Deploy a txFunction after signing the challenge.
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| ownerPublicKey | string | yes | Owner `G...` key |
+| type | string | yes | `dca`, `stop_loss`, or `escrow_release` |
+| config | object | yes | Same config used for challenge |
+| deploymentHash | string | yes | Hash from challenge response |
+| signedChallengeXDR | string | yes | Challenge XDR signed by owner |
+
+**Response `201`**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "ownerPublicKey": "GABC...",
+    "type": "dca",
+    "status": "active",
+    "config": { },
+    "deploymentHash": "a1b2c3...",
+    "createdAt": "2025-01-01T12:00:00.000Z",
+    "nextRunAt": "2025-01-01T13:00:00.000Z"
+  }
+}
+```
+
+**Errors**
+
+| Status | Body (examples) |
+|--------|-------------------|
+| 400 | `{ "error": "Configuration hash mismatch. Recreate challenge and sign again." }` |
+| 400 | `{ "error": "Asset issuer is required for non-native asset USDC" }` |
+| 401 | `{ "error": "Signed challenge was not signed by the owner account" }` |
+
+---
+
+### `GET /api/turrets/:id`
+
+Get a single deployment.
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| id | string (UUID) | Deployment ID |
+
+**Response `200`** — `{ "success": true, "data": { ...deployment } }`
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 404 | `{ "error": "txFunction not found" }` |
+
+---
+
+### `GET /api/turrets/:id/history`
+
+Execution log for a deployment (newest first).
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "660e8400-e29b-41d4-a716-446655440001",
+      "deploymentId": "550e8400-e29b-41d4-a716-446655440000",
+      "status": "executed",
+      "message": "DCA txFunction generated",
+      "result": { "action": "buy_xlm_dca" },
+      "createdAt": "2025-01-01T12:30:00.000Z"
+    }
+  ]
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 404 | `{ "error": "txFunction not found" }` |
+
+---
+
+### `POST /api/turrets/:id/pause`
+
+Pause a deployment.
+
+**Response `200`** — `{ "success": true, "data": { ...deployment, "status": "paused" } }`
+
+---
+
+### `POST /api/turrets/:id/resume`
+
+Resume a paused deployment.
+
+**Response `200`** — `{ "success": true, "data": { ...deployment, "status": "active" } }`
+
+---
+
+## Webhooks
+
+Register Horizon SSE listeners that POST to your URL when payments are received.
+
+### `POST /api/webhooks`
+
+**Request body (JSON)**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| publicKey | string | yes | Account to monitor |
+| url | string | yes | HTTPS endpoint to receive events |
+| secret | string | yes | HMAC secret for `X-Webhook-Signature` |
+
+**Example request**
+```json
+{
+  "publicKey": "GABC1234567890123456789012345678901234567890123456789012345",
+  "url": "https://example.com/webhooks/stellar",
+  "secret": "whsec_..."
+}
+```
+
+**Response `201`**
+```json
+{
+  "success": true,
+  "webhook": {
+    "id": "1",
+    "publicKey": "GABC...",
+    "url": "https://example.com/webhooks/stellar",
+    "secret": "whsec_...",
+    "createdAt": "2025-01-01T12:00:00.000Z"
+  }
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 400 | `{ "error": "publicKey, url, and secret are required" }` |
+| 500 | `{ "error": "<message>" }` |
+
+**Outbound webhook payload** (POST to your `url`)
+```json
+{
+  "event": "payment.received",
+  "publicKey": "GABC...",
+  "payment": {
+    "id": "...",
+    "from": "G...",
+    "to": "G...",
+    "amount": "10.0000000",
+    "asset": "XLM",
+    "createdAt": "2025-01-01T12:00:00Z"
+  }
+}
+```
+
+Header: `X-Webhook-Signature` — HMAC-SHA256 hex of the JSON body using `secret`.
+
+---
+
+### `GET /api/webhooks/:publicKey`
+
+List webhooks for an account.
+
+**Response `200`**
+```json
+{
+  "webhooks": [
+    {
+      "id": "1",
+      "publicKey": "GABC...",
+      "url": "https://example.com/webhooks/stellar",
+      "secret": "whsec_...",
+      "createdAt": "2025-01-01T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+### `DELETE /api/webhooks/:id`
+
+Delete a webhook by numeric ID.
+
+**Path parameters**
+
+| Name | Type | Description |
+|------|------|-------------|
+| id | string | Webhook ID assigned at registration |
+
+**Response `200`**
+```json
+{
+  "success": true,
+  "message": "Webhook 1 deleted"
+}
+```
+
+**Errors**
+
+| Status | Body |
+|--------|------|
+| 404 | `{ "error": "Webhook not found" }` |
+
+---
+
+## Global errors
+
+These apply across routes unless noted otherwise.
+
+| HTTP status | When | Example body |
+|-------------|------|--------------|
+| 400 | Invalid JSON body | `{ "error": "Invalid JSON body" }` |
+| 404 | Unknown route | `{ "error": "Route not found" }` |
+| 429 | Rate limit (global) | `{ "error": "Too many requests, please try again later." }` |
+| 429 | Rate limit (strict) | `{ "error": "Too many requests to sensitive routes, please wait 1 minute." }` |
+| 500 | Unhandled server error | `{ "error": "Internal Server Error" }` or `{ "error": "<message>" }` |
+
+**CORS:** Requests from origins not listed in `ALLOWED_ORIGINS` are rejected by the CORS middleware.
+
+---
+
+## Turrets sidecar (optional)
+
+When `TURRETS_PORT` is set (default `4100`), a separate process exposes:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `http://localhost:4100/health` | Sidecar health |
+| * | `http://localhost:4100/tx-functions/*` | Same txFunction routes as `/api/turrets/*` on the main server |
+
+The main API on port **4000** mounts turrets at `/api/turrets`; prefer that URL for application integration.


### PR DESCRIPTION
## Summary

Updates `docs/api.md` to document every backend route on port 4000 with HTTP methods, parameters, JSON examples, and error responses aligned with the current implementation.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #241 

## Changes

- Expanded `docs/api.md` to cover all API routes: health, auth, federation, accounts, payments, analytics, tips, turrets, webhooks, and OpenAPI docs
- Added query/path/body parameter tables with types for each endpoint
- Added request/response JSON examples and documented error codes with exact messages from the codebase
- Documented rate limiting (global and strict), JWT requirements for account routes, and global error responses

## Testing

- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

Documentation-only change; verified route coverage against `backend/src/server.js`, route files, controllers, and `swagger.js`.

## Screenshots (if UI change)

N/A — documentation only.

## Checklist

- [x] My code follows the project style
- [x] I've updated docs if needed
- [x] No console errors or warnings
- [x] I've rebased on latest `main`