### PR TITLE
 Add a gitleaks secret-scanning workflow to CI

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,37 @@
+name: Secret Scanning
+
+# Scans the repository for hardcoded secrets (API keys, tokens, private keys)
+# using Gitleaks. Runs on every push and pull request, plus a weekly schedule
+# so newly-published detection rules catch anything that slipped through.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so PR/push scans cover every new commit, not just HEAD.
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional org/enterprise licence key; safe to leave unset for OSS repos.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+# Gitleaks configuration for Stellar MicroPay.
+# Extends the bundled default ruleset and adds project-specific detections.
+
+[extend]
+# Inherit Gitleaks' built-in rules (AWS keys, generic API tokens, private keys, …)
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-seed"
+description = "Stellar secret seed (S... 56-char base32)"
+# Stellar secret keys: 'S' followed by 55 base32 chars [A-Z2-7].
+regex = '''S[A-Z2-7]{55}'''
+keywords = ["S"]
+tags = ["stellar", "private-key"]
+
+[allowlist]
+description = "Files and paths that legitimately contain example/test values"
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/)ENV\.md$''',
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)Cargo\.lock$''',
+  '''(^|/)__tests__/''',
+  '''\.test\.js$''',
+]
+# Well-known Stellar test/documentation account addresses (public G-keys) and
+# common placeholder secrets should not trip the scanner.
+regexes = [
+  '''EXAMPLE''',
+  '''your[-_]?secret''',
+  '''changeme''',
+]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,16 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 # CORS allowed origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000
 
+# JWT signing secret for SEP-0010 session tokens.
+# REQUIRED in production — the app refuses to start with the built-in default.
+# Generate a strong value, e.g.  openssl rand -hex 32
+JWT_SECRET=
+
+# Server keypair used to sign SEP-0010 challenge transactions.
+# If unset, an ephemeral keypair is generated per cold start (tokens won't
+# survive restarts). Set a stable secret (S...) in production.
+SERVER_PRIVATE_KEY=
+
 # Stellar Federation (SEP-0001/SEP-0002)
 FEDERATION_DOMAIN=stellarmicropay.io
 FEDERATION_DOMAINS=stellarmicropay.io,stellarmicropay.com

--- a/backend/__tests__/accountsAuth.test.js
+++ b/backend/__tests__/accountsAuth.test.js
@@ -7,7 +7,7 @@
 const express = require("express");
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
-const { JWT_SECRET } = require("../src/middleware/auth");
+const { JWT_SECRET, SIGN_OPTIONS } = require("../src/middleware/auth");
 const accountRoutes = require("../src/routes/accounts");
 
 const ME = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
@@ -21,7 +21,7 @@ function appWithAccounts() {
 }
 
 function tokenFor(publicKey) {
-  return jwt.sign({ publicKey }, JWT_SECRET, { expiresIn: "1h" });
+  return jwt.sign({ publicKey }, JWT_SECRET, SIGN_OPTIONS);
 }
 
 describe("account routes authorization (#278)", () => {

--- a/backend/__tests__/webhookSignature.test.js
+++ b/backend/__tests__/webhookSignature.test.js
@@ -1,0 +1,145 @@
+/**
+ * Edge-case coverage for webhook HMAC signature generation and verification.
+ */
+"use strict";
+
+const crypto = require("crypto");
+const {
+  generateWebhookSignature,
+  verifyWebhookSignature,
+} = require("../src/utils/webhookSignature");
+
+const SECRET = "supersecret-webhook-key";
+const PAYLOAD = { event: "payment.received", amount: "10.5", asset: "XLM" };
+
+function sign(payload, secret) {
+  return generateWebhookSignature(payload, secret);
+}
+
+describe("generateWebhookSignature", () => {
+  it("produces a 64-char hex string (SHA-256)", () => {
+    const sig = sign(PAYLOAD, SECRET);
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for identical inputs", () => {
+    expect(sign(PAYLOAD, SECRET)).toBe(sign(PAYLOAD, SECRET));
+  });
+
+  it("treats a stringified object and the raw string identically", () => {
+    const asString = JSON.stringify(PAYLOAD);
+    expect(sign(PAYLOAD, SECRET)).toBe(sign(asString, SECRET));
+  });
+
+  it("changes when the secret changes", () => {
+    expect(sign(PAYLOAD, SECRET)).not.toBe(sign(PAYLOAD, "different-secret"));
+  });
+
+  it("changes when the payload changes", () => {
+    const tampered = { ...PAYLOAD, amount: "999" };
+    expect(sign(PAYLOAD, SECRET)).not.toBe(sign(tampered, SECRET));
+  });
+
+  it("is sensitive to object key ordering (JSON.stringify preserves insertion order)", () => {
+    const a = { x: 1, y: 2 };
+    const b = { y: 2, x: 1 };
+    expect(sign(a, SECRET)).not.toBe(sign(b, SECRET));
+  });
+});
+
+describe("verifyWebhookSignature — valid cases", () => {
+  it("accepts a correct signature for an object payload", () => {
+    const sig = sign(PAYLOAD, SECRET);
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, sig)).toBe(true);
+  });
+
+  it("accepts a correct signature for a string payload", () => {
+    const raw = JSON.stringify(PAYLOAD);
+    const sig = sign(raw, SECRET);
+    expect(verifyWebhookSignature(raw, SECRET, sig)).toBe(true);
+  });
+
+  it("accepts an empty-object payload with the matching signature", () => {
+    const sig = sign({}, SECRET);
+    expect(verifyWebhookSignature({}, SECRET, sig)).toBe(true);
+  });
+});
+
+describe("verifyWebhookSignature — rejection cases", () => {
+  it("rejects a tampered payload", () => {
+    const sig = sign(PAYLOAD, SECRET);
+    const tampered = { ...PAYLOAD, amount: "1000000" };
+    expect(verifyWebhookSignature(tampered, SECRET, sig)).toBe(false);
+  });
+
+  it("rejects a signature made with the wrong secret", () => {
+    const sig = sign(PAYLOAD, "attacker-secret");
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, sig)).toBe(false);
+  });
+
+  it("rejects a valid-length but incorrect signature", () => {
+    const wrong = "a".repeat(64);
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, wrong)).toBe(false);
+  });
+
+  it("rejects a signature that differs by a single flipped hex char", () => {
+    const sig = sign(PAYLOAD, SECRET);
+    const flipped =
+      (sig[0] === "0" ? "1" : "0") + sig.slice(1);
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, flipped)).toBe(false);
+  });
+});
+
+describe("verifyWebhookSignature — malformed input must not throw", () => {
+  it("returns false (not throw) for a too-short signature", () => {
+    expect(() => verifyWebhookSignature(PAYLOAD, SECRET, "abcd")).not.toThrow();
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, "abcd")).toBe(false);
+  });
+
+  it("returns false for a too-long signature", () => {
+    const sig = sign(PAYLOAD, SECRET) + "deadbeef";
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, sig)).toBe(false);
+  });
+
+  it("returns false for a non-hex signature of the right length", () => {
+    const notHex = "z".repeat(64);
+    expect(() => verifyWebhookSignature(PAYLOAD, SECRET, notHex)).not.toThrow();
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, notHex)).toBe(false);
+  });
+
+  it("returns false for an odd-length hex signature", () => {
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, "abc")).toBe(false);
+  });
+
+  it("returns false for an empty-string signature", () => {
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, "")).toBe(false);
+  });
+
+  it("returns false when the signature is undefined or null", () => {
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, undefined)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, SECRET, null)).toBe(false);
+  });
+
+  it("returns false when the secret is missing", () => {
+    const sig = sign(PAYLOAD, SECRET);
+    expect(verifyWebhookSignature(PAYLOAD, "", sig)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, undefined, sig)).toBe(false);
+  });
+});
+
+describe("verifyWebhookSignature — timing safety", () => {
+  it("uses a constant-time comparison for equal-length signatures", () => {
+    const spy = jest.spyOn(crypto, "timingSafeEqual");
+    const sig = sign(PAYLOAD, SECRET);
+    verifyWebhookSignature(PAYLOAD, SECRET, sig);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does not call timingSafeEqual on a length mismatch (avoids throw)", () => {
+    const spy = jest.spyOn(crypto, "timingSafeEqual");
+    verifyWebhookSignature(PAYLOAD, SECRET, "abcd");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -5,23 +5,90 @@
 "use strict";
 
 const jwt = require("jsonwebtoken");
+const logger = require("../utils/logger");
 
-const JWT_SECRET = process.env.JWT_SECRET || "stellar_micropay_secret_key";
+const DEFAULT_JWT_SECRET = "stellar_micropay_secret_key";
+const JWT_SECRET = process.env.JWT_SECRET || DEFAULT_JWT_SECRET;
+
+// Sign/verify options shared by the auth routes and this middleware. Pinning the
+// algorithm to HS256 prevents "alg" confusion attacks (e.g. a forged token with
+// `alg: none` or an RS256/HS256 downgrade being accepted).
+const JWT_ALGORITHM = "HS256";
+const JWT_ISSUER = "stellar-micropay";
+const ACCESS_TOKEN_TTL = "24h";
+
+// Refuse to run in production with the built-in fallback secret — tokens signed
+// with a publicly-known key can be forged by anyone.
+if (process.env.NODE_ENV === "production" && JWT_SECRET === DEFAULT_JWT_SECRET) {
+  logger.error(
+    "JWT_SECRET is unset in production — refusing to start with the insecure default secret."
+  );
+  throw new Error("JWT_SECRET must be set to a strong, unique value in production");
+}
+
+if (JWT_SECRET === DEFAULT_JWT_SECRET) {
+  logger.warn(
+    "JWT_SECRET is using the insecure built-in default. Set JWT_SECRET before deploying."
+  );
+}
+
+const VERIFY_OPTIONS = {
+  algorithms: [JWT_ALGORITHM],
+  issuer: JWT_ISSUER,
+  // Tolerate small clock drift between the signing and verifying hosts.
+  clockTolerance: 5,
+};
+
+const SIGN_OPTIONS = {
+  algorithm: JWT_ALGORITHM,
+  issuer: JWT_ISSUER,
+  expiresIn: ACCESS_TOKEN_TTL,
+};
+
+/**
+ * Extract a bearer token from the Authorization header, falling back to the
+ * httpOnly `jwt` cookie set at login.
+ */
+function extractToken(req) {
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    return authHeader.slice("Bearer ".length).trim();
+  }
+  if (req.cookies && typeof req.cookies.jwt === "string") {
+    return req.cookies.jwt;
+  }
+  return null;
+}
 
 function verifyJWT(req, res, next) {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  const token = extractToken(req);
+  if (!token) {
     return res.status(401).json({ error: "Unauthorized: missing or invalid token" });
   }
 
-  const token = authHeader.split(" ")[1];
   try {
-    const decoded = jwt.verify(token, JWT_SECRET);
+    const decoded = jwt.verify(token, JWT_SECRET, VERIFY_OPTIONS);
     req.user = decoded; // { publicKey: "G..." }
-    next();
-  } catch {
-    return res.status(401).json({ error: "Unauthorized: invalid or expired token" });
+    return next();
+  } catch (err) {
+    // Distinguish an expired token (client should refresh / re-authenticate)
+    // from a malformed or forged one.
+    if (err.name === "TokenExpiredError") {
+      return res
+        .status(401)
+        .json({ error: "Unauthorized: token expired", code: "token_expired" });
+    }
+    return res.status(401).json({ error: "Unauthorized: invalid token" });
   }
 }
 
-module.exports = { verifyJWT, JWT_SECRET };
+module.exports = {
+  verifyJWT,
+  extractToken,
+  JWT_SECRET,
+  JWT_ALGORITHM,
+  JWT_ISSUER,
+  ACCESS_TOKEN_TTL,
+  VERIFY_OPTIONS,
+  SIGN_OPTIONS,
+};

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,9 +10,31 @@
 const express = require("express");
 const jwt     = require("jsonwebtoken");
 const { Utils, Keypair } = require("@stellar/stellar-sdk");
-const { JWT_SECRET } = require("../middleware/auth");
+const {
+  JWT_SECRET,
+  SIGN_OPTIONS,
+  VERIFY_OPTIONS,
+  extractToken,
+} = require("../middleware/auth");
 
 const router = express.Router();
+
+const ACCESS_TOKEN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+// Options for the httpOnly session cookie. `secure` is only enforced in
+// production so local (http) development still works.
+function cookieOptions() {
+  return {
+    httpOnly: true,
+    secure:   process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    maxAge:   ACCESS_TOKEN_MAX_AGE_MS,
+  };
+}
+
+function issueToken(publicKey) {
+  return jwt.sign({ publicKey }, JWT_SECRET, SIGN_OPTIONS);
+}
 
 const HOME_DOMAIN = process.env.HOME_DOMAIN || "localhost:4000";
 const NETWORK_PASSPHRASE =
@@ -69,19 +91,56 @@ router.post("/", (req, res) => {
       ""
     );
 
-    const token = jwt.sign({ publicKey: accountId }, JWT_SECRET, { expiresIn: "24h" });
+    const token = issueToken(accountId);
 
-    res.cookie("jwt", token, {
-      httpOnly: true,
-      secure:   process.env.NODE_ENV === "production",
-      sameSite: "strict",
-      maxAge:   24 * 60 * 60 * 1000,
-    });
+    res.cookie("jwt", token, cookieOptions());
 
     res.json({ success: true, token });
   } catch (e) {
     res.status(401).json({ error: "Unauthorized: " + e.message });
   }
+});
+
+// POST /api/auth/refresh — exchange a still-valid (or freshly-expired) token for
+// a new one, so long-lived sessions don't force a full SEP-0010 re-challenge.
+//
+// The presented token must be structurally valid and signed by us; we allow a
+// short grace window past expiry (ignoreExpiration + manual age check) so a
+// client whose access token just lapsed can seamlessly refresh, but a token that
+// expired long ago is rejected and must re-authenticate.
+const REFRESH_GRACE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+router.post("/refresh", (req, res) => {
+  const token = extractToken(req) || req.body?.token;
+  if (!token) {
+    return res.status(401).json({ error: "Unauthorized: missing token" });
+  }
+
+  let decoded;
+  try {
+    // Verify signature/issuer/algorithm but tolerate expiry here; we enforce a
+    // stricter grace window manually below.
+    decoded = jwt.verify(token, JWT_SECRET, {
+      ...VERIFY_OPTIONS,
+      ignoreExpiration: true,
+    });
+  } catch {
+    return res.status(401).json({ error: "Unauthorized: invalid token" });
+  }
+
+  // Reject tokens that expired beyond the refresh grace window.
+  if (typeof decoded.exp === "number") {
+    const expiredForMs = Date.now() - decoded.exp * 1000;
+    if (expiredForMs > REFRESH_GRACE_MS) {
+      return res
+        .status(401)
+        .json({ error: "Unauthorized: token expired, please re-authenticate" });
+    }
+  }
+
+  const newToken = issueToken(decoded.publicKey);
+  res.cookie("jwt", newToken, cookieOptions());
+  return res.json({ success: true, token: newToken });
 });
 
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -123,9 +123,38 @@ const helmetOptions = {
       fontSrc: ["'self'"],
       objectSrc: ["'none'"],
       frameSrc: ["'none'"],
+      // Disallow this API from being framed by any site (clickjacking defence,
+      // the CSP-level equivalent of X-Frame-Options: DENY).
+      frameAncestors: ["'none'"],
+      // Forbid <base> tag hijacking and form posts to third-party origins.
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
     },
   },
+  // HTTP Strict Transport Security — force HTTPS for two years, cover subdomains,
+  // and allow browser-preload-list inclusion. TLS is terminated at the
+  // load-balancer, so the header is emitted here for clients that reach us
+  // directly over HTTPS.
+  hsts: {
+    maxAge: 63072000, // 2 years
+    includeSubDomains: true,
+    preload: true,
+  },
+  // Send no referrer to other origins (avoids leaking API paths / tokens in
+  // Referer headers).
+  referrerPolicy: { policy: "no-referrer" },
+  // This JSON API should never be embedded cross-origin, nor share its window.
+  crossOriginResourcePolicy: { policy: "same-site" },
+  crossOriginOpenerPolicy: { policy: "same-origin" },
+  // Belt-and-braces clickjacking header for older clients that ignore CSP.
+  frameguard: { action: "deny" },
+  // Block Adobe cross-domain policy files.
+  permittedCrossDomainPolicies: { permittedPolicies: "none" },
 };
+
+// Remove the framework fingerprint header (helmet also does this, but disabling
+// at the Express level guarantees it even if helmet config changes).
+app.disable("x-powered-by");
 
 app.use(helmet(helmetOptions));
 // gzip/brotli-negotiated response compression (#611) — shrinks JSON payloads

--- a/backend/src/utils/webhookSignature.js
+++ b/backend/src/utils/webhookSignature.js
@@ -23,11 +23,26 @@ function generateWebhookSignature(payload, secret) {
  * @returns {boolean} True if the signature is valid, false otherwise.
  */
 function verifyWebhookSignature(payload, secret, signature) {
+  // Reject anything that isn't a usable secret/signature before doing crypto.
+  if (typeof signature !== 'string' || signature.length === 0) {
+    return false;
+  }
+  if (typeof secret !== 'string' || secret.length === 0) {
+    return false;
+  }
+
   const expectedSignature = generateWebhookSignature(payload, secret);
-  return crypto.timingSafeEqual(
-    Buffer.from(expectedSignature, 'hex'),
-    Buffer.from(signature, 'hex')
-  );
+  const expectedBuf = Buffer.from(expectedSignature, 'hex');
+  const providedBuf = Buffer.from(signature, 'hex');
+
+  // timingSafeEqual throws on length mismatch; a length difference already means
+  // the signatures don't match, so short-circuit to false. Comparing lengths is
+  // not secret-dependent, so this leaks no timing information about the secret.
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuf, providedBuf);
 }
 
 module.exports = {


### PR DESCRIPTION
Summary

1. Gitleaks secret-scanning workflow ([security] CI)
- .github/workflows/gitleaks.yml — runs on push/PR to main+develop plus a weekly cron, with contents: read least-privilege permissions and full history (fetch-depth: 0).
- .gitleaks.toml — extends the default ruleset, adds a Stellar secret-seed rule (S[A-Z2-7]{55}, matching the codebase's existing redaction pattern), and allowlists example/lock/test files.

2. JWT/session expiry & refresh hardening
- src/middleware/auth.js — pins algorithms: ["HS256"] (blocks alg confusion/downgrade), refuses to boot in production with the built-in default secret (warns otherwise), adds issuer + clock tolerance, distinguishes token_expired from invalid, and accepts the token from the httpOnly cookie as a fallback. Exports shared SIGN_OPTIONS/VERIFY_OPTIONS.
- src/routes/auth.js — logins now use the shared sign options; added POST /api/auth/refresh that re-issues a token within a 7-day grace window without a full SEP-0010 re-challenge.
- .env.example — documents required JWT_SECRET and SERVER_PRIVATE_KEY.

3. Webhook signature verification edge cases
- src/utils/webhookSignature.js — verifyWebhookSignature now returns false (instead of throwing) on empty/missing secret or signature, non-hex, odd-length, and length-mismatched inputs, short-circuiting before crypto.timingSafeEqual (which throws on unequal lengths).
- __tests__/webhookSignature.test.js — new suite: determinism, object-vs-string equivalence, key-ordering sensitivity, tampered payload, wrong secret, single-bit flip, malformed/too-short/too-long/non-hex/null signatures, and timing-safety assertions.

4. Helmet security headers hardened
- src/server.js — added frameAncestors/baseUri/formAction to CSP, HSTS (2yr, subdomains, preload), no-referrer, crossOriginResourcePolicy: same-site, crossOriginOpenerPolicy: same-origin, frameguard: deny, permittedCrossDomainPolicies: none, and app.disable("x-powered-by").

I also updated __tests__/accountsAuth.test.js to mint tokens via the shared SIGN_OPTIONS so the new issuer check doesn't break it. All changed files pass node --check.



closes #587
closes #588
closes #593
closes #594