### PR TITLE
fix: resolve issues #197 #199 #205 #206

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -13,7 +13,18 @@ const stellarService = require("../services/stellarService");
 async function getPayments(req, res, next) {
   try {
     const { publicKey } = req.params;
-    const limit = Math.min(parseInt(req.query.limit) || 20, 100);
+
+    // #197: explicit validation — || 20 silently swallows limit=0; NaN propagates to Horizon
+    const rawLimit = req.query.limit;
+    let limit = 20;
+    if (rawLimit !== undefined) {
+      const parsed = parseInt(rawLimit, 10);
+      if (isNaN(parsed) || !Number.isSafeInteger(parsed) || parsed < 1) {
+        return res.status(400).json({ error: "limit must be a positive integer" });
+      }
+      limit = Math.min(parsed, 100);
+    }
+
     const cursor = req.query.cursor || undefined;
 
     const payments = await stellarService.getPayments(publicKey, { limit, cursor });

--- a/backend/src/middleware/rateLimit.js
+++ b/backend/src/middleware/rateLimit.js
@@ -22,4 +22,17 @@ const strictLimiter = rateLimit({
   message: { error: "Too many requests to sensitive routes, please wait 1 minute." },
 });
 
-module.exports = { strictLimiter };
+/**
+ * Sensitive route limiting — 10 requests per minute (#205).
+ * Applied to account lookup and balance endpoints that could be used for
+ * account enumeration.
+ */
+const sensitiveLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests to this endpoint, please wait 1 minute." },
+});
+
+module.exports = { strictLimiter, sensitiveLimiter };

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -7,7 +7,7 @@
 
 const express = require("express");
 const router = express.Router();
-const { strictLimiter } = require("../middleware/rateLimit");
+const { strictLimiter, sensitiveLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey, sanitizeUsername } = require("../middleware/sanitization");
 const { verifyJWT } = require("../middleware/auth");
 const accountController = require("../controllers/accountController");
@@ -30,19 +30,19 @@ function requireOwnAccount(req, res, next) {
  * Resolve a username to a Stellar public key.
  * Must be registered before /:publicKey or Express matches it as a key.
  */
-router.get("/resolve/:username", strictLimiter, sanitizeUsername, accountController.resolveUsername);
+router.get("/resolve/:username", sensitiveLimiter, sanitizeUsername, accountController.resolveUsername);
 
 /**
  * GET /api/accounts/:publicKey
  * Fetch account info and balances from Horizon.
  */
-router.get("/:publicKey", strictLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getAccount);
+router.get("/:publicKey", sensitiveLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getAccount);
 
 /**
  * GET /api/accounts/:publicKey/balance
  * Fetch just the XLM balance for an account.
  */
-router.get("/:publicKey/balance", strictLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getBalance);
+router.get("/:publicKey/balance", sensitiveLimiter, verifyJWT, sanitizePublicKey, requireOwnAccount, accountController.getBalance);
 
 /**
  * POST /api/accounts/register

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -25,6 +25,6 @@ router.get("/:publicKey", strictLimiter, sanitizePublicKey, paymentController.ge
  * GET /api/payments/:publicKey/stats
  * Return aggregate stats for an account (total sent, received, count).
  */
-router.get("/:publicKey/stats", paymentController.getStats);
+router.get("/:publicKey/stats", strictLimiter, paymentController.getStats);
 
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -31,6 +31,15 @@ const { validateEnv, parseAllowedOrigins } = require("./config/validateEnv");
 const app = express();
 const PORT = process.env.PORT || 4000;
 
+// ─── Error message sanitization (#206) ───────────────────────────────────────
+// Stellar secret keys: 'S' + 55 base32 chars [A-Z2-7]. Strip before logging or
+// sending to Sentry/clients so a mis-routed key never appears in outputs.
+
+const STELLAR_SECRET_PATTERN = /S[A-Z2-7]{55}/g;
+function sanitizeMessage(msg) {
+  return typeof msg === "string" ? msg.replace(STELLAR_SECRET_PATTERN, "[REDACTED]") : msg;
+}
+
 // ─── Sentry ───────────────────────────────────────────────────────────────────
 
 Sentry.init({
@@ -39,6 +48,16 @@ Sentry.init({
   // Only enable in production unless SENTRY_DSN is explicitly set
   enabled: !!process.env.SENTRY_DSN,
   tracesSampleRate: 0.2,
+  // #206: strip Stellar secret keys from error messages before Sentry receives them
+  beforeSend(event) {
+    if (event.exception?.values) {
+      event.exception.values = event.exception.values.map((v) => ({
+        ...v,
+        value: sanitizeMessage(v.value),
+      }));
+    }
+    return event;
+  },
 });
 
 function stripProtocol(value) {
@@ -217,8 +236,8 @@ Sentry.setupExpressErrorHandler(app);
 app.use((err, req, res, next) => {
   void next;
   const status = err.status || 500;
-  const message = err.message || "Internal Server Error";
-
+  const message = sanitizeMessage(err.message) || "Internal Server Error";
+  logger.error({ status, message }, "Request error");
   res.status(status).json({ error: message });
 });
 

--- a/frontend/lib/wallet.ts
+++ b/frontend/lib/wallet.ts
@@ -137,6 +137,14 @@ export async function connectWallet(): Promise<{
     // 2. Request access from the user
     const access = await requestAccess();
 
+    // #199: check error field — denial does not throw, it returns {error}
+    if (access.error) {
+      return {
+        publicKey: null,
+        error: access.error.message || "Connection rejected. Please approve the connection in Freighter.",
+      };
+    }
+
     // 3. Get the public key
     const publicKey = access.address || (await getAddress()).address;
 


### PR DESCRIPTION
  ## Summary

  Resolves four open issues: two security hardening items and two input-validation bugs.

  ### #205 — Per-endpoint rate limits for sensitive routes
  - Added `sensitiveLimiter` (10 req/min per IP) in `middleware/rateLimit.js` for account lookup/resolve/balance
  endpoints that are susceptible to enumeration.
  - Swapped the existing `strictLimiter` (20 req/min) to `sensitiveLimiter` on `GET /api/accounts/:publicKey`,
  `GET /api/accounts/:publicKey/balance`, and `GET /api/accounts/resolve/:username`.
  - Added `strictLimiter` to `GET /api/payments/:publicKey/stats`, which previously had **no** rate limiter at
  all.

  ### #199 — requestAccess() return value not checked
  - In `connectWallet()` (`frontend/lib/wallet.ts`), added an explicit check for `access.error` immediately after
  `requestAccess()`.
  - Freighter signals user denial via an error field (not a thrown exception); without this guard the code fell
  through to `getAddress()` and could return an empty string with no error shown.

  ### #206 — Private keys could be logged
  - Added `sanitizeMessage()` in `server.js` using the regex `/S[A-Z2-7]{55}/g` (precise Stellar base32 pattern)
  to strip any accidental secret key from error messages.
  - Applied sanitization in three places: the generic error handler, the `logger.error` call, and the Sentry
  `beforeSend` hook so keys are scrubbed before reaching external monitoring.

  ### #197 — parseInt silently mishandles limit=0 and non-integers
  - Replaced `parseInt(req.query.limit) || 20` with explicit `isNaN` / `Number.isSafeInteger` / range validation
  in `paymentController.js`.
  - `limit=0`, negative values, and non-numeric strings now return HTTP 400 instead of silently defaulting or
  passing `NaN` to Horizon.

  ## Files changed
  - `backend/src/middleware/rateLimit.js`
  - `backend/src/routes/accounts.js`
  - `backend/src/routes/payments.js`
  - `backend/src/server.js`
  - `backend/src/controllers/paymentController.js`
  - `frontend/lib/wallet.ts`

  ## Test plan
  - [ ] `cd backend && npm test` — all existing tests pass
  - [ ] `GET /api/payments/:publicKey/stats` — confirm rate-limited (returns 429 after 20 req/min)
  - [ ] `GET /api/payments/:publicKey?limit=0` → 400 `{ "error": "limit must be a positive integer" }`
  - [ ] `GET /api/payments/:publicKey?limit=abc` → 400
  - [ ] `GET /api/payments/:publicKey?limit=50` → 200 with up to 50 results
  - [ ] Deny Freighter access in browser → error message surfaced, no silent empty-key return

  Closes #197
  Closes #199
  Closes #205
  Closes #206