### PR TITLE
Remove unused backend 404 handler parameter

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -222,7 +222,7 @@ app.get("/api/docs.json", (req, res) => {
 
 // ─── 404 Handler ───────────────────────────────────────────────────────────────
 
-app.use((req, res, next) => {
+app.use((req, res) => {
   const sanitizedPath = req.path.replace(/[\r\n]/g, "");
   logger.warn({ method: req.method, path: sanitizedPath }, "Route not found");
   res.status(404).json({ error: "Route not found" });


### PR DESCRIPTION
Fixes #632.

## Summary

- Removed the unused `next` parameter from the backend 404 handler in `backend/src/server.js`.
- Keeps the existing 404 response behavior unchanged.
- Resolves the ESLint `no-unused-vars` warning reported for the backend source.

## Validation

- `npm ci`
  - Completed successfully.
  - Existing warning: the package requires Node `20.19.5`; local validation used Node `22.17.1`.
- `npm.cmd run lint`
- `npm.cmd test -- --runInBand`
  - 9 test suites passed.
  - 79 tests passed.
