### PR TITLE
fix: Result from initialize, clone from in tip event, SSR guards for Freighter

### DIFF
--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -1,9 +1,14 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype,
-    token, Address, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol,
 };
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ContractError {
+    AlreadyInitialized = 1,
+}
 
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
 const PERSISTENT_BUMP_AMOUNT: u32 = 500_000;
@@ -43,36 +48,42 @@ pub struct MicroPayContract;
 
 #[contractimpl]
 impl MicroPayContract {
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().persistent().has(&DataKey::Admin) {
-            panic!("Contract already initialized");
+            return Err(ContractError::AlreadyInitialized);
         }
         env.storage().persistent().set(&DataKey::Admin, &admin);
-        env.storage().persistent().extend_ttl(&DataKey::Admin, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Admin,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
         // Emit an init event so off-chain indexers can detect an initialised
         // contract without polling get_admin() (#258).
-        env.events()
-            .publish((Symbol::new(&env, "init"),), admin);
+        env.events().publish((Symbol::new(&env, "init"),), admin);
+        Ok(())
     }
 
     pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
         current_admin.require_auth();
-        let stored_admin: Address = env.storage().persistent().get(&DataKey::Admin).expect("Contract not initialized");
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
         if current_admin != stored_admin {
             panic!("Unauthorized");
         }
         env.storage().persistent().set(&DataKey::Admin, &new_admin);
-        env.storage().persistent().extend_ttl(&DataKey::Admin, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Admin,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
-    pub fn send_tip(
-        env: Env,
-        token_address: Address,
-        from: Address,
-        to: Address,
-        amount: i128,
-    ) {
+    pub fn send_tip(env: Env, token_address: Address, from: Address, to: Address, amount: i128) {
         from.require_auth();
         if amount <= 0 {
             panic!("Tip amount must be positive");
@@ -80,14 +91,34 @@ impl MicroPayContract {
         let token = token::Client::new(&env, &token_address);
         token.transfer(&from, &to, &amount);
 
-        let current_total: i128 = env.storage().persistent().get(&DataKey::TipTotal(to.clone())).unwrap_or(0);
-        let current_count: u32 = env.storage().persistent().get(&DataKey::TipCount(to.clone())).unwrap_or(0);
+        let current_total: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TipTotal(to.clone()))
+            .unwrap_or(0);
+        let current_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TipCount(to.clone()))
+            .unwrap_or(0);
 
-        env.storage().persistent().set(&DataKey::TipTotal(to.clone()), &(current_total + amount));
-        env.storage().persistent().extend_ttl(&DataKey::TipTotal(to.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipTotal(to.clone()), &(current_total + amount));
+        env.storage().persistent().extend_ttl(
+            &DataKey::TipTotal(to.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
-        env.storage().persistent().set(&DataKey::TipCount(to.clone()), &(current_count + 1));
-        env.storage().persistent().extend_ttl(&DataKey::TipCount(to.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipCount(to.clone()), &(current_count + 1));
+        env.storage().persistent().extend_ttl(
+            &DataKey::TipCount(to.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
         let record = TipRecord {
             from: from.clone(),
@@ -95,17 +126,30 @@ impl MicroPayContract {
             amount,
             ledger: env.ledger().sequence(),
         };
-        env.storage().persistent().set(&DataKey::TipRecord(to.clone(), current_count), &record);
-        env.storage().persistent().extend_ttl(&DataKey::TipRecord(to.clone(), current_count), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipRecord(to.clone(), current_count), &record);
+        env.storage().persistent().extend_ttl(
+            &DataKey::TipRecord(to.clone(), current_count),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
-        env.events().publish((Symbol::new(&env, "tip"), from, to.clone()), amount);
+        // Clone `from` into the event tuple so the owned binding is not moved
+        // out before the borrow checker is done with it (#202).
+        env.events()
+            .publish((Symbol::new(&env, "tip"), from.clone(), to.clone()), amount);
     }
 
     pub fn get_tip_total(env: Env, recipient: Address) -> i128 {
         let key = DataKey::TipTotal(recipient);
         let val = env.storage().persistent().get(&key).unwrap_or(0);
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
         }
         val
     }
@@ -114,37 +158,55 @@ impl MicroPayContract {
         let key = DataKey::TipCount(recipient);
         let val = env.storage().persistent().get(&key).unwrap_or(0);
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
         }
         val
     }
 
     pub fn get_admin(env: Env) -> Address {
         let key = DataKey::Admin;
-        let val: Address = env.storage().persistent().get(&key).expect("Contract not initialized");
-        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        let val: Address = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Contract not initialized");
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
         val
     }
 
     pub fn get_tip_record(env: Env, recipient: Address, index: u32) -> TipRecord {
         let key = DataKey::TipRecord(recipient, index);
-        let val: TipRecord = env.storage().persistent().get(&key).expect("Tip record not found");
-        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        let val: TipRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Tip record not found");
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
         val
     }
 
-    pub fn mint_receipt(
-        env: Env,
-        from: Address,
-        to: Address,
-        amount: i128,
-        memo: Symbol,
-    ) -> u32 {
+    pub fn mint_receipt(env: Env, from: Address, to: Address, amount: i128, memo: Symbol) -> u32 {
         from.require_auth();
         if amount <= 0 {
             panic!("Receipt amount must be positive");
         }
-        let count: u32 = env.storage().persistent().get(&DataKey::ReceiptCount(from.clone())).unwrap_or(0);
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReceiptCount(from.clone()))
+            .unwrap_or(0);
 
         let receipt = ReceiptMetadata {
             from: from.clone(),
@@ -155,13 +217,26 @@ impl MicroPayContract {
             ledger: env.ledger().sequence(),
         };
 
-        env.storage().persistent().set(&DataKey::ReceiptRecord(from.clone(), count), &receipt);
-        env.storage().persistent().extend_ttl(&DataKey::ReceiptRecord(from.clone(), count), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReceiptRecord(from.clone(), count), &receipt);
+        env.storage().persistent().extend_ttl(
+            &DataKey::ReceiptRecord(from.clone(), count),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
-        env.storage().persistent().set(&DataKey::ReceiptCount(from.clone()), &(count + 1));
-        env.storage().persistent().extend_ttl(&DataKey::ReceiptCount(from.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReceiptCount(from.clone()), &(count + 1));
+        env.storage().persistent().extend_ttl(
+            &DataKey::ReceiptCount(from.clone()),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
-        env.events().publish((Symbol::new(&env, "receipt"), from), count);
+        env.events()
+            .publish((Symbol::new(&env, "receipt"), from), count);
         count
     }
 
@@ -169,15 +244,27 @@ impl MicroPayContract {
         let key = DataKey::ReceiptCount(payer);
         let val = env.storage().persistent().get(&key).unwrap_or(0);
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
         }
         val
     }
 
     pub fn get_receipt(env: Env, payer: Address, index: u32) -> ReceiptMetadata {
         let key = DataKey::ReceiptRecord(payer, index);
-        let val: ReceiptMetadata = env.storage().persistent().get(&key).expect("Receipt not found");
-        env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        let val: ReceiptMetadata = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Receipt not found");
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
         val
     }
 
@@ -211,14 +298,34 @@ impl MicroPayContract {
             }
             token.transfer(&from, &to, &amount);
 
-            let current_total: i128 = env.storage().persistent().get(&DataKey::TipTotal(to.clone())).unwrap_or(0);
-            let current_count: u32 = env.storage().persistent().get(&DataKey::TipCount(to.clone())).unwrap_or(0);
+            let current_total: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::TipTotal(to.clone()))
+                .unwrap_or(0);
+            let current_count: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::TipCount(to.clone()))
+                .unwrap_or(0);
 
-            env.storage().persistent().set(&DataKey::TipTotal(to.clone()), &(current_total + amount));
-            env.storage().persistent().extend_ttl(&DataKey::TipTotal(to.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage()
+                .persistent()
+                .set(&DataKey::TipTotal(to.clone()), &(current_total + amount));
+            env.storage().persistent().extend_ttl(
+                &DataKey::TipTotal(to.clone()),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
 
-            env.storage().persistent().set(&DataKey::TipCount(to.clone()), &(current_count + 1));
-            env.storage().persistent().extend_ttl(&DataKey::TipCount(to.clone()), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage()
+                .persistent()
+                .set(&DataKey::TipCount(to.clone()), &(current_count + 1));
+            env.storage().persistent().extend_ttl(
+                &DataKey::TipCount(to.clone()),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
 
             let record = TipRecord {
                 from: from.clone(),
@@ -226,8 +333,14 @@ impl MicroPayContract {
                 amount,
                 ledger: env.ledger().sequence(),
             };
-            env.storage().persistent().set(&DataKey::TipRecord(to.clone(), current_count), &record);
-            env.storage().persistent().extend_ttl(&DataKey::TipRecord(to.clone(), current_count), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage()
+                .persistent()
+                .set(&DataKey::TipRecord(to.clone(), current_count), &record);
+            env.storage().persistent().extend_ttl(
+                &DataKey::TipRecord(to.clone(), current_count),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
         }
     }
 }
@@ -237,10 +350,7 @@ impl MicroPayContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{
-        testutils::{Address as _},
-        Address, Env,
-    };
+    use soroban_sdk::{testutils::Address as _, Address, Env};
 
     #[test]
     fn test_initialize() {
@@ -279,9 +389,10 @@ mod tests {
         );
     }
 
+    /// Issue #200 — initialize() must return Err(AlreadyInitialized) on re-init,
+    /// not panic. try_initialize is testable without aborting the harness.
     #[test]
-    #[ignore = "Soroban host panics abort under the current native test harness"]
-    fn test_double_initialize_fails() {
+    fn test_double_initialize_returns_error() {
         let env = Env::default();
         let contract_id = env.register_contract(None, MicroPayContract);
         let client = MicroPayContractClient::new(&env, &contract_id);
@@ -289,7 +400,12 @@ mod tests {
         let admin = Address::generate(&env);
         client.initialize(&admin);
 
-        assert!(client.try_initialize(&admin).is_err());
+        let result = client.try_initialize(&admin);
+        assert!(result.is_err(), "second initialize() must return an error");
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::AlreadyInitialized,
+        );
     }
 
     #[test]
@@ -433,5 +549,68 @@ mod tests {
         env.set_auths(&[]);
 
         client.send_tip(&token_id, &from, &to, &amount);
+    }
+
+    /// Issue #202 — send_tip must emit a tip event containing both sender and
+    /// recipient without a borrow/move conflict on `from`.
+    #[test]
+    fn test_send_tip_emits_event_with_from_and_to() {
+        use soroban_sdk::{testutils::Events, vec, IntoVal};
+
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 250;
+
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        client.send_tip(&token_id, &from, &to, &amount);
+
+        let events = env.events().all();
+        // Two events: init (from initialize) + tip.
+        assert_eq!(events.len(), 2);
+        let tip_event = events.get(1).unwrap();
+        // Topic must be (Symbol("tip"), from, to).
+        let expected_topics = (Symbol::new(&env, "tip"), from.clone(), to.clone()).into_val(&env);
+        assert_eq!(tip_event.1, expected_topics);
+        // Data must be the amount.
+        let expected_data = amount.into_val(&env);
+        assert_eq!(tip_event.2, expected_data);
+    }
+
+    /// Issue #201 — TipTotal and TipCount must survive across separate env
+    /// storage reads (persistent, not instance). Verifies the keys don't
+    /// collide or disappear between calls.
+    #[test]
+    fn test_tip_totals_are_per_recipient_persistent() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 1000);
+
+        client.send_tip(&token_id, &from, &alice, &300);
+        client.send_tip(&token_id, &from, &alice, &200);
+        client.send_tip(&token_id, &from, &bob, &400);
+
+        // Alice and Bob totals must be independent (persistent per-address keys).
+        assert_eq!(client.get_tip_total(&alice), 500);
+        assert_eq!(client.get_tip_count(&alice), 2);
+        assert_eq!(client.get_tip_total(&bob), 400);
+        assert_eq!(client.get_tip_count(&bob), 1);
     }
 }

--- a/frontend/__tests__/wallet-ssr.test.ts
+++ b/frontend/__tests__/wallet-ssr.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Issue #198 — SSR guard tests for lib/wallet.ts.
+ *
+ * Freighter calls access `window.freighter`; during Next.js SSR `window` is
+ * undefined and any unguarded call throws a ReferenceError. These tests verify
+ * that isFreighterInstalled, hasSiteAccess, and signTransactionWithWallet
+ * return safe defaults instead of throwing when `window` is undefined.
+ *
+ * @jest-environment node
+ */
+
+import { jest, describe, test, expect } from "@jest/globals";
+
+// Mock @stellar/freighter-api so no real browser extension is needed.
+jest.mock("@stellar/freighter-api", () => ({
+  isConnected: jest.fn(),
+  isAllowed: jest.fn(),
+  getAddress: jest.fn(),
+  signTransaction: jest.fn(),
+  requestAccess: jest.fn(),
+}));
+
+// Mock lib/stellar to avoid network calls.
+jest.mock("@/lib/stellar", () => ({
+  getNetworkPassphrase: jest.fn(() => "Test SDF Network ; September 2015"),
+  TransactionCategory: {},
+}));
+
+// In the `node` jest environment `window` is already undefined — these tests
+// directly exercise the SSR branches of each guarded function.
+
+describe("wallet.ts — SSR guards (issue #198)", () => {
+  test("isFreighterInstalled returns false when window is undefined", async () => {
+    const { isFreighterInstalled } = await import("@/lib/wallet");
+    expect(typeof window).toBe("undefined");
+    const result = await isFreighterInstalled();
+    expect(result).toBe(false);
+  });
+
+  test("hasSiteAccess returns false when window is undefined", async () => {
+    const { hasSiteAccess } = await import("@/lib/wallet");
+    const result = await hasSiteAccess();
+    expect(result).toBe(false);
+  });
+
+  test("signTransactionWithWallet returns error when window is undefined", async () => {
+    const { signTransactionWithWallet } = await import("@/lib/wallet");
+    const result = await signTransactionWithWallet("fake-xdr");
+    expect(result.signedXDR).toBeNull();
+    expect(result.error).toMatch(/server-side rendering/i);
+  });
+});

--- a/frontend/lib/wallet.ts
+++ b/frontend/lib/wallet.ts
@@ -87,8 +87,10 @@ export const EXTENSION_URLS: Record<SupportedBrowser, string> = {
 
 /**
  * Check whether the Freighter extension is installed in the browser.
+ * Returns false during SSR where `window` is undefined (#198).
  */
 export async function isFreighterInstalled(): Promise<boolean> {
+  if (typeof window === "undefined") return false;
   try {
     const result = await isConnected();
     return Boolean(result.isConnected);
@@ -99,8 +101,10 @@ export async function isFreighterInstalled(): Promise<boolean> {
 
 /**
  * Check if this site has already been granted access by the user.
+ * Returns false during SSR where `window` is undefined (#198).
  */
 export async function hasSiteAccess(): Promise<boolean> {
+  if (typeof window === "undefined") return false;
   try {
     const result = await isAllowed();
     return Boolean(result.isAllowed);
@@ -206,6 +210,9 @@ export async function performSEP0010Auth(
 export async function signTransactionWithWallet(
   transactionXDR: string
 ): Promise<{ signedXDR: string | null; error: string | null }> {
+  if (typeof window === "undefined") {
+    return { signedXDR: null, error: "Wallet signing is not available during server-side rendering." };
+  }
   try {
     const signed = await signTransaction(transactionXDR, {
       networkPassphrase: getNetworkPassphrase(),


### PR DESCRIPTION
## Summary

- **#200** — `initialize()` now returns `Result<(), ContractError>` and returns `Err(ContractError::AlreadyInitialized)` on re-init instead of calling `panic!`. Defines `ContractError` enum with `#[contracterror]`. Adds `test_double_initialize_returns_error` using `try_initialize`.

- **#202** — `send_tip` event tuple now explicitly clones `from` before passing it into the `(tip, from, to)` topic, eliminating the borrow/move conflict. Adds `test_send_tip_emits_event_with_from_and_to` verifying the topic contains both sender and recipient addresses.

- **#201** — All `TipTotal`, `TipCount`, and `TipRecord` entries were already using `env.storage().persistent()`. Adds `test_tip_totals_are_per_recipient_persistent` confirming per-recipient key isolation across two separate recipients.

- **#198** — `isFreighterInstalled`, `hasSiteAccess`, and `signTransactionWithWallet` in `frontend/lib/wallet.ts` now return safe defaults (`false` / `{ signedXDR: null, error: "…" }`) when `typeof window === "undefined"`, preventing the `ReferenceError` during Next.js SSR. Adds `frontend/__tests__/wallet-ssr.test.ts` (3 tests, `@jest-environment node`) verifying the SSR branches.

## Tests

- Contract: `test_double_initialize_returns_error`, `test_send_tip_emits_event_with_from_and_to`, `test_tip_totals_are_per_recipient_persistent` (all new)
- Frontend: `wallet-ssr.test.ts` — 3 passing tests in node environment; full suite 75/75 passing

closes #198
closes #200
closes #201
closes #202