### PR TITLE
fix: resolve a11y issues #600, #601, #602, #603

### DIFF
--- a/frontend/lib/useCountUp.ts
+++ b/frontend/lib/useCountUp.ts
@@ -6,6 +6,10 @@ export function useCountUp(target: number, duration: number = 2000, startOnView:
   const [hasAnimated, setHasAnimated] = useState(false);
   const elementRef = useRef<HTMLDivElement>(null);
 
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
   useEffect(() => {
     if (!startOnView) {
       setIsVisible(true);
@@ -28,6 +32,11 @@ export function useCountUp(target: number, duration: number = 2000, startOnView:
   useEffect(() => {
     if (!isVisible || hasAnimated) return;
 
+    if (prefersReducedMotion) {
+      setCount(target);
+      return;
+    }
+
     let startTime: number;
     const animate = (currentTime: number) => {
       if (!startTime) startTime = currentTime;
@@ -41,7 +50,7 @@ export function useCountUp(target: number, duration: number = 2000, startOnView:
     };
 
     requestAnimationFrame(animate);
-  }, [isVisible, target, duration, hasAnimated]);
+  }, [isVisible, target, duration, hasAnimated, prefersReducedMotion]);
 
   return { count, elementRef };
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -117,8 +117,14 @@ function AppShell({
   return (
     <>
       <div className="min-h-screen bg-white bg-grid transition-colors duration-300 dark:bg-cosmos-900">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:rounded-lg focus:bg-stellar-500 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:outline-none focus:ring-2 focus:ring-white"
+        >
+          Skip to main content
+        </a>
         <Navbar />
-        <main>
+        <main id="main-content" tabIndex={-1}>
           <Component {...pageProps} stellarURI={stellarURI} />
         </main>
         <InstallBanner />

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1081,6 +1081,7 @@ export default function Dashboard({ stellarURI }: DashboardProps) {
                     </div>
                     <button
                       onClick={() => setSelectedMonth(null)}
+                      aria-label="Close month details"
                       className="p-2 text-slate-400 hover:text-white transition-colors rounded-lg hover:bg-white/5"
                     >
                       <CloseIcon className="w-5 h-5" />

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -15,7 +15,7 @@
     --color-primary: #0ea5e9;
     --color-primary-glow: rgba(14, 165, 233, 0.3);
     --color-text: #e2e8f0;
-    --color-muted: #64748b;
+    --color-muted: #94a3b8;
     color-scheme: dark;
   }
 


### PR DESCRIPTION
Closes #600
Closes #601
Closes #602
Closes #603

## What changed

- Issue #600: Added aria-label to the close button in the dashboard month details widget
- Issue #601: Added visually-hidden-until-focused skip-to-content link as the first focusable element in _app.tsx
- Issue #602: Brightened dark-theme `--color-muted` from `#64748b` to `#94a3b8` to meet WCAG AA contrast (4.5:1+ on `#050a1a`)
- Issue #603: `useCountUp` now checks `prefers-reduced-motion` and skips animation, showing the final value immediately