### PR TITLE
test: unit tests for BatchPaymentForm, ExternalPaymentBanner, QRCodeModal, RecurringPayments (#504, #506, #511, #513)

### DIFF
--- a/frontend/__tests__/BatchPaymentForm.test.tsx
+++ b/frontend/__tests__/BatchPaymentForm.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import BatchPaymentForm from "@/components/BatchPaymentForm";
+
+jest.mock("@/lib/stellar", () => ({
+  isValidStellarAddress: jest.fn(
+    (addr: string) => typeof addr === "string" && addr.startsWith("G") && addr.length === 56
+  ),
+  buildPaymentTransaction: jest.fn(() =>
+    Promise.resolve({ toXDR: () => "mocked-xdr" })
+  ),
+  submitTransaction: jest.fn(() => Promise.resolve({ hash: "tx-abc123" })),
+  STELLAR_MEMO_TEXT_MAX_BYTES: 28,
+  STELLAR_MINIMUM_ACCOUNT_BALANCE_XLM: 1,
+  truncateMemoText: jest.fn((text: string) => text),
+}));
+
+jest.mock("@/lib/wallet", () => ({
+  signTransactionWithWallet: jest.fn(() =>
+    Promise.resolve({ signedXDR: "signed-xdr", error: null })
+  ),
+}));
+
+const OWN_KEY   = "GOWN1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+const VALID_ADDR = "GDEST234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+
+const defaultProps = {
+  publicKey: OWN_KEY,
+  xlmBalance: "100",
+  onBatchSuccess: jest.fn(),
+};
+
+describe("BatchPaymentForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with a single empty recipient row by default", () => {
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    expect(screen.getAllByPlaceholderText("G...")).toHaveLength(1);
+    expect(screen.getByText("1 / 10")).toBeInTheDocument();
+  });
+
+  it("adds a new recipient row when Add recipient is clicked", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /Add recipient/i }));
+
+    expect(screen.getAllByPlaceholderText("G...")).toHaveLength(2);
+    expect(screen.getByText("2 / 10")).toBeInTheDocument();
+  });
+
+  it("removes a recipient row when Remove is clicked", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /Add recipient/i }));
+    expect(screen.getAllByPlaceholderText("G...")).toHaveLength(2);
+
+    const removeButtons = screen.getAllByRole("button", { name: /Remove/i });
+    await user.click(removeButtons[0]);
+
+    expect(screen.getAllByPlaceholderText("G...")).toHaveLength(1);
+    expect(screen.getByText("1 / 10")).toBeInTheDocument();
+  });
+
+  it("Send batch button is disabled when no row has a valid address and amount", () => {
+    render(<BatchPaymentForm {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /Send batch/i })).toBeDisabled();
+  });
+
+  it("Send batch button is enabled once a row has a valid address and positive amount", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    await user.type(screen.getByPlaceholderText("G..."), VALID_ADDR);
+    await user.type(screen.getByPlaceholderText("0.5"), "2");
+
+    expect(screen.getByRole("button", { name: /Send batch/i })).not.toBeDisabled();
+  });
+
+  it("computes the total amount correctly across multiple rows", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    await user.type(screen.getAllByPlaceholderText("0.5")[0], "2.5");
+    await user.click(screen.getByRole("button", { name: /Add recipient/i }));
+    await user.type(screen.getAllByPlaceholderText("0.5")[1], "7.5");
+
+    expect(screen.getByText(/10\.0000000 XLM/)).toBeInTheDocument();
+  });
+
+  it("shows inline validation error for an invalid Stellar address after batch submit", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    // Add a second valid row so the button is enabled
+    await user.click(screen.getByRole("button", { name: /Add recipient/i }));
+    const addressInputs = screen.getAllByPlaceholderText("G...");
+    const amountInputs  = screen.getAllByPlaceholderText("0.5");
+
+    await user.type(addressInputs[1], VALID_ADDR);
+    await user.type(amountInputs[1], "1");
+
+    // First row intentionally left with bad address
+    await user.type(addressInputs[0], "INVALID_ADDRESS");
+    await user.type(amountInputs[0], "1");
+
+    await user.click(screen.getByRole("button", { name: /Send batch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid Stellar address/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows inline validation error when amount is zero or missing", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /Add recipient/i }));
+    const addressInputs = screen.getAllByPlaceholderText("G...");
+    const amountInputs  = screen.getAllByPlaceholderText("0.5");
+
+    // Second row is valid; enables submit
+    await user.type(addressInputs[1], VALID_ADDR);
+    await user.type(amountInputs[1], "1");
+
+    // First row has valid address but no amount
+    await user.type(addressInputs[0], VALID_ADDR);
+
+    await user.click(screen.getByRole("button", { name: /Send batch/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Amount must be greater than 0/i)).toBeInTheDocument();
+    });
+  });
+
+  it("warns when total XLM exceeds available balance", async () => {
+    const user = userEvent.setup();
+    render(<BatchPaymentForm {...defaultProps} xlmBalance="5" />);
+
+    await user.type(screen.getByPlaceholderText("G..."), VALID_ADDR);
+    await user.type(screen.getByPlaceholderText("0.5"), "10");
+
+    expect(
+      screen.getByText(/Total exceeds your available XLM balance/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/ExternalPaymentBanner.test.tsx
+++ b/frontend/__tests__/ExternalPaymentBanner.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import ExternalPaymentBanner from "@/components/ExternalPaymentBanner";
+
+describe("ExternalPaymentBanner", () => {
+  const onDismiss = jest.fn();
+
+  beforeEach(() => {
+    onDismiss.mockClear();
+  });
+
+  it("is visible when rendered (visible under the condition that triggers it)", () => {
+    render(<ExternalPaymentBanner onDismiss={onDismiss} />);
+    expect(
+      screen.getByText(/Payment request from external app/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the default message when no message prop is supplied", () => {
+    render(<ExternalPaymentBanner onDismiss={onDismiss} />);
+    expect(
+      screen.getByText(/Send a payment using the pre-filled form below/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a custom message when the message prop is provided", () => {
+    render(
+      <ExternalPaymentBanner
+        message="Pay 5 XLM to charity.stellar"
+        onDismiss={onDismiss}
+      />
+    );
+    expect(screen.getByText("Pay 5 XLM to charity.stellar")).toBeInTheDocument();
+  });
+
+  it("shows the origin domain when the originDomain prop is provided", () => {
+    render(
+      <ExternalPaymentBanner originDomain="app.example.com" onDismiss={onDismiss} />
+    );
+    expect(screen.getByText("app.example.com")).toBeInTheDocument();
+  });
+
+  it("does not render an origin line when originDomain is omitted", () => {
+    render(<ExternalPaymentBanner onDismiss={onDismiss} />);
+    expect(screen.queryByText(/Origin:/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onDismiss when the Dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ExternalPaymentBanner onDismiss={onDismiss} />);
+
+    await user.click(screen.getByRole("button", { name: /Dismiss/i }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("banner disappears after the parent acts on the dismiss callback", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [visible, setVisible] = React.useState(true);
+      return visible ? (
+        <ExternalPaymentBanner onDismiss={() => setVisible(false)} />
+      ) : (
+        <p>dismissed</p>
+      );
+    }
+
+    render(<Harness />);
+    expect(
+      screen.getByText(/Payment request from external app/i)
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Dismiss/i }));
+
+    expect(screen.queryByText(/Payment request from external app/i)).not.toBeInTheDocument();
+    expect(screen.getByText("dismissed")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when only the required onDismiss prop is provided", () => {
+    expect(() => render(<ExternalPaymentBanner onDismiss={onDismiss} />)).not.toThrow();
+  });
+});

--- a/frontend/__tests__/PaymentStatusModal.test.tsx
+++ b/frontend/__tests__/PaymentStatusModal.test.tsx
@@ -380,9 +380,9 @@ describe("PaymentStatusModal", () => {
     it("renders with proper ARIA attributes", async () => {
       const user = userEvent.setup();
       render(<ModalHarness status="building" />);
-      
+
       await user.click(screen.getByRole("button", { name: "Open modal" }));
-      
+
       const dialog = screen.getByRole("dialog");
       expect(dialog).toHaveAttribute("aria-modal", "true");
       expect(dialog).toHaveAttribute("aria-labelledby", "payment-status-title");
@@ -391,11 +391,92 @@ describe("PaymentStatusModal", () => {
     it("has proper heading for screen readers", async () => {
       const user = userEvent.setup();
       render(<ModalHarness status="success" />);
-      
+
       await user.click(screen.getByRole("button", { name: "Open modal" }));
-      
+
       const title = screen.getByRole("heading", { level: 3 });
       expect(title).toHaveAttribute("id", "payment-status-title");
+    });
+  });
+
+  describe("focus trap & focus-return (#597)", () => {
+    it("moves focus into the modal when it opens", async () => {
+      const user = userEvent.setup();
+      render(<ModalHarness status="success" />);
+
+      await user.click(screen.getByRole("button", { name: "Open modal" }));
+      const dialog = await screen.findByRole("dialog");
+
+      await waitFor(() => {
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+    });
+
+    it("Tab key keeps focus inside the modal while it is open", async () => {
+      const user = userEvent.setup();
+      render(<ModalHarness status="success" />);
+
+      await user.click(screen.getByRole("button", { name: "Open modal" }));
+      const dialog = await screen.findByRole("dialog");
+
+      await waitFor(() => {
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+
+      // Tab once — should still be inside the modal
+      await user.tab();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+
+      // Tab again — still inside
+      await user.tab();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    it("Shift+Tab also keeps focus inside the modal", async () => {
+      const user = userEvent.setup();
+      render(<ModalHarness status="success" />);
+
+      await user.click(screen.getByRole("button", { name: "Open modal" }));
+      const dialog = await screen.findByRole("dialog");
+
+      await waitFor(() => {
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
+
+      await user.tab({ shift: true });
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    it("returns focus to the opener button after the modal closes via Escape", async () => {
+      const user = userEvent.setup();
+      render(<ModalHarness status="success" />);
+
+      const opener = screen.getByRole("button", { name: "Open modal" });
+      await user.click(opener);
+
+      await screen.findByRole("dialog");
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        expect(opener).toHaveFocus();
+      });
+    });
+
+    it("returns focus to the opener button after the modal closes via Close button", async () => {
+      const user = userEvent.setup();
+      render(<ModalHarness status="success" />);
+
+      const opener = screen.getByRole("button", { name: "Open modal" });
+      await user.click(opener);
+
+      await screen.findByRole("dialog");
+      const closeBtn = screen.getByRole("button", { name: /^Close$/i });
+      await user.click(closeBtn);
+
+      await waitFor(() => {
+        expect(opener).toHaveFocus();
+      });
     });
   });
 });

--- a/frontend/__tests__/QRCodeModal.test.tsx
+++ b/frontend/__tests__/QRCodeModal.test.tsx
@@ -32,7 +32,95 @@ function ModalHarness() {
   );
 }
 
-describe("QRCodeModal", () => {
+const PUBLIC_KEY = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+
+describe("QRCodeModal — address encoding & rendering (#511)", () => {
+  it("renders a QR code canvas for the provided address", () => {
+    render(
+      <QRCodeModal isOpen onClose={jest.fn()} publicKey={PUBLIC_KEY} />
+    );
+    expect(screen.getByTestId("qr-code-canvas")).toBeInTheDocument();
+  });
+
+  it("encodes the address into the Stellar SEP-0007 payment URI", () => {
+    render(
+      <QRCodeModal isOpen onClose={jest.fn()} publicKey={PUBLIC_KEY} />
+    );
+    expect(
+      screen.getByText(`web+stellar:pay?destination=${PUBLIC_KEY}`)
+    ).toBeInTheDocument();
+  });
+
+  it("appends amount to the URI when a positive amount is provided", () => {
+    render(
+      <QRCodeModal isOpen onClose={jest.fn()} publicKey={PUBLIC_KEY} amount="42.5" />
+    );
+    expect(
+      screen.getByText(`web+stellar:pay?destination=${PUBLIC_KEY}&amount=42.5`)
+    ).toBeInTheDocument();
+  });
+
+  it("omits amount from URI when amount is zero", () => {
+    render(
+      <QRCodeModal isOpen onClose={jest.fn()} publicKey={PUBLIC_KEY} amount="0" />
+    );
+    expect(
+      screen.getByText(`web+stellar:pay?destination=${PUBLIC_KEY}`)
+    ).toBeInTheDocument();
+  });
+
+  it("updates the displayed URI when the publicKey prop changes", () => {
+    const KEY_A = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+    const KEY_B = "GXYZ1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+    const { rerender } = render(
+      <QRCodeModal isOpen onClose={jest.fn()} publicKey={KEY_A} />
+    );
+    expect(
+      screen.getByText(`web+stellar:pay?destination=${KEY_A}`)
+    ).toBeInTheDocument();
+
+    rerender(<QRCodeModal isOpen onClose={jest.fn()} publicKey={KEY_B} />);
+    expect(
+      screen.getByText(`web+stellar:pay?destination=${KEY_B}`)
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when the Close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QRCodeModal isOpen onClose={onClose} publicKey={PUBLIC_KEY} />);
+
+    await user.click(screen.getByRole("button", { name: /^Close$/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the Close icon button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QRCodeModal isOpen onClose={onClose} publicKey={PUBLIC_KEY} />);
+
+    await user.click(screen.getByRole("button", { name: /Close QR code modal/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the Download QR button", () => {
+    render(<QRCodeModal isOpen onClose={jest.fn()} publicKey={PUBLIC_KEY} />);
+    expect(
+      screen.getByRole("button", { name: /Download QR/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when isOpen is false", () => {
+    render(
+      <QRCodeModal isOpen={false} onClose={jest.fn()} publicKey={PUBLIC_KEY} />
+    );
+    expect(screen.queryByTestId("qr-code-canvas")).not.toBeInTheDocument();
+  });
+});
+
+describe("QRCodeModal — focus trap & keyboard (#511)", () => {
   it("traps focus, closes on Escape, and returns focus to the opener", async () => {
     const user = userEvent.setup();
     render(<ModalHarness />);

--- a/frontend/__tests__/RecurringPayments.test.tsx
+++ b/frontend/__tests__/RecurringPayments.test.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import RecurringPayments from "@/components/RecurringPayments";
+
+const RECIPIENT = "GDEST234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567";
+
+function renderRP(onPayNow = jest.fn()) {
+  return render(<RecurringPayments onPayNow={onPayNow} />);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("RecurringPayments — schedule creation (#513)", () => {
+  it("shows an empty state message when no schedules exist", () => {
+    renderRP();
+    expect(screen.getByText(/No recurring schedules yet/i)).toBeInTheDocument();
+  });
+
+  it("opens the new-schedule form when '+ New schedule' is clicked", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+
+    expect(screen.getByText(/New recurring payment/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create/i })).toBeInTheDocument();
+  });
+
+  it("creates a new schedule with a valid recipient and amount", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+
+    await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+    await user.clear(screen.getByPlaceholderText("0.0000000"));
+    await user.type(screen.getByPlaceholderText("0.0000000"), "5");
+
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+
+    expect(screen.getByText(/5 XLM/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No recurring schedules yet/i)).not.toBeInTheDocument();
+  });
+
+  it("creates a weekly schedule and shows the frequency label", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+
+    await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+    await user.clear(screen.getByPlaceholderText("0.0000000"));
+    await user.type(screen.getByPlaceholderText("0.0000000"), "2");
+    await user.selectOptions(screen.getByRole("combobox"), "weekly");
+
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+
+    expect(screen.getByText(/weekly/i)).toBeInTheDocument();
+  });
+
+  it("rejects submission when recipient is missing and shows an error", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+
+    await user.clear(screen.getByPlaceholderText("0.0000000"));
+    await user.type(screen.getByPlaceholderText("0.0000000"), "3");
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+
+    expect(screen.getByText(/Recipient is required/i)).toBeInTheDocument();
+  });
+
+  it("rejects submission when amount is zero or invalid and shows an error", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+
+    await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+    // Leave amount empty
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+
+    expect(screen.getByText(/Enter a valid amount/i)).toBeInTheDocument();
+  });
+
+  it("dismisses the form when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+    expect(screen.getByText(/New recurring payment/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(screen.queryByText(/New recurring payment/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("RecurringPayments — listing existing schedules (#513)", () => {
+  it("lists multiple schedules after creation", async () => {
+    const user = userEvent.setup();
+    renderRP();
+
+    for (const amount of ["1", "2"]) {
+      await user.click(screen.getByText(/\+ New schedule/i));
+      await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+      await user.clear(screen.getByPlaceholderText("0.0000000"));
+      await user.type(screen.getByPlaceholderText("0.0000000"), amount);
+      await user.click(screen.getByRole("button", { name: /Create/i }));
+    }
+
+    expect(screen.getByText(/1 XLM/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 XLM/i)).toBeInTheDocument();
+  });
+
+  it("persists schedules to localStorage so they survive a re-render", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderRP();
+
+    await user.click(screen.getByText(/\+ New schedule/i));
+    await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+    await user.clear(screen.getByPlaceholderText("0.0000000"));
+    await user.type(screen.getByPlaceholderText("0.0000000"), "9");
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+    unmount();
+
+    renderRP();
+    expect(screen.getByText(/9 XLM/i)).toBeInTheDocument();
+  });
+});
+
+describe("RecurringPayments — pause / delete actions (#513)", () => {
+  async function createSchedule(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByText(/\+ New schedule/i));
+    await user.type(screen.getByPlaceholderText("G..."), RECIPIENT);
+    await user.clear(screen.getByPlaceholderText("0.0000000"));
+    await user.type(screen.getByPlaceholderText("0.0000000"), "3");
+    await user.click(screen.getByRole("button", { name: /Create/i }));
+  }
+
+  it("pauses a schedule when the Pause button is clicked", async () => {
+    const user = userEvent.setup();
+    renderRP();
+    await createSchedule(user);
+
+    await user.click(screen.getByRole("button", { name: /Pause schedule/i }));
+
+    expect(screen.getByText(/Paused/i)).toBeInTheDocument();
+  });
+
+  it("resumes a paused schedule when the Play button is clicked", async () => {
+    const user = userEvent.setup();
+    renderRP();
+    await createSchedule(user);
+
+    await user.click(screen.getByRole("button", { name: /Pause schedule/i }));
+    expect(screen.getByText(/Paused/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Resume schedule/i }));
+    expect(screen.queryByText(/Paused/i)).not.toBeInTheDocument();
+  });
+
+  it("removes a schedule when the Delete button is clicked", async () => {
+    const user = userEvent.setup();
+    renderRP();
+    await createSchedule(user);
+
+    expect(screen.getByText(/3 XLM/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Delete schedule/i }));
+
+    expect(screen.queryByText(/3 XLM/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/No recurring schedules yet/i)).toBeInTheDocument();
+  });
+
+  it("opens the edit form pre-filled with the schedule values", async () => {
+    const user = userEvent.setup();
+    renderRP();
+    await createSchedule(user);
+
+    await user.click(screen.getByRole("button", { name: /Edit schedule/i }));
+
+    expect(screen.getByText(/Edit schedule/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("0.0000000")).toHaveValue(3);
+  });
+});

--- a/frontend/components/PaymentStatusModal.tsx
+++ b/frontend/components/PaymentStatusModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 export type PaymentStepId = "building" | "signing" | "submitting" | "confirming";
 export type PaymentFlowStatus =
@@ -54,12 +54,67 @@ export default function PaymentStatusModal({
 
   const isTerminal = status === "success" || status === "error";
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (!isOpen) return;
 
     setNow(Date.now());
     const interval = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(interval);
+  }, [isOpen]);
+
+  // Focus trap and focus-return (#597)
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const active = document.activeElement;
+    returnFocusRef.current = active instanceof HTMLElement ? active : null;
+
+    const frame = window.requestAnimationFrame(() => {
+      const focusable = getFocusableElements(dialogRef.current);
+      const target = focusable[0] ?? dialogRef.current;
+      target?.focus();
+    });
+
+    const handleTab = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const current = document.activeElement;
+
+      if (event.shiftKey) {
+        if (!current || !dialogRef.current?.contains(current) || current === first) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (!current || !dialogRef.current?.contains(current) || current === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleTab);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("keydown", handleTab);
+      const target = returnFocusRef.current;
+      if (target) {
+        window.setTimeout(() => target.focus(), 0);
+      }
+    };
   }, [isOpen]);
 
   useEffect(() => {
@@ -97,10 +152,12 @@ export default function PaymentStatusModal({
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/80 p-4 backdrop-blur-sm">
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="payment-status-title"
-        className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-slate-900/95 shadow-2xl"
+        tabIndex={-1}
+        className="w-full max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-slate-900/95 shadow-2xl outline-none"
       >
         <div className="border-b border-white/10 px-6 py-5">
           <div className="flex items-start justify-between gap-4">
@@ -348,6 +405,22 @@ function StepIcon({
   if (id === "signing") return <SignatureIcon className="h-4 w-4 text-slate-300" />;
   if (id === "submitting") return <UploadIcon className="h-4 w-4 text-slate-300" />;
   return <SparklesIcon className="h-4 w-4 text-slate-300" />;
+}
+
+function getFocusableElements(root: HTMLElement | null): HTMLElement[] {
+  if (!root) return [];
+  const selector = [
+    'button:not([disabled])',
+    '[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(",");
+  return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter((el) => {
+    const style = window.getComputedStyle(el);
+    return style.visibility !== "hidden" && style.display !== "none";
+  });
 }
 
 function CheckIcon({ className }: { className?: string }) {


### PR DESCRIPTION
## Summary

Adds unit test suites (Jest + React Testing Library) for four previously untested frontend components, and adds a focus trap + focus-return implementation to PaymentStatusModal.

### #504 — BatchPaymentForm
- Single empty recipient row rendered by default; counter shows `1 / 10`
- Add recipient creates a second row; Remove reduces the count
- Send batch button is disabled when no row is valid; enabled once a valid address + positive amount exist
- Inline validation errors surface after submission: invalid Stellar address → `Invalid Stellar address`, zero/missing amount → `Amount must be greater than 0`
- Total XLM is summed correctly across multiple rows
- Balance-exceeded warning renders when total > available balance

### #506 — ExternalPaymentBanner
- Banner is visible when rendered (simulates the parent condition being met)
- Default message shown when `message` prop is omitted; custom message rendered when supplied
- `originDomain` prop rendered; absent when not provided
- Dismiss button calls `onDismiss` once
- Stateful harness confirms banner disappears after parent acts on the dismiss callback

### #511 — QRCodeModal
Extended the existing `QRCodeModal.test.tsx` with coverage of all acceptance criteria:
- QR canvas element is present when `isOpen=true`
- SEP-0007 URI (`web+stellar:pay?destination=...`) encodes the address; amount appended only when positive
- URI updates on `publicKey` prop change (rerender test)
- Both the icon close button and the text Close button call `onClose`
- Download QR button is rendered
- Nothing rendered when `isOpen=false`

### #513 — RecurringPayments
- Empty state shown before any schedule exists
- `+ New schedule` opens the form; Cancel closes it
- Form creation: valid inputs persist a schedule visible in the list
- Invalid inputs (empty recipient, zero/missing amount) surface inline errors
- Schedules survive unmount/remount via localStorage
- Multiple schedules listed simultaneously
- Pause → shows Paused label; Resume → removes label
- Delete removes the schedule and restores the empty-state message
- Edit opens the form pre-filled with the schedule's current values

### #597 — PaymentStatusModal: focus trap & focus-return
Implements WCAG 2.1 SC 2.1.2 keyboard accessibility requirements:
- `useRef` + `useEffect` on `isOpen` saves the previously focused element and moves focus into the modal (first focusable element or the dialog root) via `requestAnimationFrame`
- `keydown` listener traps Tab / Shift+Tab so focus never leaves the modal while open
- On close (Escape or Close button) focus is restored to the element that triggered the modal via `setTimeout(..., 0)` to survive React's render cycle
- Added `getFocusableElements` helper (same pattern as QRCodeModal)
- Extended `PaymentStatusModal.test.tsx` with 5 new tests: focus moves into modal on open, Tab stays inside, Shift+Tab stays inside, Escape restores opener focus, Close-button restores opener focus

Closes #504
Closes #506
Closes #511
Closes #513
Closes #597