### PR TITLE
[feature] Shareable payment request links (ROADMAP v1.5)

### DIFF
--- a/frontend/__tests__/paymentLinks.test.ts
+++ b/frontend/__tests__/paymentLinks.test.ts
@@ -2,11 +2,13 @@
  * @jest-environment jsdom
  */
 import {
+  buildPaymentLinkUrl,
   canRedeemPaymentLink,
   clearPaymentLinkStore,
   getPaymentLinkRecord,
   listPaymentLinks,
   markPaymentLinkRedeemed,
+  parsePaymentLinkQuery,
   paymentLinkId,
   rememberPaymentLink,
   type PaymentLinkPayload,
@@ -33,10 +35,84 @@ describe("paymentLinkId", () => {
 
   it("normalizes whitespace and missing memo", () => {
     expect(
-      paymentLinkId({ destination: "  GABC  ", amount: " 10 ", memo: undefined })
-    ).toBe(
-      paymentLinkId({ destination: "GABC", amount: "10", memo: "" })
+      paymentLinkId({
+        destination: "  GABC  ",
+        amount: " 10 ",
+        memo: undefined,
+      }),
+    ).toBe(paymentLinkId({ destination: "GABC", amount: "10", memo: "" }));
+  });
+});
+
+describe("shareable payment link urls", () => {
+  it("builds explicit /pay query params", () => {
+    const url = buildPaymentLinkUrl("https://example.com", {
+      ...PAYLOAD,
+      validUntil: 1893456000000,
+    });
+    expect(url).toBe(
+      "https://example.com/pay?to=GABCDEF&amount=10&memo=thanks&expires=1893456000000",
     );
+  });
+
+  it("omits empty optional fields", () => {
+    expect(
+      buildPaymentLinkUrl("https://example.com", {
+        destination: "GABCDEF",
+        amount: "10",
+        memo: "   ",
+      }),
+    ).toBe("https://example.com/pay?to=GABCDEF&amount=10");
+  });
+
+  it("parses query params into payment form prefill payload", () => {
+    expect(
+      parsePaymentLinkQuery({
+        to: "GABCDEF",
+        amount: "10",
+        memo: "coffee",
+        expires: "1893456000000",
+      }),
+    ).toEqual({
+      ok: true,
+      payload: {
+        destination: "GABCDEF",
+        amount: "10",
+        memo: "coffee",
+        validUntil: 1893456000000,
+      },
+    });
+  });
+
+  it("parses unix-second expiry timestamps", () => {
+    expect(
+      parsePaymentLinkQuery({
+        to: "GABCDEF",
+        amount: "10",
+        expires: "1893456000",
+      }),
+    ).toEqual({
+      ok: true,
+      payload: {
+        destination: "GABCDEF",
+        amount: "10",
+        validUntil: 1893456000000,
+      },
+    });
+  });
+
+  it("rejects invalid expiry timestamps", () => {
+    expect(
+      parsePaymentLinkQuery({ to: "GABCDEF", amount: "10", expires: "soon" }),
+    ).toEqual({ ok: false, reason: "invalid-expiry" });
+  });
+
+  it("keeps parsing legacy base64 data links", () => {
+    const data = btoa(JSON.stringify(PAYLOAD));
+    expect(parsePaymentLinkQuery({ data })).toEqual({
+      ok: true,
+      payload: { ...PAYLOAD, validUntil: null },
+    });
   });
 });
 
@@ -46,9 +122,12 @@ describe("payment link store", () => {
   });
 
   it("remembers a freshly generated link as pending", () => {
-    const record = rememberPaymentLink(PAYLOAD, "https://example/pay?data=…");
+    const record = rememberPaymentLink(
+      PAYLOAD,
+      "https://example/pay?to=GABCDEF&amount=10",
+    );
     expect(record.status).toBe("pending");
-    expect(record.url).toContain("data");
+    expect(record.url).toContain("to=GABCDEF");
     expect(getPaymentLinkRecord(PAYLOAD)?.status).toBe("pending");
   });
 
@@ -101,7 +180,7 @@ describe("canRedeemPaymentLink", () => {
 
   it("rejects expired links via the validUntil field", () => {
     expect(
-      canRedeemPaymentLink({ ...PAYLOAD, validUntil: Date.now() - 1 })
+      canRedeemPaymentLink({ ...PAYLOAD, validUntil: Date.now() - 1 }),
     ).toEqual({ ok: false, reason: "expired" });
   });
 

--- a/frontend/components/PaymentLinkGenerator.tsx
+++ b/frontend/components/PaymentLinkGenerator.tsx
@@ -1,14 +1,14 @@
-import React, { useState } from 'react';
-import clsx from 'clsx';
-import { QRCodeSVG } from 'qrcode.react'; // Ensure this is installed
-import { rememberPaymentLink } from '@/lib/paymentLinks';
+import React, { useState } from "react";
+import clsx from "clsx";
+import { QRCodeSVG } from "qrcode.react"; // Ensure this is installed
+import { buildPaymentLinkUrl, rememberPaymentLink } from "@/lib/paymentLinks";
 
 export default function PaymentLinkGenerator() {
-  const [destination, setDestination] = useState('');
-  const [amount, setAmount] = useState('');
-  const [memo, setMemo] = useState('');
-  const [expiry, setExpiry] = useState('never'); // New: Expiry state
-  const [generatedLink, setGeneratedLink] = useState('');
+  const [destination, setDestination] = useState("");
+  const [amount, setAmount] = useState("");
+  const [memo, setMemo] = useState("");
+  const [expiry, setExpiry] = useState("never"); // New: Expiry state
+  const [generatedLink, setGeneratedLink] = useState("");
   const [copied, setCopied] = useState(false);
   const [showQR, setShowQR] = useState(false); // New: QR Toggle
 
@@ -18,8 +18,8 @@ export default function PaymentLinkGenerator() {
     // Calculate expiry timestamp
     let validUntil: number | null = null;
     const now = Date.now();
-    if (expiry === '24h') validUntil = now + 24 * 60 * 60 * 1000;
-    if (expiry === '7d') validUntil = now + 7 * 24 * 60 * 60 * 1000;
+    if (expiry === "24h") validUntil = now + 24 * 60 * 60 * 1000;
+    if (expiry === "7d") validUntil = now + 7 * 24 * 60 * 60 * 1000;
 
     const paymentData = {
       destination: destination.trim(),
@@ -28,8 +28,7 @@ export default function PaymentLinkGenerator() {
       validUntil, // Requirement: Expiry encoding
     };
 
-    const base64Data = btoa(JSON.stringify(paymentData));
-    const url = `${window.location.origin}/pay?data=${base64Data}`;
+    const url = buildPaymentLinkUrl(window.location.origin, paymentData);
     // Track the link locally so the issuer can see pending/redeemed/expired
     // status and the pay page can block reuse after redemption (#157).
     rememberPaymentLink(paymentData, url);
@@ -43,7 +42,7 @@ export default function PaymentLinkGenerator() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error('Failed to copy!', err);
+      console.error("Failed to copy!", err);
     }
   };
 
@@ -51,7 +50,7 @@ export default function PaymentLinkGenerator() {
     <div className="card animate-fade-in border-stellar-400/20">
       <h2 className="font-display text-lg font-semibold text-white mb-6 flex items-center gap-2">
         <LinkIcon className="w-5 h-5 text-stellar-400" />
-        Generate Payment Link
+        Create Payment Link
       </h2>
 
       <div className="space-y-4">
@@ -93,8 +92,8 @@ export default function PaymentLinkGenerator() {
         {/* New: Expiry Dropdown */}
         <div>
           <label className="label">Link Expiry</label>
-          <select 
-            value={expiry} 
+          <select
+            value={expiry}
             onChange={(e) => setExpiry(e.target.value)}
             className="input-field bg-cosmos-950 border-stellar-400/20 text-slate-300"
           >
@@ -109,18 +108,20 @@ export default function PaymentLinkGenerator() {
           disabled={!destination || !amount}
           className="btn-primary w-full py-2.5"
         >
-          Create Link
+          Create payment link
         </button>
 
         {generatedLink && (
           <div className="mt-4 p-4 rounded-xl bg-stellar-400/5 border border-stellar-400/20 animate-slide-up">
             <div className="flex justify-between items-center mb-2">
-              <p className="text-[10px] uppercase tracking-wider text-stellar-400 font-bold">Generated URL</p>
-              <button 
+              <p className="text-[10px] uppercase tracking-wider text-stellar-400 font-bold">
+                Generated URL
+              </p>
+              <button
                 onClick={() => setShowQR(!showQR)}
                 className="text-[10px] text-slate-400 hover:text-white underline"
               >
-                {showQR ? 'Hide QR' : 'Show QR'}
+                {showQR ? "Hide QR" : "Show QR"}
               </button>
             </div>
 
@@ -134,10 +135,12 @@ export default function PaymentLinkGenerator() {
                 onClick={copyToClipboard}
                 className={clsx(
                   "px-3 rounded font-medium text-xs transition-all shrink-0",
-                  copied ? "bg-emerald-500 text-white" : "bg-stellar-400 text-black hover:bg-stellar-300"
+                  copied
+                    ? "bg-emerald-500 text-white"
+                    : "bg-stellar-400 text-black hover:bg-stellar-300",
                 )}
               >
-                {copied ? 'Copied!' : 'Copy'}
+                {copied ? "Copied!" : "Copy"}
               </button>
             </div>
 
@@ -145,7 +148,9 @@ export default function PaymentLinkGenerator() {
             {showQR && (
               <div className="mt-4 flex flex-col items-center bg-white p-3 rounded-lg mx-auto w-fit">
                 <QRCodeSVG value={generatedLink} size={140} />
-                <p className="text-[10px] text-black font-bold mt-2">Scan to Pay</p>
+                <p className="text-[10px] text-black font-bold mt-2">
+                  Scan to Pay
+                </p>
               </div>
             )}
           </div>
@@ -157,8 +162,18 @@ export default function PaymentLinkGenerator() {
 
 function LinkIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+      />
     </svg>
   );
 }

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -61,7 +61,7 @@ interface SendPaymentFormProps {
     destination: string;
     amount: string;
     memo?: string;
-    validUntil?: number;
+    validUntil?: number | null;
     fromHistory?: boolean;
   } | null;
   aiPrefill?: {

--- a/frontend/lib/paymentLinks.ts
+++ b/frontend/lib/paymentLinks.ts
@@ -1,36 +1,150 @@
 /**
  * @file lib/paymentLinks.ts
- * @description Status tracking and one-shot redemption for shareable payment
- * request links (#157).
+ * @description Helpers for shareable payment request links and local status
+ * tracking for generated links.
  *
- * The link payload itself is encoded in the URL (see PaymentLinkGenerator —
- * `?data=<base64>`). This module is the local source of truth for *what state
- * a link is in* — `pending`, `redeemed`, or `expired`. Until we wire backend
- * persistence, it lives in `localStorage` keyed by a deterministic id derived
- * from the payload, so the issuer's "My links" view and the payer's pay page
- * agree on whether a link has been used yet.
+ * Shareable links use explicit query parameters so they can be inspected and
+ * shared easily, for example: `/pay?to=G...&amount=10&memo=coffee`. Optional
+ * expiry is carried as a Unix timestamp in the `expires` parameter. Legacy
+ * base64 `?data=` links are still parsed for backwards compatibility.
  */
 
-const STORAGE_KEY = 'micropay.paymentLinks.v1';
+const STORAGE_KEY = "micropay.paymentLinks.v1";
 
-export type PaymentLinkStatus = 'pending' | 'redeemed' | 'expired';
+export type PaymentLinkStatus = "pending" | "redeemed" | "expired";
 
 export interface PaymentLinkPayload {
-   destination: string;
-   amount: string;
-   memo?: string;
-   /** Unix ms; absent means no expiry. */
-   validUntil?: number | null;
+  destination: string;
+  amount: string;
+  memo?: string;
+  /** Unix ms; absent means no expiry. */
+  validUntil?: number | null;
 }
 
 export interface PaymentLinkRecord {
-   id: string;
-   payload: PaymentLinkPayload;
-   url: string;
-   status: PaymentLinkStatus;
-   createdAt: number;
-   redeemedAt?: number;
-   redeemedTxHash?: string;
+  id: string;
+  payload: PaymentLinkPayload;
+  url: string;
+  status: PaymentLinkStatus;
+  createdAt: number;
+  redeemedAt?: number;
+  redeemedTxHash?: string;
+}
+
+type QueryValue = string | string[] | undefined;
+export type PaymentLinkQuery = Record<string, QueryValue>;
+
+export type ParsedPaymentLinkQuery =
+  | { ok: true; payload: PaymentLinkPayload }
+  | { ok: false; reason: "missing" | "malformed" | "invalid-expiry" };
+
+function getQueryString(value: QueryValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function decodeBase64Json(value: string): unknown {
+  const json =
+    typeof atob === "function"
+      ? atob(value)
+      : Buffer.from(value, "base64").toString("utf8");
+  return JSON.parse(json);
+}
+
+function normalizeExpiry(value: unknown): number | null {
+  if (value == null || value === "") return null;
+
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value.trim())
+        : NaN;
+
+  if (Number.isFinite(numeric)) {
+    // Accept Unix seconds for easier manual link creation, but store ms.
+    return numeric > 0 && numeric < 1_000_000_000_000
+      ? Math.trunc(numeric * 1000)
+      : Math.trunc(numeric);
+  }
+
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return Number.NaN;
+}
+
+function coercePayload(raw: unknown): ParsedPaymentLinkQuery {
+  if (!raw || typeof raw !== "object")
+    return { ok: false, reason: "malformed" };
+  const source = raw as Record<string, unknown>;
+  const destination =
+    typeof source.destination === "string"
+      ? source.destination.trim()
+      : typeof source.to === "string"
+        ? source.to.trim()
+        : "";
+  const amount = source.amount == null ? "" : String(source.amount).trim();
+  const memo = typeof source.memo === "string" ? source.memo.trim() : "";
+  const expiryValue = source.validUntil ?? source.expires ?? source.expiry;
+  const validUntil = normalizeExpiry(expiryValue);
+
+  if (!destination || !amount) return { ok: false, reason: "missing" };
+  if (Number.isNaN(validUntil)) return { ok: false, reason: "invalid-expiry" };
+
+  return {
+    ok: true,
+    payload: {
+      destination,
+      amount,
+      memo: memo || undefined,
+      validUntil,
+    },
+  };
+}
+
+/**
+ * Build the public payment request URL required by roadmap v1.5:
+ * `/pay?to=G...&amount=10&memo=coffee`, with optional `expires=<unix-ms>`.
+ */
+export function buildPaymentLinkUrl(
+  origin: string,
+  payload: PaymentLinkPayload,
+): string {
+  const url = new URL("/pay", origin);
+  url.searchParams.set("to", payload.destination.trim());
+  url.searchParams.set("amount", String(payload.amount).trim());
+  const memo = payload.memo?.trim();
+  if (memo) url.searchParams.set("memo", memo);
+  if (payload.validUntil != null) {
+    url.searchParams.set("expires", String(Math.trunc(payload.validUntil)));
+  }
+  return url.toString();
+}
+
+/** Parse both the new explicit query-param links and legacy `?data=` links. */
+export function parsePaymentLinkQuery(
+  query: PaymentLinkQuery,
+): ParsedPaymentLinkQuery {
+  const encodedData = getQueryString(query.data);
+  if (encodedData) {
+    try {
+      return coercePayload(decodeBase64Json(encodedData));
+    } catch {
+      return { ok: false, reason: "malformed" };
+    }
+  }
+
+  const to = getQueryString(query.to);
+  const amount = getQueryString(query.amount);
+  const memo = getQueryString(query.memo);
+  const expires =
+    getQueryString(query.expires) ??
+    getQueryString(query.expiry) ??
+    getQueryString(query.validUntil);
+
+  return coercePayload({ to, amount, memo, expires });
 }
 
 /**
@@ -39,40 +153,40 @@ export interface PaymentLinkRecord {
  * duplicates in the local store.
  */
 export function paymentLinkId(payload: PaymentLinkPayload): string {
-   const canonical = JSON.stringify({
-      destination: payload.destination.trim(),
-      amount: String(payload.amount).trim(),
-      memo: payload.memo?.trim() || '',
-      validUntil: payload.validUntil ?? null,
-   });
-   // Cheap stable hash — fnv-1a 32-bit. Not crypto, just a deterministic key.
-   let hash = 0x811c9dc5;
-   for (let i = 0; i < canonical.length; i += 1) {
-      hash ^= canonical.charCodeAt(i);
-      hash = Math.imul(hash, 0x01000193) >>> 0;
-   }
-   return `pl_${hash.toString(16).padStart(8, '0')}`;
+  const canonical = JSON.stringify({
+    destination: payload.destination.trim(),
+    amount: String(payload.amount).trim(),
+    memo: payload.memo?.trim() || "",
+    validUntil: payload.validUntil ?? null,
+  });
+  // Cheap stable hash — fnv-1a 32-bit. Not crypto, just a deterministic key.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < canonical.length; i += 1) {
+    hash ^= canonical.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `pl_${hash.toString(16).padStart(8, "0")}`;
 }
 
 function readAll(): Record<string, PaymentLinkRecord> {
-   if (typeof window === 'undefined') return {};
-   try {
-      const raw = window.localStorage.getItem(STORAGE_KEY);
-      if (!raw) return {};
-      const parsed = JSON.parse(raw) as Record<string, PaymentLinkRecord>;
-      return parsed && typeof parsed === 'object' ? parsed : {};
-   } catch {
-      return {};
-   }
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, PaymentLinkRecord>;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
 }
 
 function writeAll(records: Record<string, PaymentLinkRecord>): void {
-   if (typeof window === 'undefined') return;
-   try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
-   } catch {
-      // Quota exceeded or storage disabled — silently drop. UI still works.
-   }
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+  } catch {
+    // Quota exceeded or storage disabled — silently drop. UI still works.
+  }
 }
 
 /**
@@ -80,22 +194,22 @@ function writeAll(records: Record<string, PaymentLinkRecord>): void {
  * was already stored, the existing record is returned untouched.
  */
 export function rememberPaymentLink(
-   payload: PaymentLinkPayload,
-   url: string
+  payload: PaymentLinkPayload,
+  url: string,
 ): PaymentLinkRecord {
-   const id = paymentLinkId(payload);
-   const all = readAll();
-   if (all[id]) return all[id];
-   const record: PaymentLinkRecord = {
-      id,
-      payload,
-      url,
-      status: 'pending',
-      createdAt: Date.now(),
-   };
-   all[id] = record;
-   writeAll(all);
-   return record;
+  const id = paymentLinkId(payload);
+  const all = readAll();
+  if (all[id]) return all[id];
+  const record: PaymentLinkRecord = {
+    id,
+    payload,
+    url,
+    status: "pending",
+    createdAt: Date.now(),
+  };
+  all[id] = record;
+  writeAll(all);
+  return record;
 }
 
 /**
@@ -105,23 +219,23 @@ export function rememberPaymentLink(
  * honour the on-link `validUntil`.
  */
 export function getPaymentLinkRecord(
-   payload: PaymentLinkPayload
+  payload: PaymentLinkPayload,
 ): PaymentLinkRecord | null {
-   const id = paymentLinkId(payload);
-   const all = readAll();
-   const existing = all[id];
-   if (!existing) return null;
+  const id = paymentLinkId(payload);
+  const all = readAll();
+  const existing = all[id];
+  if (!existing) return null;
 
-   if (existing.status === 'pending') {
-      const expired =
-         payload.validUntil != null && Date.now() > payload.validUntil;
-      if (expired) {
-         existing.status = 'expired';
-         all[id] = existing;
-         writeAll(all);
-      }
-   }
-   return existing;
+  if (existing.status === "pending") {
+    const expired =
+      payload.validUntil != null && Date.now() > payload.validUntil;
+    if (expired) {
+      existing.status = "expired";
+      all[id] = existing;
+      writeAll(all);
+    }
+  }
+  return existing;
 }
 
 /**
@@ -130,20 +244,20 @@ export function getPaymentLinkRecord(
  * already redeemed or expired (and therefore cannot be reused).
  */
 export function markPaymentLinkRedeemed(
-   payload: PaymentLinkPayload,
-   txHash: string
+  payload: PaymentLinkPayload,
+  txHash: string,
 ): boolean {
-   const id = paymentLinkId(payload);
-   const all = readAll();
-   const existing = all[id];
-   if (!existing) return false;
-   if (existing.status !== 'pending') return false;
-   existing.status = 'redeemed';
-   existing.redeemedAt = Date.now();
-   existing.redeemedTxHash = txHash;
-   all[id] = existing;
-   writeAll(all);
-   return true;
+  const id = paymentLinkId(payload);
+  const all = readAll();
+  const existing = all[id];
+  if (!existing) return false;
+  if (existing.status !== "pending") return false;
+  existing.status = "redeemed";
+  existing.redeemedAt = Date.now();
+  existing.redeemedTxHash = txHash;
+  all[id] = existing;
+  writeAll(all);
+  return true;
 }
 
 /**
@@ -151,18 +265,18 @@ export function markPaymentLinkRedeemed(
  * stale `pending` records past their expiry surface as `expired` to the UI.
  */
 export function listPaymentLinks(): PaymentLinkRecord[] {
-   const all = readAll();
-   const records = Object.values(all).map(record => {
-      if (
-         record.status === 'pending' &&
-         record.payload.validUntil != null &&
-         Date.now() > record.payload.validUntil
-      ) {
-         return { ...record, status: 'expired' as const };
-      }
-      return record;
-   });
-   return records.sort((a, b) => b.createdAt - a.createdAt);
+  const all = readAll();
+  const records = Object.values(all).map((record) => {
+    if (
+      record.status === "pending" &&
+      record.payload.validUntil != null &&
+      Date.now() > record.payload.validUntil
+    ) {
+      return { ...record, status: "expired" as const };
+    }
+    return record;
+  });
+  return records.sort((a, b) => b.createdAt - a.createdAt);
 }
 
 /**
@@ -170,27 +284,27 @@ export function listPaymentLinks(): PaymentLinkRecord[] {
  * paid. Used by pay.tsx to block reuse after redemption.
  */
 export function canRedeemPaymentLink(
-   payload: PaymentLinkPayload
-): { ok: true } | { ok: false; reason: 'expired' | 'redeemed' } {
-   if (payload.validUntil != null && Date.now() > payload.validUntil) {
-      return { ok: false, reason: 'expired' };
-   }
-   const record = getPaymentLinkRecord(payload);
-   if (record?.status === 'redeemed') {
-      return { ok: false, reason: 'redeemed' };
-   }
-   if (record?.status === 'expired') {
-      return { ok: false, reason: 'expired' };
-   }
-   return { ok: true };
+  payload: PaymentLinkPayload,
+): { ok: true } | { ok: false; reason: "expired" | "redeemed" } {
+  if (payload.validUntil != null && Date.now() > payload.validUntil) {
+    return { ok: false, reason: "expired" };
+  }
+  const record = getPaymentLinkRecord(payload);
+  if (record?.status === "redeemed") {
+    return { ok: false, reason: "redeemed" };
+  }
+  if (record?.status === "expired") {
+    return { ok: false, reason: "expired" };
+  }
+  return { ok: true };
 }
 
 /** Test/dev helper — wipes the local store. */
 export function clearPaymentLinkStore(): void {
-   if (typeof window === 'undefined') return;
-   try {
-      window.localStorage.removeItem(STORAGE_KEY);
-   } catch {
-      // ignore
-   }
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
 }

--- a/frontend/pages/PaymentRequestGenerator.tsx
+++ b/frontend/pages/PaymentRequestGenerator.tsx
@@ -1,13 +1,14 @@
-import React, { useState, useRef } from 'react';
-import clsx from 'clsx';
-import { QRCodeCanvas } from 'qrcode.react';
+import React, { useState, useRef } from "react";
+import clsx from "clsx";
+import { QRCodeCanvas } from "qrcode.react";
+import { buildPaymentLinkUrl, rememberPaymentLink } from "@/lib/paymentLinks";
 
 export default function PaymentRequestGenerator() {
-  const [destination, setDestination] = useState('');
-  const [amount, setAmount] = useState('');
-  const [memo, setMemo] = useState('');
-  const [expiry, setExpiry] = useState('never');
-  const [generatedLink, setGeneratedLink] = useState('');
+  const [destination, setDestination] = useState("");
+  const [amount, setAmount] = useState("");
+  const [memo, setMemo] = useState("");
+  const [expiry, setExpiry] = useState("never");
+  const [generatedLink, setGeneratedLink] = useState("");
   const [copied, setCopied] = useState(false);
   const [showQR, setShowQR] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -17,8 +18,8 @@ export default function PaymentRequestGenerator() {
 
     let validUntil: number | null = null;
     const now = Date.now();
-    if (expiry === '24h') validUntil = now + 24 * 60 * 60 * 1000;
-    if (expiry === '7d') validUntil = now + 7 * 24 * 60 * 60 * 1000;
+    if (expiry === "24h") validUntil = now + 24 * 60 * 60 * 1000;
+    if (expiry === "7d") validUntil = now + 7 * 24 * 60 * 60 * 1000;
 
     const paymentData = {
       destination: destination.trim(),
@@ -27,8 +28,8 @@ export default function PaymentRequestGenerator() {
       validUntil,
     };
 
-    const base64Data = btoa(JSON.stringify(paymentData));
-    const url = `${window.location.origin}/request?r=${base64Data}`;
+    const url = buildPaymentLinkUrl(window.location.origin, paymentData);
+    rememberPaymentLink(paymentData, url);
     setGeneratedLink(url);
     setCopied(false);
     setShowQR(false);
@@ -40,7 +41,7 @@ export default function PaymentRequestGenerator() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error('Failed to copy!', err);
+      console.error("Failed to copy!", err);
     }
   };
 
@@ -58,7 +59,7 @@ export default function PaymentRequestGenerator() {
     <div className="card animate-fade-in border-stellar-400/20">
       <h2 className="font-display text-lg font-semibold text-white mb-6 flex items-center gap-2">
         <LinkIcon className="w-5 h-5 text-stellar-400" />
-        Request Payment
+        Create Payment Link
       </h2>
 
       <div className="space-y-4">
@@ -99,8 +100,8 @@ export default function PaymentRequestGenerator() {
 
         <div>
           <label className="label">Link Expiry</label>
-          <select 
-            value={expiry} 
+          <select
+            value={expiry}
             onChange={(e) => setExpiry(e.target.value)}
             className="input-field bg-cosmos-950 border-stellar-400/20 text-slate-300"
           >
@@ -115,18 +116,20 @@ export default function PaymentRequestGenerator() {
           disabled={!destination || !amount}
           className="btn-primary w-full py-2.5"
         >
-          Create Request Link
+          Create payment link
         </button>
 
         {generatedLink && (
           <div className="mt-4 p-4 rounded-xl bg-stellar-400/5 border border-stellar-400/20 animate-slide-up">
             <div className="flex justify-between items-center mb-2">
-              <p className="text-[10px] uppercase tracking-wider text-stellar-400 font-bold">Generated URL</p>
-              <button 
+              <p className="text-[10px] uppercase tracking-wider text-stellar-400 font-bold">
+                Generated URL
+              </p>
+              <button
                 onClick={() => setShowQR(!showQR)}
                 className="text-[10px] text-slate-400 hover:text-white underline"
               >
-                {showQR ? 'Hide QR' : 'Show QR'}
+                {showQR ? "Hide QR" : "Show QR"}
               </button>
             </div>
 
@@ -140,18 +143,25 @@ export default function PaymentRequestGenerator() {
                 onClick={copyToClipboard}
                 className={clsx(
                   "px-3 rounded font-medium text-xs transition-all shrink-0",
-                  copied ? "bg-emerald-500 text-white" : "bg-stellar-400 text-black hover:bg-stellar-300"
+                  copied
+                    ? "bg-emerald-500 text-white"
+                    : "bg-stellar-400 text-black hover:bg-stellar-300",
                 )}
               >
-                {copied ? 'Copied!' : 'Copy'}
+                {copied ? "Copied!" : "Copy"}
               </button>
             </div>
 
             {showQR && (
               <div className="mt-4 flex flex-col items-center bg-white p-3 rounded-lg mx-auto w-fit">
-                <QRCodeCanvas value={generatedLink} size={140} ref={canvasRef} includeMargin />
-                <button 
-                  onClick={downloadQR} 
+                <QRCodeCanvas
+                  value={generatedLink}
+                  size={140}
+                  ref={canvasRef}
+                  includeMargin
+                />
+                <button
+                  onClick={downloadQR}
                   className="mt-3 text-[10px] bg-slate-100 hover:bg-slate-200 text-black px-3 py-1 rounded font-bold uppercase transition-colors"
                 >
                   Download QR
@@ -167,8 +177,18 @@ export default function PaymentRequestGenerator() {
 
 function LinkIcon({ className }: { className?: string }) {
   return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"
+      />
     </svg>
   );
 }

--- a/frontend/pages/pay.tsx
+++ b/frontend/pages/pay.tsx
@@ -12,6 +12,7 @@ import { formatStroopsToXLM } from "@/utils/format";
 import {
   canRedeemPaymentLink,
   markPaymentLinkRedeemed,
+  parsePaymentLinkQuery,
 } from "@/lib/paymentLinks";
 import { useWallet } from "@/lib/useWallet";
 
@@ -19,58 +20,87 @@ interface PrefillData {
   destination: string;
   amount: string;
   memo?: string;
-  validUntil?: number;
+  validUntil?: number | null;
 }
 
 export default function PayPage() {
   const { publicKey } = useWallet();
   const router = useRouter();
-  const { data } = router.query;
-  
+
   const [prefill, setPrefill] = useState<PrefillData | null>(null);
   const [xlmBalance, setXlmBalance] = useState<string>("0");
   const [tipTotal, setTipTotal] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null); // New: Error state
 
-  // Step 1: Decode and Validate URL data
+  // Step 1: Parse and validate URL payment details.
   useEffect(() => {
-    if (data && typeof data === "string") {
-      try {
-        const decodedString = atob(data); 
-        const parsedData = JSON.parse(decodedString);
+    if (!router.isReady) return;
 
-        // Validation: Check for Expiration
-        if (parsedData.validUntil && Date.now() > parsedData.validUntil) {
-          setError("This payment link has expired.");
-          return;
-        }
+    const hasPaymentQuery = [
+      "data",
+      "to",
+      "amount",
+      "memo",
+      "expires",
+      "expiry",
+      "validUntil",
+    ].some((key) => router.query[key] != null);
 
-        // Validation: Check for Required Fields
-        if (!parsedData.destination || !parsedData.amount) {
-          setError("The payment link data is incomplete or malformed.");
-          return;
-        }
-
-        // Reuse guard (#157): block links that have already been redeemed
-        // on this device. Expiry is also re-checked centrally here.
-        const redeemable = canRedeemPaymentLink(parsedData);
-        if (!redeemable.ok) {
-          setError(
-            redeemable.reason === "redeemed"
-              ? "This payment link has already been redeemed."
-              : "This payment link has expired."
-          );
-          return;
-        }
-
-        setPrefill(parsedData);
-        setError(null); // Clear errors if valid
-      } catch (err) {
-        console.error("Invalid payment link data", err);
-        setError("Invalid payment link. Please check the URL.");
-      }
+    if (!hasPaymentQuery) {
+      setPrefill(null);
+      setError(null);
+      return;
     }
-  }, [data]);
+
+    const parsed = parsePaymentLinkQuery(router.query);
+    if (!parsed.ok) {
+      setPrefill(null);
+      setError(
+        parsed.reason === "invalid-expiry"
+          ? "The payment link expiry timestamp is invalid."
+          : parsed.reason === "missing"
+            ? "The payment link data is incomplete or malformed."
+            : "Invalid payment link. Please check the URL.",
+      );
+      return;
+    }
+
+    // Reuse guard (#157): block links that have already been redeemed
+    // on this device. Expiry is also checked centrally immediately before
+    // the request can be paid.
+    const redeemable = canRedeemPaymentLink(parsed.payload);
+    if (!redeemable.ok) {
+      setPrefill(null);
+      setError(
+        redeemable.reason === "redeemed"
+          ? "This payment link has already been redeemed."
+          : "This payment link has expired.",
+      );
+      return;
+    }
+
+    setPrefill(parsed.payload);
+    setError(null);
+  }, [router.isReady, router.query]);
+
+  // Keep long-open payment request pages from being submitted after expiry.
+  useEffect(() => {
+    if (!prefill?.validUntil) return;
+
+    const msUntilExpiry = prefill.validUntil - Date.now();
+    if (msUntilExpiry <= 0) {
+      setPrefill(null);
+      setError("This payment link has expired.");
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPrefill(null);
+      setError("This payment link has expired.");
+    }, msUntilExpiry);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [prefill?.validUntil]);
 
   // Step 2: Fetch balance if wallet is connected
   useEffect(() => {
@@ -97,10 +127,12 @@ export default function PayPage() {
         <div className="bg-red-500/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
           <span className="text-2xl text-red-500">⚠️</span>
         </div>
-        <h2 className="text-xl font-bold text-white mb-2">Payment Unavailable</h2>
+        <h2 className="text-xl font-bold text-white mb-2">
+          Payment Unavailable
+        </h2>
         <p className="text-slate-400 mb-6">{error}</p>
-        <button 
-          onClick={() => router.push('/dashboard')} 
+        <button
+          onClick={() => router.push("/dashboard")}
           className="btn-secondary w-full py-2"
         >
           Return to Dashboard
@@ -116,11 +148,11 @@ export default function PayPage() {
           Complete Payment
         </h1>
         <p className="text-slate-400">
-          {publicKey 
-            ? "Review the details below to authorize the transaction." 
+          {publicKey
+            ? "Review the details below to authorize the transaction."
             : "You’ve received a payment request. Connect your wallet to proceed."}
         </p>
-        
+
         {tipTotal !== null && CONTRACT_ID && (
           <div className="mt-4 inline-flex items-center gap-2 px-3 py-1 rounded-full bg-stellar-500/10 border border-stellar-500/20">
             <span className="text-xs font-medium text-stellar-400">
@@ -150,7 +182,7 @@ export default function PayPage() {
                 markPaymentLinkRedeemed(prefill, txHash);
               }
               // Redirect to transactions after success
-              setTimeout(() => router.push('/transactions'), 3000);
+              setTimeout(() => router.push("/transactions"), 3000);
             }}
           />
         </div>


### PR DESCRIPTION
## Summary
Description
Add frontend/lib/paymentLinks.ts with buildPaymentLinkUrl, parsePaymentLinkQuery, expiry normalization, and local-store helpers (rememberPaymentLink, getPaymentLinkRecord, markPaymentLinkRedeemed, listPaymentLinks, clearPaymentLinkStore) that track link status in localStorage and handle legacy ?data= base64 links.
Update the generator UIs to create explicit /pay links and persist them: frontend/components/PaymentLinkGenerator.tsx and frontend/pages/PaymentRequestGenerator.tsx now use buildPaymentLinkUrl and call rememberPaymentLink, expose expiry options, and show QR/copy UX.
Update the payer flow in frontend/pages/pay.tsx to use parsePaymentLinkQuery(router.query), validate required fields and expiry, block reused/expired links via canRedeemPaymentLink, and install a timeout that invalidates prefilled pages if the link expires while the page is open.
Make the prefill type nullable for validUntil in frontend/components/SendPaymentForm.tsx so parsed links with/without expiry are supported, and extend frontend/__tests__/paymentLinks.test.ts with unit cases for URL building, parsing (including unix-second expiry), legacy data parsing, and store behaviour.

<!-- What does this PR do? 1-2 sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #211 <!-- issue number -->

## Changes

<!-- List the key changes made -->
- 
- 

## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`
