### PR TITLE
refactor: remove unused variables in backend/src

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -266,7 +266,7 @@ app.get("/api/docs.json", (req, res) => {
 
 // ─── 404 Handler ───────────────────────────────────────────────────────────────
 
-app.use((req, res, next) => {
+app.use((req, res) => {
   const sanitizedPath = req.path.replace(/[\r\n]/g, "");
   logger.warn({ method: req.method, path: sanitizedPath }, "Route not found");
   res.status(404).json({ error: "Route not found" });

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -134,7 +134,7 @@ function registerMultiSigReminder(unsignedXDR, signers, threshold) {
   logger.info(JSON.stringify({ type: "multisig_reminder_registered", signersCount: signers.length, threshold }));
   
   // Start the reminder timer
-  scheduleReminder(unsignedXDR, reminder);
+  scheduleReminder(unsignedXDR);
   
   return reminder;
 }
@@ -142,7 +142,7 @@ function registerMultiSigReminder(unsignedXDR, signers, threshold) {
 /**
  * Schedule a reminder to be sent after the configurable delay
  */
-function scheduleReminder(unsignedXDR, reminder) {
+function scheduleReminder(unsignedXDR) {
   setTimeout(async () => {
     const current = multiSigReminders.get(unsignedXDR);
     if (!current || current.reminderSent) return;


### PR DESCRIPTION
Closes #632

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

Ran ESLint's `no-unused-vars` rule across `backend/src` and removed the dead code it surfaced:

1. Removed unused `next` parameter from the 404 catch-all handler in `server.js`
2. Removed unused `reminder` parameter from `scheduleReminder()` in `webhookService.js` and updated its call site

ESLint now reports zero `no-unused-vars` violations in `backend/src`. No functional behavior changes.

## Motivation / Context

Closes #632

Dead code increases maintenance burden and can confuse contributors. Removing unused variables keeps the codebase clean and ensures ESLint passes cleanly.