### PR TITLE
feat:E2E tests, ESLint, Horizon reliability, payment confirmation

### DIFF
--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -19,6 +19,58 @@ const server = new Horizon.Server(HORIZON_URL);
 const ACCOUNT_CACHE_TTL_MS = 5_000;
 const ACCOUNT_CACHE_MAX = 256;
 
+// ─── Timeout + retry ──────────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 3;
+
+function isTransientError(err) {
+  if (!err) return false;
+  const status = err?.response?.status ?? err?.status;
+  if (status === 404) return false; // definitive — don't retry
+  if (status >= 500) return true;
+  const msg = err?.message || "";
+  return (
+    msg.includes("ECONNRESET") ||
+    msg.includes("ETIMEDOUT") ||
+    msg.includes("ENOTFOUND") ||
+    msg.includes("network") ||
+    err.name === "AbortError"
+  );
+}
+
+/**
+ * Run `fn` with a hard timeout and retry up to MAX_RETRIES times on
+ * transient errors, using exponential back-off (100 ms × 2^attempt).
+ */
+async function withTimeoutAndRetry(fn, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  let lastErr;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const result = await Promise.race([
+        fn(controller.signal),
+        new Promise((_, reject) =>
+          controller.signal.addEventListener("abort", () =>
+            reject(Object.assign(new Error("Horizon request timed out"), { name: "AbortError" }))
+          )
+        ),
+      ]);
+      clearTimeout(timer);
+      return result;
+    } catch (err) {
+      clearTimeout(timer);
+      lastErr = err;
+      if (!isTransientError(err) || attempt === MAX_RETRIES) throw err;
+      // Exponential back-off: 100 ms, 200 ms, 400 ms …
+      await new Promise((resolve) => setTimeout(resolve, 100 * 2 ** attempt));
+    }
+  }
+  throw lastErr;
+}
+
 /** @type {Map<string, { value: object, expiresAt: number }>} */
 const accountCache = new Map();
 
@@ -59,7 +111,7 @@ async function getAccount(publicKey) {
   if (cached) return cached;
 
   try {
-    const account = await server.loadAccount(publicKey);
+    const account = await withTimeoutAndRetry(() => server.loadAccount(publicKey));
 
     const balances = account.balances.map((b) => {
       if (b.asset_type === "native") {
@@ -122,7 +174,7 @@ async function getPayments(publicKey, { limit = 20, cursor } = {}) {
     query = query.cursor(cursor);
   }
 
-  const result = await query.call();
+  const result = await withTimeoutAndRetry(() => query.call());
 
   const payments = [];
 
@@ -152,7 +204,7 @@ async function getPayments(publicKey, { limit = 20, cursor } = {}) {
 
     let memo;
     try {
-      const tx = await op.transaction();
+      const tx = await withTimeoutAndRetry(() => op.transaction());
       if (tx.memo_type === "text" && tx.memo) {
         memo = tx.memo;
       }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "next",
   "rules": {
-    "@next/next/no-img-element": "error"
+    "@next/next/no-img-element": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }]
   }
 }

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -938,14 +938,16 @@ interface SendConfirmationModalProps {
 
 function SendConfirmationModal({ isOpen, destination, amount, asset, memo, estimatedFee, onCancel, onConfirm }: SendConfirmationModalProps) {
   if (!isOpen) return null;
+  const shortened = shortenAddress(destination, 8);
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true" aria-labelledby="confirm-payment-title">
       <div className="w-full max-w-md rounded-2xl bg-slate-900 p-6 border border-white/10 shadow-2xl">
-        <h3 className="text-xl font-bold text-white mb-4">Confirm Payment</h3>
+        <h3 id="confirm-payment-title" className="text-xl font-bold text-white mb-4">Confirm Payment</h3>
         <div className="space-y-4">
           <div>
             <p className="text-xs text-slate-400 uppercase font-bold">To</p>
-            <p className="text-sm font-mono text-slate-200 break-all">{destination}</p>
+            <p className="text-base font-semibold text-white">{shortened}</p>
+            <p className="text-xs font-mono text-slate-400 break-all mt-0.5">{destination}</p>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
@@ -953,7 +955,7 @@ function SendConfirmationModal({ isOpen, destination, amount, asset, memo, estim
               <p className="text-lg font-bold text-white">{amount} {asset}</p>
             </div>
             <div>
-              <p className="text-xs text-slate-400 uppercase font-bold">Fee</p>
+              <p className="text-xs text-slate-400 uppercase font-bold">Estimated Fee</p>
               <p className="text-sm text-slate-300">{estimatedFee}</p>
             </div>
           </div>
@@ -966,7 +968,7 @@ function SendConfirmationModal({ isOpen, destination, amount, asset, memo, estim
         </div>
         <div className="mt-8 flex gap-3">
           <button onClick={onCancel} className="flex-1 rounded-xl border border-white/10 py-3 text-sm font-semibold text-white hover:bg-white/5 transition-all">Cancel</button>
-          <button onClick={onConfirm} className="flex-1 btn-primary py-3">Confirm & Send</button>
+          <button onClick={onConfirm} className="flex-1 btn-primary py-3">Confirm & Sign</button>
         </div>
       </div>
     </div>

--- a/frontend/e2e/wallet-connect.spec.ts
+++ b/frontend/e2e/wallet-connect.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * E2E tests for wallet connect flow (issue #223).
+ *
+ * Scenarios:
+ *  1. Dashboard shows 'Connect wallet' prompt when no Freighter extension is present.
+ *  2. After mock-connecting Freighter, wallet address and balance are displayed.
+ *  3. Navigating to /transactions after connect shows the transaction list.
+ */
+import { test as base, expect } from '@playwright/test';
+import { test as authenticatedTest } from './fixtures';
+
+// ── Scenario 1: no extension present ─────────────────────────────────────────
+
+base.describe('wallet not connected', () => {
+  base.beforeEach(async ({ page }) => {
+    // Freighter stub that reports it is NOT installed / connected.
+    await page.addInitScript(() => {
+      (window as any).freighter = {
+        isConnected: async () => ({ isConnected: false }),
+        getPublicKey: async () => ({ publicKey: '' }),
+        signTransaction: async () => ({ signedTransaction: '' }),
+        requestAccess: async () => ({}),
+        isAllowed: async () => ({ isAllowed: false }),
+      };
+    });
+  });
+
+  base.test('dashboard shows Connect wallet prompt and button', async ({ page }) => {
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByText('Connect your wallet to get started')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /Connect Freighter Wallet/i }),
+    ).toBeVisible();
+  });
+
+  base.test('transactions page shows Connect wallet prompt and button', async ({ page }) => {
+    await page.goto('/transactions');
+
+    await expect(page.getByRole('heading', { name: 'Transaction History' })).toBeVisible();
+    await expect(page.getByText('Connect your wallet to view your payments')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /Connect Freighter Wallet/i }),
+    ).toBeVisible();
+  });
+});
+
+// ── Scenario 2 & 3: Freighter mock-connected ──────────────────────────────────
+// Uses the shared fixture that injects a fully-mocked freighter + backend.
+
+authenticatedTest(
+  'after mock connect, wallet address and XLM balance are displayed on dashboard',
+  async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: /Connect Freighter Wallet/i }).click();
+
+    // Wallet address card becomes visible once connected.
+    const addressLabel = page.locator('p.label').filter({ hasText: 'Wallet Address' });
+    await expect(addressLabel).toBeVisible({ timeout: 15_000 });
+
+    // Balance card is rendered with an XLM suffix.
+    await expect(page.locator('p.label').filter({ hasText: 'XLM Balance' })).toBeVisible();
+    await expect(page.getByText(/XLM/)).toBeVisible();
+  },
+);
+
+authenticatedTest(
+  'after mock connect, navigating to /transactions shows the transaction list',
+  async ({ page }) => {
+    // Connect wallet first via the dashboard.
+    await page.goto('/dashboard');
+    await page.getByRole('button', { name: /Connect Freighter Wallet/i }).click();
+
+    // Wait until dashboard is authenticated.
+    await expect(
+      page.locator('p.label').filter({ hasText: 'Wallet Address' }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Navigate to the transactions page.
+    await page.goto('/transactions');
+
+    // The authenticated view renders the heading and transaction list container.
+    await expect(
+      page.getByRole('heading', { name: 'Transaction History' }),
+    ).toBeVisible();
+
+    // The list (or its empty-state) must be present — not the "connect wallet" gate.
+    await expect(
+      page.getByText('Connect your wallet to view your payments'),
+    ).not.toBeVisible();
+  },
+);

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,70 @@
+# PR: Multi-issue improvements — E2E tests, ESLint, Horizon reliability, payment confirmation
+
+## Summary
+
+- closes #223 — E2E tests for wallet connect flow (Playwright)
+- closes #228 — ESLint `no-console` rule for frontend
+- closes #235 — Timeout + retry logic for `stellarService.js` Horizon calls
+- closes #238 — Confirmation dialog improvements before sending payment
+
+---
+
+## Changes
+
+### `frontend/e2e/wallet-connect.spec.ts` (new file) — closes #223
+
+Added a dedicated Playwright spec that covers the three acceptance criteria:
+
+1. **No extension** — unauthenticated dashboard shows "Connect your wallet to get started" and the "Connect Freighter Wallet" button; same check on `/transactions`.
+2. **After mock connect** — clicking the button with the fixture-injected Freighter stub results in the wallet address label and XLM balance being visible on the dashboard.
+3. **Transactions page post-connect** — navigating to `/transactions` after connecting renders the transaction list view (not the wallet-gate screen).
+
+Uses the existing `fixtures.ts` for the authenticated scenarios (mocked Freighter, Horizon, and backend auth endpoints).
+
+---
+
+### `frontend/.eslintrc.json` — closes #228
+
+Added the `no-console` rule at `warn` level, allowing `console.warn` and `console.error` to pass through:
+
+```json
+"no-console": ["warn", { "allow": ["warn", "error"] }]
+```
+
+This surfaces direct `console.log` calls during `next lint` / CI so developers are reminded to use the project's logging abstraction, without breaking any existing `console.warn` / `console.error` calls.
+
+---
+
+### `backend/src/services/stellarService.js` — closes #235
+
+Introduced a `withTimeoutAndRetry(fn, timeoutMs)` helper that:
+
+- Races each Horizon call against a **10-second `AbortController` timer**.
+- **Retries up to 3 times** on transient errors (`5xx`, `ECONNRESET`, `ETIMEDOUT`, `AbortError`) using **exponential back-off** (100 ms × 2ⁿ).
+- Does **not** retry `404` responses (account not found is definitive).
+
+Applied to all three Horizon call sites:
+- `server.loadAccount(publicKey)` inside `getAccount`
+- `query.call()` inside `getPayments`
+- `op.transaction()` (memo fetch) inside `getPayments`
+
+---
+
+### `frontend/components/SendPaymentForm.tsx` — closes #238
+
+Updated `SendConfirmationModal` to fully satisfy the acceptance criteria:
+
+- **Destination** now shows both the **shortened form** (`GABCD…WXYZ`) and the **full address** in monospace below it — users can spot accidental paste errors at a glance.
+- Renamed the primary CTA from `Confirm & Send` → **`Confirm & Sign`** to match the acceptance criteria and reflect that Freighter signing occurs on confirmation.
+- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` for accessibility.
+
+---
+
+## Test plan
+
+- [ ] Run `npm run test:e2e` in `frontend/` — `wallet-connect.spec.ts` passes in Chromium.
+- [ ] Run `npm run lint` in `frontend/` — `no-console` warnings appear for any `console.log` calls.
+- [ ] Restart the backend and send a payment with a slow/unreachable Horizon URL — the server returns a timeout error after ~10 s instead of hanging indefinitely.
+- [ ] On the dashboard, fill in a destination and amount, click **Send** — the confirmation modal shows shortened + full address, fee, optional memo, and a **Confirm & Sign** button. Clicking Cancel returns to the form.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
# PR: Multi-issue improvements — E2E tests, ESLint, Horizon reliability, payment confirmation

## Summary

- closes #223 — E2E tests for wallet connect flow (Playwright)
- closes #228 — ESLint `no-console` rule for frontend
- closes #235 — Timeout + retry logic for `stellarService.js` Horizon calls
- closes #238 — Confirmation dialog improvements before sending payment

---

## Changes

### `frontend/e2e/wallet-connect.spec.ts` (new file) — closes #223

Added a dedicated Playwright spec that covers the three acceptance criteria:

1. **No extension** — unauthenticated dashboard shows "Connect your wallet to get started" and the "Connect Freighter Wallet" button; same check on `/transactions`.
2. **After mock connect** — clicking the button with the fixture-injected Freighter stub results in the wallet address label and XLM balance being visible on the dashboard.
3. **Transactions page post-connect** — navigating to `/transactions` after connecting renders the transaction list view (not the wallet-gate screen).

Uses the existing `fixtures.ts` for the authenticated scenarios (mocked Freighter, Horizon, and backend auth endpoints).

---

### `frontend/.eslintrc.json` — closes #228

Added the `no-console` rule at `warn` level, allowing `console.warn` and `console.error` to pass through:

```json
"no-console": ["warn", { "allow": ["warn", "error"] }]
```

This surfaces direct `console.log` calls during `next lint` / CI so developers are reminded to use the project's logging abstraction, without breaking any existing `console.warn` / `console.error` calls.

---

### `backend/src/services/stellarService.js` — closes #235

Introduced a `withTimeoutAndRetry(fn, timeoutMs)` helper that:

- Races each Horizon call against a **10-second `AbortController` timer**.
- **Retries up to 3 times** on transient errors (`5xx`, `ECONNRESET`, `ETIMEDOUT`, `AbortError`) using **exponential back-off** (100 ms × 2ⁿ).
- Does **not** retry `404` responses (account not found is definitive).

Applied to all three Horizon call sites:
- `server.loadAccount(publicKey)` inside `getAccount`
- `query.call()` inside `getPayments`
- `op.transaction()` (memo fetch) inside `getPayments`

---

### `frontend/components/SendPaymentForm.tsx` — closes #238

Updated `SendConfirmationModal` to fully satisfy the acceptance criteria:

- **Destination** now shows both the **shortened form** (`GABCD…WXYZ`) and the **full address** in monospace below it — users can spot accidental paste errors at a glance.
- Renamed the primary CTA from `Confirm & Send` → **`Confirm & Sign`** to match the acceptance criteria and reflect that Freighter signing occurs on confirmation.
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` for accessibility.

---

## Test plan

- [ ] Run `npm run test:e2e` in `frontend/` — `wallet-connect.spec.ts` passes in Chromium.
- [ ] Run `npm run lint` in `frontend/` — `no-console` warnings appear for any `console.log` calls.
- [ ] Restart the backend and send a payment with a slow/unreachable Horizon URL — the server returns a timeout error after ~10 s instead of hanging indefinitely.
- [ ] On the dashboard, fill in a destination and amount, click **Send** — the confirmation modal shows shortened + full address, fee, optional memo, and a **Confirm & Sign** button. Clicking Cancel returns to the form.
