### PR TITLE
Add startup env validation to fail fast on missing config.

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 PORT=4000
 NODE_ENV=development
 
-# Stellar Network: "testnet" | "mainnet"
+# Required — validated at startup (see src/config/validateEnv.js)
 STELLAR_NETWORK=testnet
 HORIZON_URL=https://horizon-testnet.stellar.org
 

--- a/backend/__tests__/validateEnv.test.js
+++ b/backend/__tests__/validateEnv.test.js
@@ -1,0 +1,53 @@
+/**
+ * __tests__/validateEnv.test.js
+ * Unit tests for startup environment validation.
+ */
+
+"use strict";
+
+const { collectErrors } = require("../src/config/validateEnv");
+
+describe("validateEnv.collectErrors", () => {
+  it("returns no errors when required vars are valid", () => {
+    expect(
+      collectErrors({
+        STELLAR_NETWORK: "testnet",
+        HORIZON_URL: "https://horizon-testnet.stellar.org",
+      })
+    ).toEqual([]);
+  });
+
+  it("flags missing STELLAR_NETWORK and HORIZON_URL", () => {
+    const errors = collectErrors({});
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("STELLAR_NETWORK is required"),
+        expect.stringContaining("HORIZON_URL is required"),
+      ])
+    );
+  });
+
+  it("rejects invalid STELLAR_NETWORK values", () => {
+    const errors = collectErrors({
+      STELLAR_NETWORK: "devnet",
+      HORIZON_URL: "https://horizon-testnet.stellar.org",
+    });
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('STELLAR_NETWORK must be "testnet" or "mainnet"'),
+      ])
+    );
+  });
+
+  it("rejects malformed HORIZON_URL", () => {
+    const errors = collectErrors({
+      STELLAR_NETWORK: "testnet",
+      HORIZON_URL: "not-a-url",
+    });
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("HORIZON_URL must be a valid URL"),
+      ])
+    );
+  });
+});

--- a/backend/src/config/validateEnv.js
+++ b/backend/src/config/validateEnv.js
@@ -1,0 +1,59 @@
+/**
+ * src/config/validateEnv.js
+ * Fail-fast validation for required backend environment variables.
+ */
+
+"use strict";
+
+const VALID_NETWORKS = ["testnet", "mainnet"];
+
+function collectErrors(env) {
+  const errors = [];
+
+  const stellarNetwork = env.STELLAR_NETWORK?.trim();
+  if (!stellarNetwork) {
+    errors.push('STELLAR_NETWORK is required (e.g. "testnet" or "mainnet")');
+  } else if (!VALID_NETWORKS.includes(stellarNetwork)) {
+    errors.push(
+      `STELLAR_NETWORK must be "testnet" or "mainnet", got "${stellarNetwork}"`
+    );
+  }
+
+  const horizonUrl = env.HORIZON_URL?.trim();
+  if (!horizonUrl) {
+    errors.push(
+      'HORIZON_URL is required (e.g. "https://horizon-testnet.stellar.org")'
+    );
+  } else {
+    try {
+      new URL(horizonUrl);
+    } catch {
+      errors.push(`HORIZON_URL must be a valid URL, got "${horizonUrl}"`);
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validate required environment variables.
+ * Logs actionable errors and exits the process when validation fails.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ */
+function validateEnv(env = process.env) {
+  const errors = collectErrors(env);
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.error("\nEnvironment validation failed:\n");
+  for (const message of errors) {
+    console.error(`  - ${message}`);
+  }
+  console.error("\nCopy backend/.env.example to backend/.env and set the required values.\n");
+  process.exit(1);
+}
+
+module.exports = { validateEnv, collectErrors };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -26,6 +26,7 @@ const swaggerUi = require("swagger-ui-express");
 const swaggerSpec = require("./swagger");
 const { startTurretsServer } = require("./turretsServer");
 const logger = require("./utils/logger");
+const { validateEnv } = require("./config/validateEnv");
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -187,6 +188,7 @@ app.use((err, req, res, next) => {
 // ─── Start ────────────────────────────────────────────────────────────────────
 
 if (require.main === module) {
+  validateEnv();
   app.listen(PORT, () => {
     console.log(`
   ✨ Stellar MicroPay API

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,14 +1,12 @@
-# Stellar Network (testnet or mainnet)
+# Required — validated at startup (see scripts/validateEnv.mjs)
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
-
-# Horizon API URL
 NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# Optional
 
 # Soroban Contract ID (for recording tips)
 NEXT_PUBLIC_CONTRACT_ID=
-
-# Backend API URL
-NEXT_PUBLIC_API_URL=http://localhost:4000
 
 # Anthropic API Key for AI Payment Assistant
 ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import { validateEnv } from "./scripts/validateEnv.mjs";
+
+validateEnv();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -42,5 +42,10 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 300_000,
+    env: {
+      NEXT_PUBLIC_STELLAR_NETWORK: 'testnet',
+      NEXT_PUBLIC_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+      NEXT_PUBLIC_API_URL: 'http://localhost:4000',
+    },
   },
 });

--- a/frontend/scripts/validateEnv.mjs
+++ b/frontend/scripts/validateEnv.mjs
@@ -1,0 +1,78 @@
+/**
+ * scripts/validateEnv.mjs
+ * Fail-fast validation for required frontend environment variables.
+ */
+
+const VALID_NETWORKS = ["testnet", "mainnet"];
+
+function collectErrors(env) {
+  const errors = [];
+
+  const network = env.NEXT_PUBLIC_STELLAR_NETWORK?.trim();
+  if (!network) {
+    errors.push(
+      'NEXT_PUBLIC_STELLAR_NETWORK is required (e.g. "testnet" or "mainnet")'
+    );
+  } else if (!VALID_NETWORKS.includes(network)) {
+    errors.push(
+      `NEXT_PUBLIC_STELLAR_NETWORK must be "testnet" or "mainnet", got "${network}"`
+    );
+  }
+
+  const horizonUrl = env.NEXT_PUBLIC_HORIZON_URL?.trim();
+  if (!horizonUrl) {
+    errors.push(
+      'NEXT_PUBLIC_HORIZON_URL is required (e.g. "https://horizon-testnet.stellar.org")'
+    );
+  } else {
+    try {
+      new URL(horizonUrl);
+    } catch {
+      errors.push(
+        `NEXT_PUBLIC_HORIZON_URL must be a valid URL, got "${horizonUrl}"`
+      );
+    }
+  }
+
+  const apiUrl = env.NEXT_PUBLIC_API_URL?.trim();
+  if (!apiUrl) {
+    errors.push(
+      'NEXT_PUBLIC_API_URL is required (e.g. "http://localhost:4000")'
+    );
+  } else {
+    try {
+      new URL(apiUrl);
+    } catch {
+      errors.push(
+        `NEXT_PUBLIC_API_URL must be a valid URL, got "${apiUrl}"`
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validate required environment variables.
+ * Logs actionable errors and exits the process when validation fails.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ */
+export function validateEnv(env = process.env) {
+  const errors = collectErrors(env);
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.error("\nEnvironment validation failed:\n");
+  for (const message of errors) {
+    console.error(`  - ${message}`);
+  }
+  console.error(
+    "\nCopy frontend/.env.example to frontend/.env.local and set the required values.\n"
+  );
+  process.exit(1);
+}
+
+export { collectErrors };


### PR DESCRIPTION
Validate required Stellar and API env vars in backend and frontend before boot so misconfiguration surfaces immediately instead of deep in the Horizon SDK.

## Summary

Adds fail-fast startup validation for required environment variables in both the backend and frontend. Missing or invalid `STELLAR_NETWORK`, `HORIZON_URL`, or `NEXT_PUBLIC_*` config now logs a clear error and exits before the Horizon SDK is used.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #227 

## Changes

- Added `backend/src/config/validateEnv.js` to require `STELLAR_NETWORK` and `HORIZON_URL` at server startup
- Wired validation into `backend/src/server.js` (runs only when starting the server, not when imported by tests)
- Added `frontend/scripts/validateEnv.mjs` to require `NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_HORIZON_URL`, and `NEXT_PUBLIC_API_URL`
- Wired frontend validation into `frontend/next.config.mjs` so `next dev`, `next build`, and `next start` all check env early
- Updated `frontend/playwright.config.ts` with required env vars for E2E CI builds
- Added backend unit tests in `backend/__tests__/validateEnv.test.js`
- Updated `backend/.env.example` and `frontend/.env.example` to mark required variables

## Testing

- [ ] Tested locally on Testnet
- [x] Added/updated unit tests
- [ ] Manually tested UI flow

- Backend lint passed
- Backend `validateEnv` unit tests passed (4/4)
- Backend federation integration tests passed (9/9) — server import unaffected
- Verified fail-fast output when required env vars are missing

## Screenshots (if UI change)

N/A — no UI changes.

## Checklist

- [x] My code follows the project style
- [x] I've updated docs if needed
- [x] No console errors or warnings
- [x] I've rebased on latest `main`