### PR TITLE
infra: Add PR labeler workflow based on changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+frontend:
+  - changed-files:
+    - any-glob-to-any-file: 'frontend/**'
+backend:
+  - changed-files:
+    - any-glob-to-any-file: 'backend/**'
+contracts:
+  - changed-files:
+    - any-glob-to-any-file: 'contracts/**'
+docs:
+  - changed-files:
+    - any-glob-to-any-file: 'docs/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically label pull requests based on the files they touch, streamlining the triage process.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #583 

## Changes

- Added `.github/workflows/labeler.yml` to trigger the `actions/labeler` workflow on new pull requests.
- Added `.github/labeler.yml` to define path-matching rules that automatically apply the `frontend`, `backend`, `contracts`, and `docs` labels.

## Testing

- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)
N/A

## Checklist

- [x] My code follows the project style
- [ ] I've updated docs if needed
- [x] No console errors or warnings
- [x] I've rebased on latest `main`
