### PR TITLE
#221 [test] Add Rust unit tests for send_tip storage and TipRecord retrieval

### DIFF
--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -354,4 +354,83 @@ mod tests {
         assert_eq!(client.get_tip_total(&recipient), 0);
         assert_eq!(client.get_tip_count(&recipient), 0);
     }
+
+    // ── Helper: deploy a SAC token, mint `amount` to `to`, return token address ──
+    fn create_token(env: &Env, admin: &Address, to: &Address, amount: i128) -> Address {
+        let token_id = env.register_stellar_asset_contract(admin.clone());
+        let sac = token::StellarAssetClient::new(env, &token_id);
+        sac.mint(to, &amount);
+        token_id
+    }
+
+    #[test]
+    fn test_send_tip_stores_record() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 500;
+
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        client.send_tip(&token_id, &from, &to, &amount);
+
+        let record = client.get_tip_record(&to, &0);
+        assert_eq!(record.from, from);
+        assert_eq!(record.to, to);
+        assert_eq!(record.amount, amount);
+        assert_eq!(record.ledger, env.ledger().sequence());
+    }
+
+    #[test]
+    fn test_send_tip_increments_totals() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let first_amount: i128 = 300;
+        let second_amount: i128 = 700;
+
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, first_amount + second_amount);
+        client.send_tip(&token_id, &from, &to, &first_amount);
+        client.send_tip(&token_id, &from, &to, &second_amount);
+
+        assert_eq!(client.get_tip_total(&to), first_amount + second_amount);
+        assert_eq!(client.get_tip_count(&to), 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_send_tip_unauthorized() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 100;
+
+        // Mint tokens to `from` but do NOT call env.mock_all_auths(),
+        // so from.require_auth() inside send_tip will fail.
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        // Clear mocked auths so the send_tip call is not authorized.
+        env.set_auths(&[]);
+
+        client.send_tip(&token_id, &from, &to, &amount);
+    }
 }


### PR DESCRIPTION
## test(smart-contract): Add `send_tip` unit tests
Close  #221

### Summary

Adds three focused unit tests for the `send_tip` function in the Soroban `MicroPayContract`, covering the core storage, accounting, and authorization behaviors. Also introduces a private `create_token` test helper to reduce boilerplate across the new tests.

---

### Changes

**File modified:** `contracts/stellar-micropay-contract/src/lib.rs`

- Added `create_token` helper — registers a Stellar Asset Contract (SAC) via `env.register_stellar_asset_contract`, mints a specified amount to a given address, and returns the token contract address.
- Added `test_send_tip_stores_record` — calls `send_tip` and asserts that `get_tip_record(recipient, 0)` returns a `TipRecord` with the correct `from`, `to`, `amount`, and `ledger` fields.
- Added `test_send_tip_increments_totals` — sends two tips to the same recipient and asserts that `get_tip_total` equals the combined amount and `get_tip_count` equals `2`.
- Added `test_send_tip_unauthorized` — verifies that calling `send_tip` without satisfying `from.require_auth()` causes a panic, by clearing mocked auths with `env.set_auths(&[])` before the call.

---

### Test Design Decisions

- All tests follow the existing project conventions: `Env::default()`, `env.register_contract(None, ...)`, `MicroPayContractClient::new(...)`, and `env.mock_all_auths()`.
- `create_token` is scoped to the test module — no production code was touched.
- The unauthorized test uses `#[should_panic]` without an `expected` string, since the auth failure message is an internal `HostError` whose format is not part of the public contract API.
- `env.mock_all_auths()` is called before `create_token` in all tests that need it, ensuring the SAC `mint` call (which also requires auth) is covered.

---

### Notes

> The test suite currently cannot be executed locally due to a pre-existing incompatibility in the `soroban-sdk 20.x` dependency tree: `soroban-env-common 20.0.0` pins `arbitrary = "=1.3.2"`, while `stellar-xdr 20.0.0`'s generated code uses the `arbitrary 1.4.x` API (`try_size_hint`). This affects **all** existing tests in the project, not just the new ones. Zero errors originate from `lib.rs` itself — confirmed via `cargo check --target wasm32-unknown-unknown`.

---

### Label

`smart-contract` · `test`
