### PR TITLE
Close contributor issue batch: docs, contract test, e2e spec, rate-limit unit tests

### DIFF
--- a/backend/__tests__/rateLimit.test.js
+++ b/backend/__tests__/rateLimit.test.js
@@ -1,0 +1,89 @@
+/**
+ * __tests__/rateLimit.test.js
+ * Isolated unit tests for the strict/sensitive rate limiters (#534) — the
+ * global and per-route limits documented in docs/api.md.
+ *
+ * Each test mounts the real exported limiter on a throwaway Express app (not
+ * the full server) and gives every test its own fake client IP via
+ * `X-Forwarded-For`, so hit counts from one test never leak into another even
+ * though `strictLimiter`/`sensitiveLimiter` are process-wide singletons with
+ * their own in-memory store.
+ */
+
+"use strict";
+
+const express = require("express");
+const request = require("supertest");
+const { strictLimiter, sensitiveLimiter } = require("../src/middleware/rateLimit");
+
+function buildApp(limiter) {
+  const app = express();
+  // trust proxy = 1 → req.ip is read from X-Forwarded-For, one hop back.
+  app.set("trust proxy", 1);
+  app.get("/probe", limiter, (req, res) => res.json({ ok: true }));
+  return app;
+}
+
+let ipCounter = 0;
+function uniqueIp() {
+  ipCounter += 1;
+  return `10.0.${(ipCounter >> 8) & 0xff}.${ipCounter & 0xff}`;
+}
+
+describe.each([
+  ["strictLimiter", strictLimiter, 20, "Too many requests to sensitive routes, please wait 1 minute."],
+  ["sensitiveLimiter", sensitiveLimiter, 10, "Too many requests to this endpoint, please wait 1 minute."],
+])("%s", (_name, limiter, max, message) => {
+  it(`allows ${max} requests per window through with RateLimit-* headers set`, async () => {
+    const app = buildApp(limiter);
+    const ip = uniqueIp();
+
+    for (let i = 0; i < max; i++) {
+      const res = await request(app).get("/probe").set("X-Forwarded-For", ip);
+      expect(res.status).toBe(200);
+      expect(res.headers["ratelimit-limit"]).toBe(String(max));
+      expect(res.headers["ratelimit-remaining"]).toBe(String(max - i - 1));
+      expect(res.headers["ratelimit-reset"]).toBeDefined();
+    }
+  });
+
+  it(`returns 429 with the documented body on the ${max + 1}th request in the window`, async () => {
+    const app = buildApp(limiter);
+    const ip = uniqueIp();
+
+    for (let i = 0; i < max; i++) {
+      const res = await request(app).get("/probe").set("X-Forwarded-For", ip);
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).get("/probe").set("X-Forwarded-For", ip);
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({ error: message });
+  });
+
+  it("resets the window after it expires, allowing requests again", async () => {
+    const app = buildApp(limiter);
+    const ip = uniqueIp();
+
+    for (let i = 0; i < max; i++) {
+      await request(app).get("/probe").set("X-Forwarded-For", ip);
+    }
+    const stillBlocked = await request(app).get("/probe").set("X-Forwarded-For", ip);
+    expect(stillBlocked.status).toBe(429);
+
+    // The store only checks wall-clock time lazily (on the next hit), so
+    // faking Date.now() past the 1-minute window is enough to simulate the
+    // window expiring — no real waiting, and no interference with
+    // supertest's own use of real timers for the HTTP request itself.
+    const realNow = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockImplementation(() => realNow + 60_001);
+
+    try {
+      const afterReset = await request(app).get("/probe").set("X-Forwarded-For", ip);
+      expect(afterReset.status).toBe(200);
+      expect(afterReset.headers["ratelimit-remaining"]).toBe(String(max - 1));
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -1397,6 +1397,53 @@ mod tests {
         assert_eq!(client.get_claimable(&id), DEPOSIT + RATE * 10);
     }
 
+    /// #556 — claim_stream and top_up_stream both land in the same ledger
+    /// (no advance_by between them). Accounting must stay exact: the top-up
+    /// must not retroactively change what was already claimable, and after a
+    /// second claim later on, claimed + whatever remains locked in the
+    /// contract must reconcile exactly against the total ever deposited.
+    #[test]
+    fn test_claim_and_top_up_same_ledger() {
+        let env = Env::default();
+        let (contract_id, client, token_id, payer, recipient) =
+            stream_fixture(&env, DEPOSIT * 2);
+        let token = token::Client::new(&env, &token_id);
+
+        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+
+        // Accrue some balance, then partially claim it.
+        advance_by(&env, 10);
+        let first_claim = client.claim_stream(&id, &recipient);
+        assert_eq!(first_claim, RATE * 10);
+
+        // top_up_stream happens in the very same ledger as the claim above —
+        // no advance_by call between them.
+        client.top_up_stream(&id, &payer, &DEPOSIT);
+
+        let after_topup = client.get_stream(&id);
+        assert_eq!(after_topup.deposited, DEPOSIT * 2);
+        assert_eq!(after_topup.claimed, RATE * 10);
+        // The top-up must not change what's claimable right now — the
+        // extended runway only shows up as ledgers advance.
+        assert_eq!(client.get_claimable(&id), 0);
+
+        advance_by(&env, 5);
+        let second_claim = client.claim_stream(&id, &recipient);
+        assert_eq!(second_claim, RATE * 5);
+
+        let final_stream = client.get_stream(&id);
+        assert_eq!(final_stream.claimed, RATE * 15);
+        assert_eq!(token.balance(&recipient), final_stream.claimed);
+
+        // Reconciliation: claimed + whatever remains locked in the contract
+        // for this stream equals the total ever deposited, exactly.
+        let remaining_in_contract = token.balance(&contract_id);
+        assert_eq!(
+            final_stream.claimed + remaining_in_contract,
+            after_topup.deposited
+        );
+    }
+
     #[test]
     fn test_close_stream_with_refund() {
         let env = Env::default();

--- a/frontend/e2e/network.spec.ts
+++ b/frontend/e2e/network.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+// #540 — e2e coverage for pages/network.tsx: it should reflect the active
+// Stellar network (via the Navbar badge, driven by NEXT_PUBLIC_STELLAR_NETWORK)
+// and render its Horizon-backed stats without errors.
+
+const LEDGER_RECORDS = Array.from({ length: 10 }, (_, i) => ({
+  sequence: 1_000_000 - i,
+  closed_at: new Date(Date.now() - i * 5_000).toISOString(),
+  successful_transaction_count: 42 + i,
+}));
+
+const FEE_STATS_BODY = {
+  last_ledger: '1000000',
+  last_ledger_base_fee: '100',
+  ledger_capacity_usage: '0.5',
+  fee_charged: {
+    max: '1000', min: '100', mode: '100',
+    p10: '100', p20: '100', p30: '100', p40: '100',
+    p50: '150', p60: '100', p70: '100', p80: '100',
+    p90: '100', p95: '200', p99: '500',
+  },
+  max_fee: {
+    max: '1000', min: '100', mode: '100',
+    p10: '100', p20: '100', p30: '100', p40: '100',
+    p50: '100', p60: '100', p70: '100', p80: '100',
+    p90: '100', p95: '100', p99: '100',
+  },
+};
+
+test.beforeEach(async ({ page }) => {
+  // Mock Freighter so no browser extension is needed (Navbar/WalletProvider
+  // probe for it on mount even though this page doesn't require a wallet).
+  await page.addInitScript(() => {
+    (window as any).freighter = {
+      isConnected: async () => ({ isConnected: false }),
+      getAddress: async () => ({ address: '' }),
+      getPublicKey: async () => ({ publicKey: '' }),
+      signTransaction: async () => ({ signedTxXdr: '' }),
+      requestAccess: async () => ({}),
+      isAllowed: async () => ({ isAllowed: false }),
+    };
+  });
+
+  // fetchNetworkStats() calls server.ledgers() and server.feeStats() against
+  // Horizon — mock both so the page renders deterministic data offline.
+  await page.route('**/horizon-testnet.stellar.org/ledgers**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ _embedded: { records: LEDGER_RECORDS } }),
+    });
+  });
+
+  await page.route('**/horizon-testnet.stellar.org/fee_stats**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(FEE_STATS_BODY),
+    });
+  });
+});
+
+test('network page shows the active network (testnet) indicator', async ({ page }) => {
+  await page.goto('/network');
+
+  // The e2e webServer runs with NEXT_PUBLIC_STELLAR_NETWORK=testnet, and the
+  // Navbar renders a "Testnet"/"Mainnet" badge sourced from that config.
+  const badge = page.getByText('Testnet', { exact: true });
+  await expect(badge).toBeVisible();
+});
+
+test('network stats render without errors', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+
+  await page.goto('/network');
+
+  await expect(
+    page.getByRole('heading', { name: 'Stellar Network Statistics' })
+  ).toBeVisible();
+
+  // Stats grid populated from the mocked Horizon responses.
+  await expect(page.getByText('#1,000,000').first()).toBeVisible();
+  await expect(page.getByText('Avg Transactions')).toBeVisible();
+  await expect(page.getByText('Base Fee', { exact: true })).toBeVisible();
+  await expect(page.getByText('P50 Fee')).toBeVisible();
+  await expect(page.getByText('P95 Fee')).toBeVisible();
+  await expect(page.getByText('P99 Fee')).toBeVisible();
+
+  // No error state and no uncaught client-side exceptions.
+  await expect(page.getByText('Network Error')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+});
+
+test('network page shows an error state when Horizon requests fail', async ({ page }) => {
+  await page.unroute('**/horizon-testnet.stellar.org/ledgers**');
+  await page.route('**/horizon-testnet.stellar.org/ledgers**', (route) => {
+    route.fulfill({ status: 503, contentType: 'application/json', body: '{}' });
+  });
+
+  await page.goto('/network');
+
+  await expect(page.getByRole('heading', { name: 'Network Error' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Try Again' })).toBeVisible();
+});

--- a/frontend/lib/ToastContext.tsx
+++ b/frontend/lib/ToastContext.tsx
@@ -35,6 +35,7 @@ const ToastContext = createContext<ToastContextValue | undefined>(undefined);
 
 let _counter = 0;
 
+/** Provides the toast context, managing the stacked toast list and auto-dismiss timers for descendants. */
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -77,6 +78,7 @@ const NOOP_CTX: ToastContextValue = {
   removeToast: () => {},
 };
 
+/** Access the toast context, falling back to a no-op implementation when used outside a ToastProvider. */
 export function useToastContext(): ToastContextValue {
   return useContext(ToastContext) ?? NOOP_CTX;
 }

--- a/frontend/lib/addressBook.ts
+++ b/frontend/lib/addressBook.ts
@@ -78,6 +78,7 @@ function dedupeContacts(contacts: AddressBookContact[]) {
   });
 }
 
+/** Load and merge all stored contacts (current and legacy storage keys), deduplicated by address. */
 export function loadAddressBookContacts(): AddressBookContact[] {
   const primaryContacts = readContactsFromKey(ADDRESS_BOOK_STORAGE_KEY);
   const legacyContacts = readContactsFromKey(LEGACY_CONTACTS_STORAGE_KEY);
@@ -85,6 +86,7 @@ export function loadAddressBookContacts(): AddressBookContact[] {
   return dedupeContacts([...primaryContacts, ...legacyContacts, ...legacyFavourites]);
 }
 
+/** Persist the given contacts to local storage and notify listeners via a custom event. */
 export function saveAddressBookContacts(contacts: AddressBookContact[]) {
   if (typeof window === "undefined") return;
 
@@ -96,6 +98,7 @@ export function saveAddressBookContacts(contacts: AddressBookContact[]) {
   }
 }
 
+/** Create a new contact or update an existing one matched by address, then persist and return the full contacts list. */
 export function upsertAddressBookContact(input: {
   nickname: string;
   address: string;
@@ -140,6 +143,7 @@ export function upsertAddressBookContact(input: {
   return contacts;
 }
 
+/** Remove a contact by id, persist the change, and return the updated contacts list. */
 export function deleteAddressBookContact(id: string) {
   const contacts = loadAddressBookContacts().filter((contact) => contact.id !== id);
   saveAddressBookContacts(contacts);
@@ -184,6 +188,7 @@ export function getAllTags(contacts: AddressBookContact[]): string[] {
   return Array.from(tagSet).sort();
 }
 
+/** Subscribe to contact list changes (same-tab custom events and cross-tab storage events), returning an unsubscribe function. */
 export function subscribeToAddressBookContacts(callback: (contacts: AddressBookContact[]) => void) {
   if (typeof window === "undefined") return () => undefined;
 
@@ -207,6 +212,7 @@ export function subscribeToAddressBookContacts(callback: (contacts: AddressBookC
   };
 }
 
+/** Returns the local storage key used for the primary address book contacts. */
 export function getAddressBookStorageKey() {
   return ADDRESS_BOOK_STORAGE_KEY;
 }

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -89,6 +89,7 @@ export const STELLAR_MINIMUM_ACCOUNT_BALANCE_XLM =
 const STELLAR_BASE_FEE_STROOPS_STRING = String(STELLAR_BASE_FEE_STROOPS);
 const ELEVATED_FEE_MAX_STROOPS = STELLAR_BASE_FEE_STROOPS * 10;
 
+/** Truncate a memo string so its UTF-8 encoding fits within the Stellar MEMO_TEXT byte limit. */
 export function truncateMemoText(memo: string): string {
   const encoder = new TextEncoder();
   if (encoder.encode(memo).length <= STELLAR_MEMO_TEXT_MAX_BYTES) {
@@ -158,6 +159,7 @@ export const SOROBAN_RPC_URL = getSorobanRpcUrl();
 
 /** Pre-configured Soroban RPC server instance. */
 let _sorobanServer: rpc.Server | null = null;
+/** Returns a cached Soroban RPC server instance, recreating it if the network URL has changed. */
 export function getSorobanServer(): rpc.Server {
   const currentUrl = getSorobanRpcUrl();
   if (!_sorobanServer || _sorobanServer.serverURL.toString() !== currentUrl) {
@@ -1283,6 +1285,7 @@ export async function getReceiptCount(payer: string): Promise<number> {
   }
 }
 
+/** Fetch the most recent payments for an account in chronological order, for sparkline charts. */
 export async function getRecentPaymentsForSparkline(
   publicKey: string,
   limit = 10
@@ -1860,6 +1863,7 @@ export interface EscrowRecord {
   status: "Pending" | "Released" | "Cancelled";
 }
 
+/** Build and preflight a Soroban transaction that creates a new escrow locking funds for a recipient until a release ledger. */
 export async function buildCreateEscrowTransaction({
   fromPublicKey,
   toPublicKey,
@@ -1923,14 +1927,17 @@ async function buildEscrowMutation(
   return sorobanServer.prepareTransaction(tx);
 }
 
+/** Build and preflight a Soroban transaction that claims a released escrow by id. */
 export function buildClaimEscrowTransaction(fromPublicKey: string, id: number) {
   return buildEscrowMutation(fromPublicKey, "claim_escrow", id);
 }
 
+/** Build and preflight a Soroban transaction that cancels a pending escrow by id. */
 export function buildCancelEscrowTransaction(fromPublicKey: string, id: number) {
   return buildEscrowMutation(fromPublicKey, "cancel_escrow", id);
 }
 
+/** Fetch an escrow record by id from the contract, returning null if it does not exist or the query fails. */
 export async function getEscrow(callerPublicKey: string, id: number): Promise<EscrowRecord | null> {
   if (!CONTRACT_ID) return null;
   try {
@@ -1961,6 +1968,7 @@ export async function getEscrow(callerPublicKey: string, id: number): Promise<Es
   }
 }
 
+/** Fetch the latest closed ledger sequence number from the Soroban RPC server. */
 export async function getCurrentLedger(): Promise<number> {
   const latest = await sorobanServer.getLatestLedger();
   return latest.sequence;

--- a/frontend/lib/stellarConfig.ts
+++ b/frontend/lib/stellarConfig.ts
@@ -21,6 +21,7 @@ export const DEFAULT_CONFIGS: Record<"testnet" | "mainnet", NetworkConfig> = {
   },
 };
 
+/** Read the active network config from local storage (or env vars during SSR), falling back to testnet defaults. */
 export function getNetworkConfig(): NetworkConfig {
   if (typeof window === "undefined") {
     // Server-side: use env vars as fallback
@@ -41,6 +42,7 @@ export function getNetworkConfig(): NetworkConfig {
   return DEFAULT_CONFIGS.testnet;
 }
 
+/** Persist the given network config to local storage so it's used on subsequent loads. */
 export function setNetworkConfig(config: NetworkConfig): void {
   if (typeof window !== "undefined") {
     localStorage.setItem("stellar-micropay:network", JSON.stringify(config));
@@ -65,6 +67,7 @@ export const NETWORK_PASSPHRASE = getNetworkPassphrase();
 
 /** Pre-configured Horizon server instance for the active network. */
 let _server: Horizon.Server | null = null;
+/** Returns a cached Horizon server instance, recreating it if the network URL has changed. */
 export function getServer(): Horizon.Server {
   const currentConfig = getNetworkConfig();
   if (!_server || _server.serverURL.toString() !== currentConfig.horizonUrl) {

--- a/frontend/lib/turrets.ts
+++ b/frontend/lib/turrets.ts
@@ -41,6 +41,7 @@ async function parseJson(res: Response) {
   return json.data;
 }
 
+/** Request a signed-challenge XDR from the backend for deploying a new Turrets automation. */
 export async function createTurretsChallenge(params: {
   ownerPublicKey: string;
   type: TurretsType;
@@ -60,6 +61,7 @@ export async function createTurretsChallenge(params: {
   }>;
 }
 
+/** Submit the signed challenge to deploy a new Turrets automation and return the created deployment. */
 export async function deployTurretsFunction(params: {
   ownerPublicKey: string;
   type: TurretsType;
@@ -76,6 +78,7 @@ export async function deployTurretsFunction(params: {
   return parseJson(res) as Promise<TurretsDeployment>;
 }
 
+/** Fetch all Turrets deployments owned by the given public key. */
 export async function listTurretsFunctions(ownerPublicKey: string) {
   const res = await fetch(
     `${apiBase()}/api/turrets?ownerPublicKey=${encodeURIComponent(ownerPublicKey)}`
@@ -84,11 +87,13 @@ export async function listTurretsFunctions(ownerPublicKey: string) {
   return parseJson(res) as Promise<TurretsDeployment[]>;
 }
 
+/** Fetch the execution history for a Turrets deployment by id. */
 export async function getTurretsHistory(id: string) {
   const res = await fetch(`${apiBase()}/api/turrets/${encodeURIComponent(id)}/history`);
   return parseJson(res) as Promise<TurretsExecutionHistory[]>;
 }
 
+/** Pause an active Turrets deployment by id. */
 export async function pauseTurretsFunction(id: string) {
   const res = await fetch(`${apiBase()}/api/turrets/${encodeURIComponent(id)}/pause`, {
     method: "POST",
@@ -97,6 +102,7 @@ export async function pauseTurretsFunction(id: string) {
   return parseJson(res) as Promise<TurretsDeployment>;
 }
 
+/** Resume a paused Turrets deployment by id. */
 export async function resumeTurretsFunction(id: string) {
   const res = await fetch(`${apiBase()}/api/turrets/${encodeURIComponent(id)}/resume`, {
     method: "POST",

--- a/frontend/lib/useCountUp.ts
+++ b/frontend/lib/useCountUp.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 
+/** React hook that animates a number counting up to `target` over `duration` ms, optionally starting only once the element scrolls into view. */
 export function useCountUp(target: number, duration: number = 2000, startOnView: boolean = true) {
   const [count, setCount] = useState(0);
   const [isVisible, setIsVisible] = useState(!startOnView);

--- a/frontend/lib/useToast.ts
+++ b/frontend/lib/useToast.ts
@@ -6,6 +6,7 @@
 
 import { useToastContext } from "@/lib/ToastContext";
 
+/** React hook returning a `showToast(msg, type)` helper backed by the global ToastContext. */
 export function useToast() {
   const { addToast } = useToastContext();
 

--- a/frontend/lib/useWallet.tsx
+++ b/frontend/lib/useWallet.tsx
@@ -46,6 +46,7 @@ function saveLastPublicKey(publicKey: string | null) {
   }
 }
 
+/** Provides the wallet context, tracking the connected public key and restoring the last-connected wallet on mount. */
 export function WalletProvider({ children }: { children: ReactNode }) {
   const [publicKey, setPublicKey] = useState<string | null>(() => loadLastPublicKey());
   const [isWalletReady, setIsWalletReady] = useState(false);
@@ -90,6 +91,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }
 
+/** Access the wallet context; throws if called outside a WalletProvider. */
 export function useWallet() {
   const context = useContext(WalletContext);
 

--- a/frontend/lib/wallet.ts
+++ b/frontend/lib/wallet.ts
@@ -22,7 +22,9 @@ import { getNetworkPassphrase } from "./stellar";
 // ─── SEP-0010 helpers ────────────────────────────────────────────────────────
 
 let jwtToken: string | null = null;
+/** Store the SEP-0010 JWT token in memory for the current session. */
 export function setJwtToken(token: string | null) { jwtToken = token; }
+/** Returns the SEP-0010 JWT token currently held in memory, or null if not authenticated. */
 export function getJwtToken() { return jwtToken; }
 
 async function fetchAuthChallenge(publicKey: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Add one-line TSDoc summaries to every exported function in `frontend/lib` that lacked one.
- Add a contract test exercising `claim_stream` and `top_up_stream` landing in the same ledger, asserting `claimed + remaining deposit` reconciles exactly against the total ever deposited.
- Add a Playwright e2e spec for `pages/network.tsx` covering the active-network indicator (testnet/mainnet badge) and stats rendering without errors, plus a Horizon-failure error-state case.
- Add isolated unit tests for the `strictLimiter`/`sensitiveLimiter` rate-limit middleware: pass-through with `RateLimit-*` headers, 429 with the documented body on the (N+1)th request, and window reset after expiry.

Closes #575
Closes #556
Closes #540
Closes #534

## Test plan
- [x] `cargo test test_claim_and_top_up_same_ledger` (contracts/stellar-micropay-contract) — passes
- [x] `npx jest __tests__/rateLimit.test.js` (backend) — 6/6 pass
- [x] `npx playwright test e2e/network.spec.ts` (frontend) — 3/3 pass
- [x] Manually verified no exported function in `frontend/lib/*.ts(x)` is left without a one-line TSDoc comment