### PR TITLE
test: add unit tests for Toast, QuickSendModal, TradeForm, PaymentLinkGenerator

### DIFF
--- a/frontend/__tests__/PaymentLinkGenerator.test.tsx
+++ b/frontend/__tests__/PaymentLinkGenerator.test.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import PaymentLinkGenerator from "@/components/PaymentLinkGenerator";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockBuildPaymentLinkUrl = jest.fn();
+const mockRememberPaymentLink = jest.fn();
+const mockListPaymentLinks = jest.fn(() => []);
+
+jest.mock("@/lib/paymentLinks", () => ({
+  buildPaymentLinkUrl: (...args: unknown[]) => mockBuildPaymentLinkUrl(...args),
+  rememberPaymentLink: (...args: unknown[]) => mockRememberPaymentLink(...args),
+  listPaymentLinks: () => mockListPaymentLinks(),
+}));
+
+// qrcode.react renders nothing in jsdom — stub it to avoid canvas errors
+jest.mock("qrcode.react", () => ({
+  QRCodeSVG: ({ value }: { value: string }) => <svg data-testid="qr-code" data-value={value} />,
+}));
+
+// ─── clipboard ────────────────────────────────────────────────────────────────
+
+const writeTextMock = jest.fn().mockResolvedValue(undefined);
+Object.defineProperty(navigator, "clipboard", {
+  value: { writeText: writeTextMock },
+  writable: true,
+  configurable: true,
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const VALID_DESTINATION = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234";
+const FAKE_URL = "https://example.com/pay?to=GABC&amount=10";
+
+function fillForm(user: ReturnType<typeof userEvent.setup>, opts: { destination?: string; amount?: string; memo?: string } = {}) {
+  const destination = opts.destination ?? VALID_DESTINATION;
+  const amount = opts.amount ?? "10";
+  return async () => {
+    await user.type(screen.getByPlaceholderText("G..."), destination);
+    await user.clear(screen.getByPlaceholderText("1.0"));
+    await user.type(screen.getByPlaceholderText("1.0"), amount);
+    if (opts.memo) {
+      await user.type(screen.getByPlaceholderText("ID: 123"), opts.memo);
+    }
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("PaymentLinkGenerator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildPaymentLinkUrl.mockReturnValue(FAKE_URL);
+    mockListPaymentLinks.mockReturnValue([]);
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it("renders the form fields", () => {
+    render(<PaymentLinkGenerator />);
+    expect(screen.getByPlaceholderText("G...")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("1.0")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("ID: 123")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create payment link/i })).toBeInTheDocument();
+  });
+
+  it("disables the generate button when destination or amount is empty", () => {
+    render(<PaymentLinkGenerator />);
+    expect(screen.getByRole("button", { name: /create payment link/i })).toBeDisabled();
+  });
+
+  // ── Link generation ────────────────────────────────────────────────────────
+
+  it("generates a link containing the entered amount and destination", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    expect(mockBuildPaymentLinkUrl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ amount: "10", destination: VALID_DESTINATION })
+    );
+
+    expect(screen.getByDisplayValue(FAKE_URL)).toBeInTheDocument();
+  });
+
+  it("includes memo in the link payload when provided", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user, { memo: "coffee" })();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    expect(mockBuildPaymentLinkUrl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ memo: "coffee" })
+    );
+  });
+
+  it("does not generate a link when destination is empty", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    // Only type an amount, no destination
+    await user.clear(screen.getByPlaceholderText("1.0"));
+    await user.type(screen.getByPlaceholderText("1.0"), "5");
+
+    expect(screen.getByRole("button", { name: /create payment link/i })).toBeDisabled();
+    expect(mockBuildPaymentLinkUrl).not.toHaveBeenCalled();
+  });
+
+  // ── Expiry encoding ────────────────────────────────────────────────────────
+
+  it("passes validUntil=null when expiry is set to 'never'", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    // "Never Expire" is the default selection
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    expect(mockBuildPaymentLinkUrl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ validUntil: null })
+    );
+  });
+
+  it("passes a future validUntil timestamp when '24 Hours' expiry is selected", async () => {
+    const user = userEvent.setup();
+    const before = Date.now();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.selectOptions(screen.getByRole("combobox"), "24 Hours");
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    const callPayload = mockBuildPaymentLinkUrl.mock.calls[0][1];
+    expect(callPayload.validUntil).toBeGreaterThan(before);
+    // Should be approximately 24 h from now (within a 5-second tolerance)
+    expect(callPayload.validUntil).toBeCloseTo(before + 24 * 60 * 60 * 1000, -4);
+  });
+
+  it("passes a 7-day validUntil timestamp when '7 Days' expiry is selected", async () => {
+    const user = userEvent.setup();
+    const before = Date.now();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.selectOptions(screen.getByRole("combobox"), "7 Days");
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    const callPayload = mockBuildPaymentLinkUrl.mock.calls[0][1];
+    expect(callPayload.validUntil).toBeGreaterThan(before);
+    expect(callPayload.validUntil).toBeCloseTo(before + 7 * 24 * 60 * 60 * 1000, -4);
+  });
+
+  // ── Clipboard ─────────────────────────────────────────────────────────────
+
+  it("copies the generated link to clipboard when Copy is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    expect(writeTextMock).toHaveBeenCalledWith(FAKE_URL);
+  });
+
+  it("shows 'Copied!' feedback after clicking copy", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ delay: null });
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+    await user.click(screen.getByRole("button", { name: /copy/i }));
+
+    expect(screen.getByRole("button", { name: /copied!/i })).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(2100));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^copy$/i })).toBeInTheDocument()
+    );
+    jest.useRealTimers();
+  });
+
+  // ── QR code ───────────────────────────────────────────────────────────────
+
+  it("shows QR code when 'Show QR' is clicked after generation", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+    await user.click(screen.getByRole("button", { name: /show qr/i }));
+
+    const qr = screen.getByTestId("qr-code");
+    expect(qr).toBeInTheDocument();
+    expect(qr).toHaveAttribute("data-value", FAKE_URL);
+  });
+
+  it("hides QR code when 'Hide QR' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+    await user.click(screen.getByRole("button", { name: /show qr/i }));
+    await user.click(screen.getByRole("button", { name: /hide qr/i }));
+
+    expect(screen.queryByTestId("qr-code")).not.toBeInTheDocument();
+  });
+
+  // ── Link history ──────────────────────────────────────────────────────────
+
+  it("shows link history section when 'Show Link History' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await user.click(screen.getByRole("button", { name: /show link history/i }));
+    expect(screen.getByText(/no links found/i)).toBeInTheDocument();
+  });
+
+  it("calls rememberPaymentLink after generating a link", async () => {
+    const user = userEvent.setup();
+    render(<PaymentLinkGenerator />);
+
+    await fillForm(user)();
+    await user.click(screen.getByRole("button", { name: /create payment link/i }));
+
+    expect(mockRememberPaymentLink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/QuickSendModal.test.tsx
+++ b/frontend/__tests__/QuickSendModal.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import QuickSendModal from "@/components/QuickSendModal";
+
+// Stub the heavy SendPaymentForm so we can test the modal shell in isolation
+jest.mock("@/components/SendPaymentForm", () => {
+  const React = require("react");
+  return function MockSendPaymentForm({
+    publicKey,
+    xlmBalance,
+    onSuccess,
+  }: {
+    publicKey: string;
+    xlmBalance: string;
+    onSuccess?: () => void;
+  }) {
+    return (
+      <div data-testid="send-payment-form">
+        <span data-testid="mock-public-key">{publicKey}</span>
+        <span data-testid="mock-xlm-balance">{xlmBalance}</span>
+        <button type="button" onClick={onSuccess}>
+          Confirm payment
+        </button>
+      </div>
+    );
+  };
+});
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  onClose: jest.fn(),
+  publicKey: "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234",
+  xlmBalance: "250.00",
+  usdcBalance: "10.00",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.body.style.overflow = "";
+});
+
+describe("QuickSendModal", () => {
+  it("renders nothing when isOpen=false", () => {
+    render(<QuickSendModal {...DEFAULT_PROPS} isOpen={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders the modal dialog when isOpen=true", () => {
+    render(<QuickSendModal {...DEFAULT_PROPS} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Quick send payment")).toBeInTheDocument();
+  });
+
+  it("passes publicKey and xlmBalance down to SendPaymentForm", () => {
+    render(<QuickSendModal {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId("mock-public-key")).toHaveTextContent(DEFAULT_PROPS.publicKey);
+    expect(screen.getByTestId("mock-xlm-balance")).toHaveTextContent(DEFAULT_PROPS.xlmBalance);
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QuickSendModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    await user.click(screen.getByLabelText("Close quick send modal"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QuickSendModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when clicking the backdrop", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QuickSendModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    // The backdrop is the dialog element itself (overlayRef)
+    const dialog = screen.getByRole("dialog");
+    await user.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the inner form signals success", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QuickSendModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: "Confirm payment" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks body scroll while open and restores it on close", () => {
+    const { unmount } = render(<QuickSendModal {...DEFAULT_PROPS} isOpen={true} />);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("shows the Esc keyboard hint", () => {
+    render(<QuickSendModal {...DEFAULT_PROPS} />);
+    expect(screen.getByText("Esc")).toBeInTheDocument();
+  });
+
+  it("does not call onClose when clicking inside the modal panel", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<QuickSendModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    // Click the inner form card — not the backdrop
+    await user.click(screen.getByTestId("send-payment-form"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/Toast.test.tsx
+++ b/frontend/__tests__/Toast.test.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import Toast, { ToastContainer } from "@/components/Toast";
+import { ToastProvider, useToastContext } from "@/lib/ToastContext";
+
+jest.mock("@/components/icons", () => ({
+  CheckIcon: ({ className }: { className?: string }) => <svg data-testid="check-icon" className={className} />,
+  AlertCircleIcon: ({ className }: { className?: string }) => <svg data-testid="alert-icon" className={className} />,
+}));
+
+// ─── Individual <Toast /> unit tests ─────────────────────────────────────────
+
+describe("Toast component", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("renders the message text", () => {
+    render(<Toast message="Payment sent!" type="success" />);
+    expect(screen.getByText("Payment sent!")).toBeInTheDocument();
+  });
+
+  it("renders success variant with check icon", () => {
+    render(<Toast message="Done" type="success" />);
+    expect(screen.getByTestId("check-icon")).toBeInTheDocument();
+  });
+
+  it("renders error variant with alert icon", () => {
+    render(<Toast message="Failed" type="error" />);
+    expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
+  });
+
+  it("renders info variant without an icon", () => {
+    render(<Toast message="Info" type="info" />);
+    expect(screen.queryByTestId("check-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("alert-icon")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose after the duration timeout", () => {
+    const onClose = jest.fn();
+    render(<Toast message="Auto-dismiss" type="info" duration={1000} onClose={onClose} />);
+
+    act(() => jest.advanceTimersByTime(1000));
+    // The component sets visible=false, then fires onClose after 300 ms
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose immediately when the dismiss button is clicked", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onClose = jest.fn();
+    render(<Toast message="Dismiss me" type="info" onClose={onClose} />);
+
+    await user.click(screen.getByLabelText("Dismiss notification"));
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Retry button only for error toasts that have onRetry", async () => {
+    const onRetry = jest.fn();
+    render(<Toast message="Err" type="error" onRetry={onRetry} />);
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("does not show Retry button for success toasts", () => {
+    render(<Toast message="OK" type="success" onRetry={jest.fn()} />);
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onRetry when the Retry button is clicked", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onRetry = jest.fn();
+    const onClose = jest.fn();
+    render(<Toast message="Err" type="error" onRetry={onRetry} onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("has role=status for accessibility", () => {
+    render(<Toast message="A11y" type="info" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});
+
+// ─── ToastContainer stacking tests ──────────────────────────────────────────
+
+function AddToastButton() {
+  const { addToast } = useToastContext();
+  return (
+    <button
+      type="button"
+      onClick={() => addToast("Toast A", "success")}
+    >
+      Add toast
+    </button>
+  );
+}
+
+function ErrorToastButton() {
+  const { addToast } = useToastContext();
+  return (
+    <button
+      type="button"
+      onClick={() => addToast("Toast Error", "error")}
+    >
+      Add error toast
+    </button>
+  );
+}
+
+function MultiToastButton() {
+  const { addToast } = useToastContext();
+  return (
+    <>
+      <button type="button" onClick={() => addToast("First", "info")}>Add first</button>
+      <button type="button" onClick={() => addToast("Second", "success")}>Add second</button>
+    </>
+  );
+}
+
+describe("ToastContainer", () => {
+  it("renders nothing when there are no toasts", () => {
+    render(
+      <ToastProvider>
+        <ToastContainer />
+      </ToastProvider>
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders a toast when one is added via context", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <AddToastButton />
+        <ToastContainer />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add toast" }));
+    expect(screen.getByText("Toast A")).toBeInTheDocument();
+  });
+
+  it("stacks multiple toasts without clobbering each other", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <MultiToastButton />
+        <ToastContainer />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add first" }));
+    await user.click(screen.getByRole("button", { name: "Add second" }));
+
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("uses aria-live=assertive when an error toast is present", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <ErrorToastButton />
+        <ToastContainer />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add error toast" }));
+    const region = screen.getByLabelText("Notifications");
+    expect(region).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("uses aria-live=polite when there are only non-error toasts", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <AddToastButton />
+        <ToastContainer />
+      </ToastProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add toast" }));
+    const region = screen.getByLabelText("Notifications");
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/frontend/__tests__/TradeForm.test.tsx
+++ b/frontend/__tests__/TradeForm.test.tsx
@@ -1,0 +1,259 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import TradeForm from "@/components/TradeForm";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockBuildPathPayment = jest.fn();
+const mockBuildSellOffer = jest.fn();
+const mockBuildBuyOffer = jest.fn();
+const mockSubmitTransaction = jest.fn();
+
+jest.mock("@/lib/stellar", () => ({
+  buildPathPaymentTransaction: (...args: unknown[]) => mockBuildPathPayment(...args),
+  buildSellOfferTransaction: (...args: unknown[]) => mockBuildSellOffer(...args),
+  buildBuyOfferTransaction: (...args: unknown[]) => mockBuildBuyOffer(...args),
+  submitTransaction: (...args: unknown[]) => mockSubmitTransaction(...args),
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+}));
+
+const mockSignTransaction = jest.fn();
+jest.mock("@stellar/freighter-api", () => ({
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+}));
+
+jest.mock("@/components/icons", () => ({
+  SwapIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="swap-icon" className={className} />
+  ),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const PUBLIC_KEY = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234";
+
+function renderTradeForm(overrides = {}) {
+  const props = {
+    publicKey: PUBLIC_KEY,
+    onTradeComplete: jest.fn(),
+    onError: jest.fn(),
+    onSuccess: jest.fn(),
+    ...overrides,
+  };
+  render(<TradeForm {...props} />);
+  return props;
+}
+
+function getAmountInput() {
+  return screen.getByPlaceholderText("0.00");
+}
+
+function getSubmitButton() {
+  return screen.getByRole("button", { name: /execute market order|place .+ order/i });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("TradeForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const fakeTx = { toXDR: () => "AAAA" };
+    mockBuildPathPayment.mockResolvedValue(fakeTx);
+    mockBuildSellOffer.mockResolvedValue(fakeTx);
+    mockBuildBuyOffer.mockResolvedValue(fakeTx);
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: "SIGNED_XDR" });
+    mockSubmitTransaction.mockResolvedValue({ hash: "TX_HASH" });
+  });
+
+  // ── Initial render ─────────────────────────────────────────────────────────
+
+  it("renders Market Order selected by default", () => {
+    renderTradeForm();
+    const marketBtn = screen.getByRole("button", { name: "Market Order" });
+    expect(marketBtn).toHaveClass("bg-stellar-500");
+  });
+
+  it("renders XLM → USDC asset selectors by default", () => {
+    renderTradeForm();
+    const selects = screen.getAllByRole("combobox");
+    expect(selects[0]).toHaveValue("XLM");
+    expect(selects[1]).toHaveValue("USDC");
+  });
+
+  it("submit button is disabled when amount is empty", () => {
+    renderTradeForm();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  it("submit button enables when amount is entered for a market order", async () => {
+    const user = userEvent.setup();
+    renderTradeForm();
+    await user.type(getAmountInput(), "5");
+    expect(getSubmitButton()).not.toBeDisabled();
+  });
+
+  it("calls onError when selling and buying the same asset", async () => {
+    const user = userEvent.setup();
+    const { onError } = renderTradeForm();
+
+    // Set both selects to XLM
+    const selects = screen.getAllByRole("combobox");
+    await user.selectOptions(selects[1], "XLM");
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    expect(onError).toHaveBeenCalledWith("Cannot trade the same asset");
+  });
+
+  it("calls onError when limit order is submitted without price", async () => {
+    const user = userEvent.setup();
+    const { onError } = renderTradeForm();
+
+    await user.click(screen.getByRole("button", { name: "Limit Order" }));
+    await user.type(getAmountInput(), "10");
+
+    // Submit button should be disabled because price is empty — but if user manages to submit:
+    // The form validates !amount || (orderType === "limit" && !price)
+    // Since price is empty the button remains disabled; let's verify it
+    expect(getSubmitButton()).toBeDisabled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  // ── Asset pair swap ────────────────────────────────────────────────────────
+
+  it("swaps asset pair when the swap button is clicked", async () => {
+    const user = userEvent.setup();
+    renderTradeForm();
+
+    const selects = screen.getAllByRole("combobox");
+    expect(selects[0]).toHaveValue("XLM");
+    expect(selects[1]).toHaveValue("USDC");
+
+    await user.click(screen.getByTestId("swap-icon").closest("button")!);
+
+    expect(selects[0]).toHaveValue("USDC");
+    expect(selects[1]).toHaveValue("XLM");
+  });
+
+  // ── Market order submission ────────────────────────────────────────────────
+
+  it("calls buildPathPaymentTransaction for a market order", async () => {
+    const user = userEvent.setup();
+    const { onSuccess, onTradeComplete } = renderTradeForm();
+
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(mockBuildPathPayment).toHaveBeenCalledTimes(1));
+    const callArgs = mockBuildPathPayment.mock.calls[0][0];
+    expect(callArgs.fromPublicKey).toBe(PUBLIC_KEY);
+    expect(callArgs.sendMax).toBe("10");
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("Market order executed successfully!"));
+    expect(onTradeComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the amount field after a successful market order", async () => {
+    const user = userEvent.setup();
+    renderTradeForm();
+
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(mockBuildPathPayment).toHaveBeenCalled());
+    await waitFor(() => expect(getAmountInput()).toHaveValue(null));
+  });
+
+  // ── Limit order submission ─────────────────────────────────────────────────
+
+  it("shows Buy/Sell side buttons when limit order is selected", async () => {
+    const user = userEvent.setup();
+    renderTradeForm();
+
+    await user.click(screen.getByRole("button", { name: "Limit Order" }));
+
+    expect(screen.getByRole("button", { name: "Buy Order" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sell Order" })).toBeInTheDocument();
+  });
+
+  it("calls buildSellOfferTransaction for a limit sell order", async () => {
+    const user = userEvent.setup();
+    const { onSuccess } = renderTradeForm();
+
+    await user.click(screen.getByRole("button", { name: "Limit Order" }));
+    await user.click(screen.getByRole("button", { name: "Sell Order" }));
+
+    await user.type(getAmountInput(), "5");
+    await user.type(screen.getByPlaceholderText("Price"), "0.2");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(mockBuildSellOffer).toHaveBeenCalledTimes(1));
+    const args = mockBuildSellOffer.mock.calls[0][0];
+    expect(args.fromPublicKey).toBe(PUBLIC_KEY);
+    expect(args.amount).toBe("5");
+    expect(args.price).toBe("0.2");
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("Place Sell Order placed successfully!"));
+  });
+
+  it("calls buildBuyOfferTransaction for a limit buy order", async () => {
+    const user = userEvent.setup();
+    const { onSuccess } = renderTradeForm();
+
+    await user.click(screen.getByRole("button", { name: "Limit Order" }));
+    // "Buy Order" is selected by default
+
+    await user.type(getAmountInput(), "3");
+    await user.type(screen.getByPlaceholderText("Price"), "0.5");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(mockBuildBuyOffer).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("Place Buy Order placed successfully!"));
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────────────
+
+  it("calls onError when signing fails", async () => {
+    const user = userEvent.setup();
+    const { onError } = renderTradeForm();
+
+    mockSignTransaction.mockResolvedValue({ error: { message: "User rejected" } });
+
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("User rejected"));
+  });
+
+  it("calls onError when submitTransaction throws", async () => {
+    const user = userEvent.setup();
+    const { onError } = renderTradeForm();
+
+    mockSubmitTransaction.mockRejectedValue(new Error("Network timeout"));
+
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("Network timeout"));
+  });
+
+  it("shows Processing... while the trade is in flight", async () => {
+    const user = userEvent.setup();
+    renderTradeForm();
+
+    // Delay resolution so we can observe the loading state
+    mockBuildPathPayment.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ toXDR: () => "AAAA" }), 200))
+    );
+
+    await user.type(getAmountInput(), "10");
+    await user.click(getSubmitButton());
+
+    expect(screen.getByRole("button", { name: /processing/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Add missing unit test coverage for four frontend components:

- **Toast + ToastContainer** — renders message/variant icons, auto-dismisses after timeout, manual close, Retry button for errors, stacking, `aria-live=assertive` with error toasts
- **QuickSendModal** — hidden when closed, dialog role when open, props forwarded to SendPaymentForm, onClose via close button / Escape / backdrop / form success, body scroll lock
- **TradeForm** — asset pair defaults and swap, submit disabled when empty, same-asset validation, market order calls `buildPathPaymentTransaction`, limit sell/buy calls correct builder, form reset on success, error propagation, loading state
- **PaymentLinkGenerator** — generate button gating, URL built with correct destination/amount/memo, expiry timestamps for 24h/7d/never, clipboard copy with feedback, QR toggle, link history panel, `rememberPaymentLink` called

Closes #509
Closes #512
Closes #514
Closes #515