### PR TITLE
feat: soroban escrow + batch payments + QR deep-link + dev healthchecks

### DIFF
--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -36,6 +36,28 @@ pub enum DataKey {
     TipRecord(Address, u32),
     ReceiptCount(Address),
     ReceiptRecord(Address, u32),
+    EscrowCount,
+    Escrow(u32),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EscrowStatus {
+    Pending,
+    Released,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Escrow {
+    pub id: u32,
+    pub from: Address,
+    pub to: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub release_ledger: u32,
+    pub status: EscrowStatus,
 }
 
 #[contract]
@@ -182,13 +204,97 @@ impl MicroPayContract {
     }
 
     pub fn create_escrow(
-        _env: Env,
-        _from: Address,
-        _to: Address,
-        _amount: i128,
-        _release_ledger: u32,
-    ) {
-        panic!("Escrow payments coming in v2.1 — see ROADMAP.md");
+        env: Env,
+        token_address: Address,
+        from: Address,
+        to: Address,
+        amount: i128,
+        release_ledger: u32,
+    ) -> u32 {
+        from.require_auth();
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        if release_ledger <= env.ledger().sequence() {
+            panic!("release_ledger must be in the future");
+        }
+
+        // Lock funds: transfer from creator into the contract itself.
+        let token = token::Client::new(&env, &token_address);
+        token.transfer(&from, &env.current_contract_address(), &amount);
+
+        let next_id: u32 = env.storage().persistent().get(&DataKey::EscrowCount).unwrap_or(0);
+        let escrow = Escrow {
+            id: next_id,
+            from: from.clone(),
+            to: to.clone(),
+            token: token_address,
+            amount,
+            release_ledger,
+            status: EscrowStatus::Pending,
+        };
+        env.storage().persistent().set(&DataKey::Escrow(next_id), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::Escrow(next_id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().set(&DataKey::EscrowCount, &(next_id + 1));
+        env.storage().persistent().extend_ttl(&DataKey::EscrowCount, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        env.events()
+            .publish((Symbol::new(&env, "escrow_create"), next_id), (from, to, amount, release_ledger));
+        next_id
+    }
+
+    pub fn claim_escrow(env: Env, id: u32) {
+        let mut escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(id)).expect("escrow not found");
+        if escrow.status != EscrowStatus::Pending {
+            panic!("escrow is not pending");
+        }
+        if env.ledger().sequence() < escrow.release_ledger {
+            panic!("release_ledger not reached");
+        }
+        // Only the recipient can claim.
+        escrow.to.require_auth();
+
+        let token = token::Client::new(&env, &escrow.token);
+        token.transfer(&env.current_contract_address(), &escrow.to, &escrow.amount);
+
+        escrow.status = EscrowStatus::Released;
+        env.storage().persistent().set(&DataKey::Escrow(id), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::Escrow(id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        env.events()
+            .publish((Symbol::new(&env, "escrow_claim"), id), (escrow.to, escrow.amount));
+    }
+
+    pub fn cancel_escrow(env: Env, id: u32) {
+        let mut escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(id)).expect("escrow not found");
+        if escrow.status != EscrowStatus::Pending {
+            panic!("escrow is not pending");
+        }
+        if env.ledger().sequence() >= escrow.release_ledger {
+            panic!("release_ledger already reached — cancellation is no longer allowed");
+        }
+        // Only the creator can cancel.
+        escrow.from.require_auth();
+
+        let token = token::Client::new(&env, &escrow.token);
+        token.transfer(&env.current_contract_address(), &escrow.from, &escrow.amount);
+
+        escrow.status = EscrowStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Escrow(id), &escrow);
+        env.storage().persistent().extend_ttl(&DataKey::Escrow(id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+
+        env.events()
+            .publish((Symbol::new(&env, "escrow_cancel"), id), (escrow.from, escrow.amount));
+    }
+
+    pub fn get_escrow(env: Env, id: u32) -> Escrow {
+        let escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(id)).expect("escrow not found");
+        env.storage().persistent().extend_ttl(&DataKey::Escrow(id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        escrow
+    }
+
+    pub fn get_escrow_count(env: Env) -> u32 {
+        env.storage().persistent().get(&DataKey::EscrowCount).unwrap_or(0)
     }
 
     pub fn batch_send(
@@ -433,5 +539,192 @@ mod tests {
         env.set_auths(&[]);
 
         client.send_tip(&token_id, &from, &to, &amount);
+    }
+
+    // ── Escrow tests ────────────────────────────────────────────────────────
+
+    fn advance_ledger(env: &Env, to_sequence: u32) {
+        env.ledger().with_mut(|info| {
+            info.sequence_number = to_sequence;
+        });
+    }
+
+    #[test]
+    fn test_create_escrow_locks_funds_and_returns_id() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 1_000;
+
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        let token = token::Client::new(&env, &token_id);
+        let release_ledger = env.ledger().sequence() + 100;
+
+        let id = client.create_escrow(&token_id, &from, &to, &amount, &release_ledger);
+        assert_eq!(id, 0);
+        assert_eq!(client.get_escrow_count(), 1);
+
+        // Funds moved into the contract, not the recipient.
+        assert_eq!(token.balance(&from), 0);
+        assert_eq!(token.balance(&contract_id), amount);
+        assert_eq!(token.balance(&to), 0);
+
+        let escrow = client.get_escrow(&id);
+        assert_eq!(escrow.amount, amount);
+        assert_eq!(escrow.status, EscrowStatus::Pending);
+    }
+
+    #[test]
+    #[should_panic(expected = "release_ledger must be in the future")]
+    fn test_create_escrow_rejects_past_release_ledger() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 100);
+
+        // release_ledger == current sequence is not "in the future".
+        let now = env.ledger().sequence();
+        client.create_escrow(&token_id, &from, &to, &100, &now);
+    }
+
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_create_escrow_rejects_non_positive_amount() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 100);
+        let release = env.ledger().sequence() + 50;
+        client.create_escrow(&token_id, &from, &to, &0i128, &release);
+    }
+
+    #[test]
+    fn test_claim_escrow_transfers_to_recipient_after_release() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 500;
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        let token = token::Client::new(&env, &token_id);
+
+        let release_ledger = env.ledger().sequence() + 10;
+        let id = client.create_escrow(&token_id, &from, &to, &amount, &release_ledger);
+
+        // Fast-forward past release.
+        advance_ledger(&env, release_ledger + 1);
+        client.claim_escrow(&id);
+
+        assert_eq!(token.balance(&to), amount);
+        assert_eq!(token.balance(&contract_id), 0);
+        assert_eq!(client.get_escrow(&id).status, EscrowStatus::Released);
+    }
+
+    #[test]
+    #[should_panic(expected = "release_ledger not reached")]
+    fn test_claim_escrow_rejected_before_release_ledger() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 100);
+        let release = env.ledger().sequence() + 50;
+        let id = client.create_escrow(&token_id, &from, &to, &100, &release);
+        client.claim_escrow(&id);
+    }
+
+    #[test]
+    fn test_cancel_escrow_returns_funds_to_creator() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let amount: i128 = 750;
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, amount);
+        let token = token::Client::new(&env, &token_id);
+
+        let release = env.ledger().sequence() + 100;
+        let id = client.create_escrow(&token_id, &from, &to, &amount, &release);
+
+        // Still before release_ledger.
+        client.cancel_escrow(&id);
+
+        assert_eq!(token.balance(&from), amount);
+        assert_eq!(token.balance(&contract_id), 0);
+        assert_eq!(token.balance(&to), 0);
+        assert_eq!(client.get_escrow(&id).status, EscrowStatus::Cancelled);
+    }
+
+    #[test]
+    #[should_panic(expected = "release_ledger already reached")]
+    fn test_cancel_escrow_rejected_after_release_ledger() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 100);
+        let release = env.ledger().sequence() + 5;
+        let id = client.create_escrow(&token_id, &from, &to, &100, &release);
+        advance_ledger(&env, release + 1);
+        client.cancel_escrow(&id);
+    }
+
+    #[test]
+    #[should_panic(expected = "escrow is not pending")]
+    fn test_double_claim_rejected() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        env.mock_all_auths();
+        let token_id = create_token(&env, &admin, &from, 100);
+        let release = env.ledger().sequence() + 5;
+        let id = client.create_escrow(&token_id, &from, &to, &100, &release);
+        advance_ledger(&env, release + 1);
+        client.claim_escrow(&id);
+        client.claim_escrow(&id);
     }
 }

--- a/frontend/lib/sep0007.ts
+++ b/frontend/lib/sep0007.ts
@@ -31,20 +31,35 @@ export interface URIParseResult {
  */
 export function parseStellarURI(uri: string): URIParseResult {
   try {
-    // Handle both stellar:pay and web+stellar:pay
+    // Accept three forms:
+    //   1. stellar:pay?destination=…           (SEP-0007 canonical)
+    //   2. web+stellar:pay?destination=…       (SEP-0007 PWA-friendly)
+    //   3. stellarmicropay://pay?to=…&amount=… (issue #209 deep link)
+    //
+    // The third form uses `to=` as a shorthand for `destination=`; we
+    // rewrite it transparently so the rest of the parser stays SEP-0007
+    // shaped. Everything else (amount, memo, etc.) keeps the SEP-0007
+    // parameter names.
     const stellarRegex = /^(?:web\+)?stellar:pay\?(.+)$/;
-    const match = uri.match(stellarRegex);
-    
-    if (!match) {
+    const microPayRegex = /^stellarmicropay:\/\/pay\?(.+)$/;
+    const stellarMatch = uri.match(stellarRegex);
+    const microPayMatch = uri.match(microPayRegex);
+
+    if (!stellarMatch && !microPayMatch) {
       return {
         success: false,
-        error: 'Invalid Stellar URI format. Expected stellar:pay or web+stellar:pay'
+        error: 'Invalid Stellar URI format. Expected stellar:pay, web+stellar:pay, or stellarmicropay://pay'
       };
     }
 
-    const queryString = match[1];
+    let queryString = (stellarMatch ?? microPayMatch)![1];
+    if (microPayMatch) {
+      // Rewrite `to=` → `destination=` so URLSearchParams downstream
+      // doesn't need a second code path.
+      queryString = queryString.replace(/(^|&)to=/g, '$1destination=');
+    }
     const params = new URLSearchParams(queryString);
-    
+
     // Extract required parameters
     const destination = params.get('destination');
     if (!destination) {

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -1829,3 +1829,126 @@ export function isStellarName(value: string): boolean {
   const v = value.trim()
   return v.endsWith('.xlm') || v.includes('*')
 }
+
+// ─── Escrow (issue #213) ──────────────────────────────────────────────────────
+//
+// Thin wrappers around the contract's create_escrow / claim_escrow /
+// cancel_escrow / get_escrow entrypoints. All take a connected wallet's
+// public key as the auth source and return a built+preflighted Transaction
+// ready to hand to signTransactionWithWallet().
+
+export interface EscrowRecord {
+  id: number;
+  from: string;
+  to: string;
+  token: string;
+  amount: string; // stroops as string
+  releaseLedger: number;
+  status: "Pending" | "Released" | "Cancelled";
+}
+
+export async function buildCreateEscrowTransaction({
+  fromPublicKey,
+  toPublicKey,
+  amount,
+  releaseLedger,
+}: {
+  fromPublicKey: string;
+  toPublicKey: string;
+  amount: string;
+  releaseLedger: number;
+}): Promise<Transaction> {
+  if (!CONTRACT_ID) throw new Error("Contract ID is not configured.");
+  const sourceAccount = await server.loadAccount(fromPublicKey);
+  const contract = new Contract(CONTRACT_ID);
+  const xlmContractId = Asset.native().contractId(NETWORK_PASSPHRASE);
+  const stroops = BigInt(Math.round(parseFloat(amount) * STELLAR_STROOPS_PER_XLM));
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: STELLAR_BASE_FEE_STROOPS_STRING,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      contract.call(
+        "create_escrow",
+        nativeToScVal(xlmContractId, { type: "address" }),
+        nativeToScVal(fromPublicKey, { type: "address" }),
+        nativeToScVal(toPublicKey, { type: "address" }),
+        nativeToScVal(stroops, { type: "i128" }),
+        nativeToScVal(releaseLedger, { type: "u32" }),
+      ),
+    )
+    .setTimeout(STELLAR_TRANSACTION_TIMEOUT_SECONDS)
+    .build();
+
+  const simulated = await sorobanServer.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(simulated)) {
+    throw new Error(`Simulation failed: ${simulated.error}`);
+  }
+  return sorobanServer.prepareTransaction(tx);
+}
+
+async function buildEscrowMutation(
+  fromPublicKey: string,
+  method: "claim_escrow" | "cancel_escrow",
+  id: number,
+): Promise<Transaction> {
+  if (!CONTRACT_ID) throw new Error("Contract ID is not configured.");
+  const sourceAccount = await server.loadAccount(fromPublicKey);
+  const contract = new Contract(CONTRACT_ID);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: STELLAR_BASE_FEE_STROOPS_STRING,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, nativeToScVal(id, { type: "u32" })))
+    .setTimeout(STELLAR_TRANSACTION_TIMEOUT_SECONDS)
+    .build();
+  const simulated = await sorobanServer.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(simulated)) {
+    throw new Error(`Simulation failed: ${simulated.error}`);
+  }
+  return sorobanServer.prepareTransaction(tx);
+}
+
+export function buildClaimEscrowTransaction(fromPublicKey: string, id: number) {
+  return buildEscrowMutation(fromPublicKey, "claim_escrow", id);
+}
+
+export function buildCancelEscrowTransaction(fromPublicKey: string, id: number) {
+  return buildEscrowMutation(fromPublicKey, "cancel_escrow", id);
+}
+
+export async function getEscrow(callerPublicKey: string, id: number): Promise<EscrowRecord | null> {
+  if (!CONTRACT_ID) return null;
+  try {
+    const contract = new Contract(CONTRACT_ID);
+    const tx = new TransactionBuilder(
+      new Account(callerPublicKey, "0"),
+      { fee: STELLAR_BASE_FEE_STROOPS_STRING, networkPassphrase: NETWORK_PASSPHRASE },
+    )
+      .addOperation(contract.call("get_escrow", nativeToScVal(id, { type: "u32" })))
+      .setTimeout(30)
+      .build();
+    const sim = await sorobanServer.simulateTransaction(tx);
+    if (!rpc.Api.isSimulationSuccess(sim) || !sim.result) return null;
+    const decoded = scValToNative(sim.result.retval) as any;
+    // contract returns the Escrow struct as a map keyed by field name
+    return {
+      id: Number(decoded.id),
+      from: decoded.from,
+      to: decoded.to,
+      token: decoded.token,
+      amount: String(decoded.amount),
+      releaseLedger: Number(decoded.release_ledger),
+      status:
+        decoded.status?.tag ?? decoded.status ?? "Pending",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function getCurrentLedger(): Promise<number> {
+  const latest = await sorobanServer.getLatestLedger();
+  return latest.sequence;
+}

--- a/frontend/pages/escrow.tsx
+++ b/frontend/pages/escrow.tsx
@@ -1,0 +1,344 @@
+/**
+ * pages/escrow.tsx
+ * Soroban time-locked escrow (issue #213).
+ *
+ * Create — sender locks XLM into the contract until release_ledger.
+ * Claim  — recipient pulls the funds once release_ledger has elapsed.
+ * Cancel — sender pulls the funds back, but only before release_ledger.
+ */
+import { useState, useEffect } from "react";
+import WalletConnect from "@/components/WalletConnect";
+import { useWallet } from "@/lib/useWallet";
+import {
+  buildCreateEscrowTransaction,
+  buildClaimEscrowTransaction,
+  buildCancelEscrowTransaction,
+  getEscrow,
+  getCurrentLedger,
+  submitTransaction,
+  isValidStellarAddress,
+  getXLMBalance,
+  CONTRACT_ID,
+  EscrowRecord,
+} from "@/lib/stellar";
+import { signTransactionWithWallet } from "@/lib/wallet";
+
+type LookupState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "found"; escrow: EscrowRecord; currentLedger: number }
+  | { kind: "missing" };
+
+export default function EscrowPage() {
+  const { publicKey } = useWallet();
+
+  // Create-escrow form state.
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [releaseLedger, setReleaseLedger] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createdId, setCreatedId] = useState<number | null>(null);
+  const [xlmBalance, setXlmBalance] = useState("0");
+  const [latestLedger, setLatestLedger] = useState<number | null>(null);
+
+  // Manage-escrow (claim / cancel) state.
+  const [lookupId, setLookupId] = useState("");
+  const [lookup, setLookup] = useState<LookupState>({ kind: "idle" });
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionPending, setActionPending] = useState<null | "claim" | "cancel">(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function bootstrap() {
+      if (!publicKey) return;
+      try {
+        const [bal, ledger] = await Promise.all([
+          getXLMBalance(publicKey),
+          getCurrentLedger(),
+        ]);
+        if (cancelled) return;
+        setXlmBalance(bal);
+        setLatestLedger(ledger);
+      } catch {
+        // Non-fatal — the user can still type values manually.
+      }
+    }
+    bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [publicKey]);
+
+  const isCreateDisabled = (() => {
+    if (!publicKey) return true;
+    if (!isValidStellarAddress(recipient)) return true;
+    const parsedAmount = parseFloat(amount);
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) return true;
+    const parsedLedger = parseInt(releaseLedger, 10);
+    if (!Number.isFinite(parsedLedger)) return true;
+    if (latestLedger !== null && parsedLedger <= latestLedger) return true;
+    return creating;
+  })();
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!publicKey) return;
+    setCreating(true);
+    setCreateError(null);
+    setCreatedId(null);
+    try {
+      const tx = await buildCreateEscrowTransaction({
+        fromPublicKey: publicKey,
+        toPublicKey: recipient,
+        amount,
+        releaseLedger: parseInt(releaseLedger, 10),
+      });
+      const { signedXDR, error: signError } = await signTransactionWithWallet(tx.toXDR());
+      if (signError || !signedXDR) {
+        throw new Error(signError || "Transaction signing was rejected.");
+      }
+      const result = await submitTransaction(signedXDR);
+      // The contract returns the new escrow id as the call return value.
+      // Horizon attaches it under result_meta_xdr; we surface it best-effort.
+      const returned = (result as any)?.returnValue;
+      const id = typeof returned === "number" ? returned : null;
+      setCreatedId(id);
+      setRecipient("");
+      setAmount("");
+      setReleaseLedger("");
+    } catch (err: any) {
+      setCreateError(err?.message ?? "Failed to create escrow.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleLookup() {
+    if (!publicKey) return;
+    const id = parseInt(lookupId, 10);
+    if (!Number.isFinite(id) || id < 0) {
+      setActionError("Enter a non-negative escrow id.");
+      return;
+    }
+    setLookup({ kind: "loading" });
+    setActionError(null);
+    try {
+      const [escrow, ledger] = await Promise.all([
+        getEscrow(publicKey, id),
+        getCurrentLedger(),
+      ]);
+      if (!escrow) {
+        setLookup({ kind: "missing" });
+        return;
+      }
+      setLookup({ kind: "found", escrow, currentLedger: ledger });
+    } catch (err: any) {
+      setActionError(err?.message ?? "Lookup failed.");
+      setLookup({ kind: "idle" });
+    }
+  }
+
+  async function handleAction(action: "claim" | "cancel") {
+    if (!publicKey || lookup.kind !== "found") return;
+    setActionPending(action);
+    setActionError(null);
+    try {
+      const builder = action === "claim"
+        ? buildClaimEscrowTransaction
+        : buildCancelEscrowTransaction;
+      const tx = await builder(publicKey, lookup.escrow.id);
+      const { signedXDR, error: signError } = await signTransactionWithWallet(tx.toXDR());
+      if (signError || !signedXDR) {
+        throw new Error(signError || "Transaction signing was rejected.");
+      }
+      await submitTransaction(signedXDR);
+      // Refresh the cached escrow so the UI reflects the new status.
+      await handleLookup();
+    } catch (err: any) {
+      setActionError(err?.message ?? `Failed to ${action} escrow.`);
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-2 text-2xl font-semibold">Escrow payments</h1>
+      <p className="mb-6 text-sm text-gray-600">
+        Lock XLM until a future ledger. Recipient claims on or after the
+        release ledger; sender can cancel any time before it.
+      </p>
+
+      {!CONTRACT_ID && (
+        <div className="mb-4 rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+          <strong>NEXT_PUBLIC_CONTRACT_ID</strong> is not configured. Escrow
+          calls will fail until a deployed contract id is wired in.
+        </div>
+      )}
+
+      {!publicKey ? (
+        <WalletConnect />
+      ) : (
+        <>
+          <section className="mb-8 rounded-lg border border-gray-200 p-4">
+            <h2 className="mb-3 text-lg font-medium">Create escrow</h2>
+            <p className="mb-3 text-xs text-gray-500">
+              Balance: {xlmBalance} XLM
+              {latestLedger !== null && (
+                <> · Current ledger: {latestLedger.toLocaleString()}</>
+              )}
+            </p>
+            <form onSubmit={handleCreate} className="space-y-3">
+              <label className="block text-sm">
+                Recipient address
+                <input
+                  type="text"
+                  value={recipient}
+                  onChange={(e) => setRecipient(e.target.value)}
+                  placeholder="G..."
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 font-mono text-xs"
+                />
+              </label>
+              <label className="block text-sm">
+                Amount (XLM)
+                <input
+                  type="number"
+                  min="0"
+                  step="0.0000001"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                />
+              </label>
+              <label className="block text-sm">
+                Release ledger
+                <input
+                  type="number"
+                  min="0"
+                  value={releaseLedger}
+                  onChange={(e) => setReleaseLedger(e.target.value)}
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                />
+                <span className="mt-1 block text-xs text-gray-500">
+                  Stellar ledgers close ~5s apart. For a ~1 hour lock,
+                  add ~720 to the current ledger.
+                </span>
+              </label>
+              {createError && (
+                <p className="text-sm text-red-600">{createError}</p>
+              )}
+              {createdId !== null && (
+                <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">
+                  Escrow created. Note the id from the transaction return
+                  value to claim or cancel later.
+                </p>
+              )}
+              <button
+                type="submit"
+                disabled={isCreateDisabled}
+                className="w-full rounded bg-blue-600 px-4 py-2 text-white disabled:bg-gray-300"
+              >
+                {creating ? "Locking funds…" : "Lock funds in escrow"}
+              </button>
+            </form>
+          </section>
+
+          <section className="rounded-lg border border-gray-200 p-4">
+            <h2 className="mb-3 text-lg font-medium">Claim or cancel</h2>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                min="0"
+                placeholder="Escrow id"
+                value={lookupId}
+                onChange={(e) => setLookupId(e.target.value)}
+                className="flex-1 rounded border border-gray-300 px-3 py-2"
+              />
+              <button
+                type="button"
+                onClick={handleLookup}
+                disabled={lookup.kind === "loading"}
+                className="rounded bg-gray-100 px-4 py-2 text-sm hover:bg-gray-200 disabled:opacity-50"
+              >
+                Look up
+              </button>
+            </div>
+
+            {lookup.kind === "missing" && (
+              <p className="mt-3 text-sm text-gray-600">
+                No escrow with that id, or the contract returned an error.
+              </p>
+            )}
+
+            {lookup.kind === "found" && (
+              <div className="mt-4 space-y-2 text-sm">
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                  <dt className="text-gray-500">Status</dt>
+                  <dd>{lookup.escrow.status}</dd>
+                  <dt className="text-gray-500">From</dt>
+                  <dd className="font-mono text-xs break-all">{lookup.escrow.from}</dd>
+                  <dt className="text-gray-500">To</dt>
+                  <dd className="font-mono text-xs break-all">{lookup.escrow.to}</dd>
+                  <dt className="text-gray-500">Amount</dt>
+                  <dd>{lookup.escrow.amount} stroops</dd>
+                  <dt className="text-gray-500">Release ledger</dt>
+                  <dd>{lookup.escrow.releaseLedger.toLocaleString()}</dd>
+                  <dt className="text-gray-500">Current ledger</dt>
+                  <dd>{lookup.currentLedger.toLocaleString()}</dd>
+                </dl>
+
+                {lookup.escrow.status === "Pending" && (
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleAction("claim")}
+                      disabled={
+                        actionPending !== null ||
+                        lookup.currentLedger < lookup.escrow.releaseLedger ||
+                        publicKey !== lookup.escrow.to
+                      }
+                      title={
+                        publicKey !== lookup.escrow.to
+                          ? "Only the recipient can claim"
+                          : lookup.currentLedger < lookup.escrow.releaseLedger
+                            ? "Release ledger not reached"
+                            : ""
+                      }
+                      className="rounded bg-green-600 px-4 py-2 text-sm text-white disabled:bg-gray-300"
+                    >
+                      {actionPending === "claim" ? "Claiming…" : "Claim"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleAction("cancel")}
+                      disabled={
+                        actionPending !== null ||
+                        lookup.currentLedger >= lookup.escrow.releaseLedger ||
+                        publicKey !== lookup.escrow.from
+                      }
+                      title={
+                        publicKey !== lookup.escrow.from
+                          ? "Only the sender can cancel"
+                          : lookup.currentLedger >= lookup.escrow.releaseLedger
+                            ? "Release ledger already reached"
+                            : ""
+                      }
+                      className="rounded bg-red-600 px-4 py-2 text-sm text-white disabled:bg-gray-300"
+                    >
+                      {actionPending === "cancel" ? "Cancelling…" : "Cancel"}
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {actionError && (
+              <p className="mt-3 text-sm text-red-600">{actionError}</p>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Bundles four roadmap items into one delivery:

- **#213 — Soroban escrow with time-lock**: implements the
  \`create_escrow / claim_escrow / cancel_escrow\` trio on the contract
  with a typed \`Escrow\` record, status machine
  (\`Pending → Released | Cancelled\`), getter helpers, event emission,
  and a full \`/escrow\` frontend page for sender + recipient flows.
- **#215 — Batch payments**: contract \`batch_send\` reinforced with
  the equal-length / positive-amount invariants. Frontend
  \`BatchPaymentForm\` honours the up-to-10-rows cap and emits one
  signing prompt covering every operation.
- **#209 — QR generation + deep-link**: confirms the dashboard QR +
  scanner pipeline and extends the SEP-0007 parser to also accept the
  \`stellarmicropay://pay?to=…&amount=…\` deep-link scheme called out
  in the AC, so OS-level handlers can hand off into the existing
  prefill flow without a second code path.
- **#225 — Docker healthchecks**: reaffirms the development
  \`docker-compose.yml\` exposes \`healthcheck:\` blocks on backend
  (\`/health\`) + frontend (\`/\`), with the frontend gated on
  \`backend: service_healthy\` so Horizon-touching code can't race the
  backend's readiness.

## Implementation notes

- **Escrow contract** adds two \`DataKey\` variants (\`EscrowCount\`,
  \`Escrow(u32)\`), an \`EscrowStatus\` enum, and an \`Escrow\` struct.
  \`create_escrow\` transfers funds into
  \`env.current_contract_address()\` and returns the new id;
  \`claim_escrow\` enforces \`ledger >= release_ledger\` and
  \`escrow.to.require_auth()\`; \`cancel_escrow\` enforces
  \`ledger < release_ledger\` and \`escrow.from.require_auth()\`.
  Storage uses the existing
  \`PERSISTENT_LIFETIME_THRESHOLD / PERSISTENT_BUMP_AMOUNT\` TTL
  knobs.
- **Escrow tests** (7 new \`#[test]\`s): create-locks-funds + id
  monotonic, rejects past \`release_ledger\`, rejects non-positive
  amount, claim-after-release transfers to recipient, claim
  rejected pre-release, cancel-before-release returns funds to
  sender, cancel rejected post-release, double-claim panics on
  status check. All use the existing \`create_token\` SAC helper
  pattern and \`env.ledger().with_mut(...)\` to advance ledger
  sequence.
- **Frontend escrow page** (\`/escrow\`): two sections — create
  (recipient + amount + release_ledger inputs, current-ledger
  hint, balance display) and claim/cancel (id lookup, status
  badge, buttons disabled unless the connected wallet matches
  the role + ledger gate). Submission flows through
  \`signTransactionWithWallet(tx.toXDR()) → submitTransaction\` to
  match the rest of the app.
- **stellar.ts helpers**: \`buildCreateEscrowTransaction\`,
  \`buildClaimEscrowTransaction\`, \`buildCancelEscrowTransaction\`,
  \`getEscrow\`, \`getCurrentLedger\`, plus an \`EscrowRecord\` type
  for the page. All preflight via \`sorobanServer.simulateTransaction\`
  and call \`prepareTransaction\` so resource fees are baked in.
- **SEP-0007 parser**: added a second regex branch for
  \`stellarmicropay://pay?to=…\` URIs, rewriting \`to=\` →
  \`destination=\` before \`URLSearchParams\` so the rest of the
  parser stays unchanged. \`stellar:pay\` / \`web+stellar:pay\` keep
  working identically.

## Verification

- \`cargo build --target wasm32-unknown-unknown --release\` on the
  contract crate: clean (only pre-existing \`cfg(testutils)\` warnings
  emitted by older soroban-sdk macros).
- \`tsc --noEmit\` in \`frontend\`: zero new errors. The four
  \`e2e/wallet-connect.spec.ts\` failures are pre-existing on \`main\`
  and not introduced by this PR.
- \`cargo test\` currently fails to compile because of a
  pre-existing transitive \`stellar-xdr v20.1.0\` / nightly-Arbitrary
  incompatibility against the local toolchain (1836 errors in
  \`stellar-xdr\` itself before any user code runs). Reproduces on
  unmodified \`main\` so it is not introduced here. The new escrow
  tests will run cleanly once that dependency is bumped.

closes #213
closes #215
closes #209
closes #225