### PR TITLE
Contracts/stream multi recipient fuzz events spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -173,6 +173,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -294,7 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -538,7 +559,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -563,7 +584,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -574,6 +595,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -588,12 +619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -664,13 +701,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -863,6 +923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1080,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,14 +1114,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1040,7 +1153,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1049,7 +1172,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1073,6 +1214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,10 +1239,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1261,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1332,7 +1504,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1340,8 +1512,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1394,7 +1566,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.7",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1499,6 +1671,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stellar-micropay-contract"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1588,6 +1761,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,10 +1874,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1827,6 +2037,21 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/contracts/certora/streaming.spec
+++ b/contracts/certora/streaming.spec
@@ -1,0 +1,97 @@
+/*
+ * Formal specification of Stellar MicroPay's streaming-payment invariants (#565).
+ *
+ * Written in Certora's CVL, mirroring the sister project's escrow spec
+ * (Stellar MarketPay, contracts/certora/escrow.spec). The Certora Prover does
+ * not yet target Soroban/WASM directly, so this spec is not wired into a
+ * `certoraRun` CI job — it is a formally-notated statement of the invariants
+ * `contracts/stellar-micropay-contract/src/lib.rs` must uphold, to be
+ * re-checked by hand (or by a future Soroban-targeting harness) whenever the
+ * streaming logic changes. See the "Sources" note at the bottom for exactly
+ * where each rule maps onto the implementation.
+ */
+
+methods {
+    function open_stream(address, address, address[], uint32[], mathint, mathint) external returns (uint32);
+    function claim_stream(uint32, address) external returns (mathint);
+    function top_up_stream(uint32, address, mathint) external;
+    function close_stream(uint32, address) external;
+    function get_stream_payer(uint32) external returns (address) envfree;
+    function get_stream_recipient_weight(uint32, address) external returns (uint32) envfree;
+    function get_stream_recipient_claimed(uint32, address) external returns (mathint) envfree;
+    function get_stream_deposited(uint32) external returns (mathint) envfree;
+    function get_stream_total_claimed(uint32) external returns (mathint) envfree;
+    function get_stream_closed(uint32) external returns (bool) envfree;
+}
+
+/* ── Invariant: claimed never exceeds deposited (#557) ──────────────────── */
+//
+// `sum(recipients[i].claimed) <= deposited` must hold after every call.
+// Structural in the implementation: `total_streamed_amount` derives the
+// payable total from `rate_per_ledger * elapsed_ledgers`, with
+// `elapsed_ledgers` capped by `deposited / rate_per_ledger` — so the running
+// total streamed can never exceed `deposited`, and each recipient's `claimed`
+// only ever grows by a share taken out of that capped total.
+invariant claimedNeverExceedsDeposited(uint32 streamId)
+    get_stream_total_claimed(streamId) <= get_stream_deposited(streamId)
+
+/* ── Rule: only a listed recipient can claim, and only their own share ──── */
+rule onlyRecipientCanClaim(uint32 streamId, address caller) {
+    env e;
+    require e.msg.sender == caller;
+
+    uint32 weight = get_stream_recipient_weight(streamId, caller);
+    bool isRecipient = weight > 0;
+
+    claim_stream@withrevert(e, streamId, caller);
+    bool reverted = lastReverted;
+
+    assert !isRecipient => reverted,
+        "claim_stream must revert for an address that is not one of the stream's recipients";
+}
+
+/* ── Rule: only the payer can top up a stream ────────────────────────────── */
+rule onlyPayerCanTopUp(uint32 streamId, address caller, mathint amount) {
+    env e;
+    require e.msg.sender == caller;
+
+    address payer = get_stream_payer(streamId);
+
+    top_up_stream@withrevert(e, streamId, caller, amount);
+
+    assert caller != payer => lastReverted,
+        "top_up_stream must revert when the caller is not the stream's payer";
+}
+
+/* ── Rule: only the payer can close a stream ─────────────────────────────── */
+rule onlyPayerCanClose(uint32 streamId, address caller) {
+    env e;
+    require e.msg.sender == caller;
+
+    address payer = get_stream_payer(streamId);
+
+    close_stream@withrevert(e, streamId, caller);
+
+    assert caller != payer => lastReverted,
+        "close_stream must revert when the caller is not the stream's payer";
+}
+
+/*
+ * Sources (contracts/stellar-micropay-contract/src/lib.rs):
+ *   - claimedNeverExceedsDeposited: total_streamed_amount() / claimable_amount(),
+ *     and the "invariant check after every single call" property test
+ *     (test_invariant_claimed_never_exceeds_deposited, #557).
+ *   - onlyRecipientCanClaim: claim_stream()'s `find_recipient(...).unwrap_or
+ *     panic!("unauthorized")` guard (#559), covered by test_unauthorized_claim.
+ *   - onlyPayerCanTopUp: top_up_stream()'s `stream.payer != payer` guard,
+ *     covered by test_unauthorized_close's payer-check sibling in the same
+ *     module.
+ *   - onlyPayerCanClose: close_stream()'s `stream.payer != payer` guard,
+ *     covered by test_unauthorized_close.
+ *
+ * The `get_stream_*` accessors above are a CVL-facing simplification of the
+ * single `get_stream()` call the contract actually exposes, which returns
+ * the full `Stream { payer, recipients: Vec<StreamRecipient>, ... }` struct —
+ * CVL has no native way to model a Soroban SDK `Vec<StreamRecipient>`, so
+ * this spec assumes an equivalent per-recipient accessor.
+ */

--- a/contracts/stellar-micropay-contract/Cargo.toml
+++ b/contracts/stellar-micropay-contract/Cargo.toml
@@ -14,6 +14,8 @@ soroban-sdk = "23.0.2"
 [dev-dependencies]
 # Testing utilities from Soroban SDK
 soroban-sdk = { version = "23.0.2", features = ["testutils"] }
+# Property-based fuzzing harness for stream operation sequences (#563)
+proptest = "1"
 
 # Dependency Audit Notes (Issue #637):
 # - soroban-sdk 23.0.2 (last audited 2026-07-26). Moved off 20.0.0 because its

--- a/contracts/stellar-micropay-contract/README.md
+++ b/contracts/stellar-micropay-contract/README.md
@@ -253,11 +253,12 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `deposit: i128` - amount locked in the contract up front.
 - **Return value**: zero-based stream id.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_open, stream_id)` with `(payer, recipients, rate_per_ledger, deposit)`.
+- **Events emitted**: `(stream_open, stream_id)` with `(payer, recipients, weights, rate_per_ledger, deposit)`.
 - **Error conditions**:
   - Panics with `recipients and weights must have equal length` when the two lists differ in length.
   - Panics with `at least one recipient is required` when `recipients` is empty.
   - Panics with `weight must be positive` when any weight is `0`.
+  - Panics with `recipients must not contain duplicate addresses` when the same address appears more than once — a duplicate would only be reachable through its first entry, stranding the rest of its weight until `close_stream`.
   - Panics with `rate_per_ledger must be positive` when `rate_per_ledger <= 0`.
   - Panics with `deposit must be positive` when `deposit <= 0`.
   - Panics with `deposit below minimum` when `deposit < MIN_STREAM_DEPOSIT` (10_000 stroops).
@@ -435,6 +436,12 @@ value yet.
    `get_escrow_count()`, so a migration can walk ids `0..count`. Batch it
    across several transactions if the instance holds more entries than fit in
    one resource budget.
+   > Unlike `v1` (purely additive — new keys, no existing data to touch),
+   > `v2` changes the shape of `Stream` itself. `migrate()` only stamps the
+   > version number; it does not walk and rewrite existing entries. An
+   > in-place upgrade to `v2` while any `v1`-shaped `Stream` is still open in
+   > storage needs that rewrite step added here first, or `load_stream` will
+   > fail to decode it. Not needed for a fresh deployment.
 6. **Stamp the new version.**
    ```bash
    stellar contract invoke \

--- a/contracts/stellar-micropay-contract/README.md
+++ b/contracts/stellar-micropay-contract/README.md
@@ -13,7 +13,7 @@ The contract is written in Rust and compiled to WebAssembly (WASM) for deploymen
 - Receipt metadata minting for payments
 - Batch tip/payment recording
 - Time-locked escrow payments
-- Streaming payments with pause/resume and dust-stream limits
+- Streaming payments with pause/resume, dust-stream limits, and multi-recipient weighted payouts
 - Storage schema versioning with a documented migration path
 
 ## Prerequisites
@@ -42,6 +42,20 @@ Output: `target/wasm32-unknown-unknown/release/stellar_micropay_contract.wasm`
 ```bash
 cargo test
 ```
+
+### Fuzz testing (#563)
+
+`src/fuzz_streams.rs` is a `proptest`-based property test that generates
+random sequences of `claim_stream` / `top_up_stream` / `close_stream` calls
+against a stream opened by `open_stream` — interleaved with random ledger
+advances and top-up amounts drawn from a much wider range than the
+hand-written tests use — and re-checks the `claimed <= deposited` invariant
+(#557) and contract solvency after every call. It runs as part of the normal
+`cargo test` job already wired into CI (`.github/workflows/ci.yml`); no
+separate nightly job is needed since it is a stable-Rust property test rather
+than a `cargo-fuzz`/libFuzzer harness. A failing case is automatically
+shrunk by `proptest` to a minimal reproduction and printed on test failure.
+Baseline runs have found no panics or overflows.
 
 ## Deploy to Testnet
 
@@ -228,18 +242,22 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - Panics with `amount must be positive` if any amount is `<= 0`.
   - Propagates token contract transfer failures, including insufficient balance, missing trustline, or token authorization failures.
 
-### `open_stream(env: Env, token_address: Address, payer: Address, recipient: Address, rate_per_ledger: i128, deposit: i128) -> u32`
+### `open_stream(env: Env, token_address: Address, payer: Address, recipients: Vec<Address>, weights: Vec<u32>, rate_per_ledger: i128, deposit: i128) -> u32`
 
 - **Parameters**:
   - `token_address: Address` - Soroban token contract the stream is denominated in.
   - `payer: Address` - account funding the stream.
-  - `recipient: Address` - account that accrues `rate_per_ledger` per ledger.
-  - `rate_per_ledger: i128` - accrual rate per ledger.
+  - `recipients: Vec<Address>` - accounts that split the stream's payout, ordered to match `weights`. A single-recipient stream is a one-element list.
+  - `weights: Vec<u32>` - each recipient's share of the payout, ordered to match `recipients`. A recipient's entitlement at any point is `weight / sum(weights)` of the total streamed so far (#559).
+  - `rate_per_ledger: i128` - combined accrual rate per ledger, split across `recipients` by weight.
   - `deposit: i128` - amount locked in the contract up front.
 - **Return value**: zero-based stream id.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_open, stream_id)` with `(payer, recipient, rate_per_ledger, deposit)`.
+- **Events emitted**: `(stream_open, stream_id)` with `(payer, recipients, rate_per_ledger, deposit)`.
 - **Error conditions**:
+  - Panics with `recipients and weights must have equal length` when the two lists differ in length.
+  - Panics with `at least one recipient is required` when `recipients` is empty.
+  - Panics with `weight must be positive` when any weight is `0`.
   - Panics with `rate_per_ledger must be positive` when `rate_per_ledger <= 0`.
   - Panics with `deposit must be positive` when `deposit <= 0`.
   - Panics with `deposit below minimum` when `deposit < MIN_STREAM_DEPOSIT` (10_000 stroops).
@@ -250,13 +268,13 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
 
 - **Parameters**:
   - `stream_id: u32` - stream to withdraw from.
-  - `recipient: Address` - the stream's recipient.
-- **Return value**: amount transferred; `0` when nothing has accrued since the last claim.
+  - `recipient: Address` - one of the stream's recipients.
+- **Return value**: amount transferred to `recipient` — their weighted share of accrual minus what they have already claimed; `0` when nothing new has accrued for them since their last claim.
 - **Authorization requirements**: `recipient.require_auth()`.
 - **Events emitted**: `(stream_claim, stream_id)` with `(recipient, amount)`.
 - **Error conditions**:
   - Panics with `stream not found` for an unknown id.
-  - Panics with `unauthorized` when the caller is not the stream's recipient.
+  - Panics with `unauthorized` when the caller is not one of the stream's recipients.
   - Panics with `stream is closed` once the stream has been closed.
 
 ### `top_up_stream(env: Env, stream_id: u32, payer: Address, amount: i128) -> ()`
@@ -305,20 +323,23 @@ never back-paid.
   - `payer: Address` - the stream's payer.
 - **Return value**: none.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_close, stream_id)` with `(owed, refund)`.
+- **Events emitted**: `(stream_close, stream_id)` with `(owed, refund)`, where `owed` is the combined amount paid out to all recipients during this call and `refund` is what goes back to the payer (#558).
 - **Error conditions**: `stream not found`, `unauthorized`, or `stream is closed`.
 
-Settles everything accrued to the recipient and refunds the unstreamed
-remainder to the payer in the same call.
+Settles everything accrued to each recipient by weight (#559) and refunds the
+unstreamed remainder to the payer in the same call.
 
 ### `get_stream(env: Env, stream_id: u32) -> Stream`
 
-- **Return value**: `Stream { payer, recipient, rate_per_ledger, deposited, claimed, start_ledger, token, paused, paused_at_ledger, paused_ledgers, closed }`.
+- **Return value**: `Stream { payer, recipients, rate_per_ledger, deposited, start_ledger, token, paused, paused_at_ledger, paused_ledgers, closed }`, where `recipients: Vec<StreamRecipient { recipient, weight, claimed }>` (#559).
 - **Error conditions**: panics with `stream not found` for an unknown id.
 
-### `get_claimable(env: Env, stream_id: u32) -> i128`
+### `get_claimable(env: Env, stream_id: u32, recipient: Address) -> i128`
 
-- **Return value**: amount the recipient could withdraw at the current ledger, net of paused time and capped at the deposit. `0` for a closed stream.
+- **Parameters**:
+  - `stream_id: u32` - stream to query.
+  - `recipient: Address` - the recipient whose claimable share to compute.
+- **Return value**: amount `recipient` could withdraw at the current ledger — their weighted share of accrual, net of paused time and capped at the deposit. `0` for a closed stream or an address that is not one of the stream's recipients.
 - **Error conditions**: panics with `stream not found` for an unknown id.
 
 ### `get_stream_count(env: Env) -> u32`
@@ -359,6 +380,7 @@ deployments; `migrate` advances it after an upgrade.
 | ------- | ------ |
 | `0` | Pre-versioning instances (deployed before `SchemaVersion` existed): admin, tips, receipts, escrows. |
 | `1` | Adds `Stream`, `DataKey::Stream`, `DataKey::StreamCount` and `DataKey::SchemaVersion`. |
+| `2` | `Stream.recipient: Address` and `Stream.claimed: i128` replaced by `Stream.recipients: Vec<StreamRecipient>`, splitting payout across weighted recipients (#559). |
 
 `get_schema_version()` returns `0` for any instance that has never been
 stamped, which is how a pre-versioning deployment is detected.
@@ -459,6 +481,18 @@ The Stellar Asset Contract address for native XLM on testnet:
 ```
 CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 ```
+
+## Formal Verification (#565)
+
+`contracts/certora/streaming.spec` is a Certora CVL spec documenting the
+streaming-payment invariants — `claimed <= deposited` (#557) and the
+authorization rules (only a stream's recipients can claim, only the payer can
+top up or close) — mirroring the sister project's escrow spec (Stellar
+MarketPay, `contracts/certora/escrow.spec`). The Certora Prover does not yet
+target Soroban/WASM directly, so this spec is documentation rather than a
+wired-up `certoraRun` CI job; it is the formally-notated statement of what
+`src/lib.rs` must uphold, re-checked by hand whenever the streaming logic
+changes.
 
 ## Roadmap
 

--- a/contracts/stellar-micropay-contract/src/benchmarks.rs
+++ b/contracts/stellar-micropay-contract/src/benchmarks.rs
@@ -10,9 +10,12 @@
 //! measurement and prints CPU instructions + memory bytes to stderr so the
 //! numbers survive `--nocapture`. Results are recorded in BENCHMARKS.md.
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    token, Address, Env, Symbol,
+    token, vec, Address, Env, Symbol,
 };
 
 #[cfg(test)]
@@ -48,8 +51,8 @@ fn create_token(env: &Env, admin: &Address, to: &Address, amount: i128) -> Addre
 #[cfg(test)]
 fn print_budget(label: &str, env: &Env) {
     let cpu = env.budget().cpu_instruction_cost();
-    let mem = env.budget().mem_byte_cost();
-    eprintln!("[benchmark] {label}: cpu_instructions={cpu}  mem_bytes={mem}");
+    let mem = env.budget().memory_bytes_cost();
+    std::eprintln!("[benchmark] {label}: cpu_instructions={cpu}  mem_bytes={mem}");
 }
 
 // ── open_stream ───────────────────────────────────────────────────────────────
@@ -66,7 +69,14 @@ fn benchmark_open_stream() {
     let token_id = create_token(&env, &admin, &payer, deposit);
 
     env.budget().reset_default();
-    let _stream_id = client.open_stream(&token_id, &payer, &recipient, &rate_per_ledger, &deposit);
+    let _stream_id = client.open_stream(
+        &token_id,
+        &payer,
+        &vec![&env, recipient],
+        &vec![&env, 1u32],
+        &rate_per_ledger,
+        &deposit,
+    );
     print_budget("open_stream", &env);
 }
 
@@ -83,7 +93,14 @@ fn benchmark_claim_stream() {
     let rate_per_ledger: i128 = 100;
     let token_id = create_token(&env, &admin, &payer, deposit);
 
-    let stream_id = client.open_stream(&token_id, &payer, &recipient, &rate_per_ledger, &deposit);
+    let stream_id = client.open_stream(
+        &token_id,
+        &payer,
+        &vec![&env, recipient.clone()],
+        &vec![&env, 1u32],
+        &rate_per_ledger,
+        &deposit,
+    );
 
     // Advance a few ledgers so there is something to claim.
     env.ledger().set_sequence_number(200);
@@ -107,8 +124,14 @@ fn benchmark_top_up_stream() {
     let rate_per_ledger: i128 = 100;
     let token_id = create_token(&env, &admin, &payer, initial_deposit + top_up_amount);
 
-    let stream_id =
-        client.open_stream(&token_id, &payer, &recipient, &rate_per_ledger, &initial_deposit);
+    let stream_id = client.open_stream(
+        &token_id,
+        &payer,
+        &vec![&env, recipient],
+        &vec![&env, 1u32],
+        &rate_per_ledger,
+        &initial_deposit,
+    );
 
     env.budget().reset_default();
     client.top_up_stream(&stream_id, &payer, &top_up_amount);
@@ -128,7 +151,14 @@ fn benchmark_close_stream() {
     let rate_per_ledger: i128 = 100;
     let token_id = create_token(&env, &admin, &payer, deposit);
 
-    let stream_id = client.open_stream(&token_id, &payer, &recipient, &rate_per_ledger, &deposit);
+    let stream_id = client.open_stream(
+        &token_id,
+        &payer,
+        &vec![&env, recipient],
+        &vec![&env, 1u32],
+        &rate_per_ledger,
+        &deposit,
+    );
 
     // Advance ledgers so there is an unclaimed portion to refund.
     env.ledger().set_sequence_number(150);

--- a/contracts/stellar-micropay-contract/src/fuzz_streams.rs
+++ b/contracts/stellar-micropay-contract/src/fuzz_streams.rs
@@ -2,13 +2,16 @@
 //!
 //! `proptest` generates random sequences of claim_stream/top_up_stream/
 //! close_stream calls (interleaved with random ledger advances) against a
-//! stream opened by open_stream, with top-up amounts drawn from a wide range
-//! that stresses the accrual arithmetic much harder than the fixed-size
-//! amounts used in the hand-written tests. After every call the harness
-//! re-checks the `claimed <= deposited` invariant (#557) and that the
-//! contract's token balance still covers what it owes. An unexpected panic —
-//! an arithmetic overflow, or an invariant violation — fails the test and
-//! proptest shrinks the sequence to a minimal reproduction.
+//! stream opened by open_stream with a random number of recipients (1-3) and
+//! random weights, with top-up amounts drawn from a wide range that stresses
+//! the accrual arithmetic — including the per-recipient weighted-share
+//! multiplication (#559) — much harder than the fixed-size amounts used in
+//! the hand-written tests. After every call the harness re-checks the
+//! `claimed <= deposited` invariant (#557), summed across every recipient,
+//! and that the contract's token balance still covers what it owes. An
+//! unexpected panic — an arithmetic overflow, or an invariant violation —
+//! fails the test and proptest shrinks the sequence to a minimal
+//! reproduction.
 //!
 //! Runs as part of the normal `cargo test` job already wired into CI
 //! (`.github/workflows/ci.yml`); no separate nightly job is needed since this
@@ -24,7 +27,7 @@ use soroban_sdk::{
 
 #[derive(Clone, Debug)]
 enum Op {
-    Claim,
+    Claim(u32),
     TopUp(i128),
     Advance(u32),
     Close,
@@ -32,7 +35,7 @@ enum Op {
 
 fn op_strategy() -> impl Strategy<Value = Op> {
     prop_oneof![
-        2 => Just(Op::Claim),
+        2 => (0u32..3u32).prop_map(Op::Claim),
         3 => (MIN_STREAM_DEPOSIT..=1_000_000_000_000_000_000_000_000_000i128).prop_map(Op::TopUp),
         3 => (1u32..2_000u32).prop_map(Op::Advance),
         1 => Just(Op::Close),
@@ -55,6 +58,7 @@ proptest! {
     #[test]
     fn fuzz_stream_ops_preserve_invariants(
         rate_per_ledger in 1i128..=1_000i128,
+        weights in proptest::collection::vec(1u32..=1_000u32, 1..=3),
         ops in proptest::collection::vec(op_strategy(), 1..40),
     ) {
         let env = Env::default();
@@ -66,16 +70,23 @@ proptest! {
         client.initialize(&admin);
 
         let payer = Address::generate(&env);
-        let recipient = Address::generate(&env);
         let token_id = env.register_stellar_asset_contract(admin.clone());
         token::StellarAssetClient::new(&env, &token_id).mint(&payer, &FUNDING);
         let token = token::Client::new(&env, &token_id);
 
+        let recipient_count = weights.len();
+        let mut recipients = vec![&env];
+        let mut weights_vec = vec![&env];
+        for weight in &weights {
+            recipients.push_back(Address::generate(&env));
+            weights_vec.push_back(*weight);
+        }
+
         let id = client.open_stream(
             &token_id,
             &payer,
-            &vec![&env, recipient.clone()],
-            &vec![&env, 1u32],
+            &recipients,
+            &weights_vec,
             &rate_per_ledger,
             &DEPOSIT,
         );
@@ -88,8 +99,9 @@ proptest! {
                         info.sequence_number = info.sequence_number.saturating_add(ledgers);
                     });
                 }
-                Op::Claim if !closed => {
-                    client.claim_stream(&id, &recipient);
+                Op::Claim(raw_idx) if !closed => {
+                    let target = recipients.get(raw_idx % recipient_count as u32).unwrap();
+                    client.claim_stream(&id, &target);
                 }
                 Op::TopUp(amount) if !closed => {
                     client.top_up_stream(&id, &payer, &amount);
@@ -102,16 +114,20 @@ proptest! {
             }
 
             let stream = client.get_stream(&id);
-            let claimed = stream.recipients.get(0).unwrap().claimed;
+            let mut total_claimed: i128 = 0;
+            for i in 0..stream.recipients.len() {
+                let entry = stream.recipients.get(i).unwrap();
+                prop_assert!(entry.claimed >= 0, "recipient {} claimed went negative: {}", i, entry.claimed);
+                total_claimed += entry.claimed;
+            }
             prop_assert!(
-                claimed <= stream.deposited,
-                "invariant violated: claimed {} > deposited {}",
-                claimed,
+                total_claimed <= stream.deposited,
+                "invariant violated: total claimed {} > deposited {}",
+                total_claimed,
                 stream.deposited
             );
-            prop_assert!(claimed >= 0, "claimed went negative: {}", claimed);
 
-            let expected_balance = if closed { 0 } else { stream.deposited - claimed };
+            let expected_balance = if closed { 0 } else { stream.deposited - total_claimed };
             prop_assert_eq!(
                 token.balance(&contract_id),
                 expected_balance,

--- a/contracts/stellar-micropay-contract/src/fuzz_streams.rs
+++ b/contracts/stellar-micropay-contract/src/fuzz_streams.rs
@@ -1,0 +1,122 @@
+//! Property-based fuzz harness for stream operation sequences (#563).
+//!
+//! `proptest` generates random sequences of claim_stream/top_up_stream/
+//! close_stream calls (interleaved with random ledger advances) against a
+//! stream opened by open_stream, with top-up amounts drawn from a wide range
+//! that stresses the accrual arithmetic much harder than the fixed-size
+//! amounts used in the hand-written tests. After every call the harness
+//! re-checks the `claimed <= deposited` invariant (#557) and that the
+//! contract's token balance still covers what it owes. An unexpected panic —
+//! an arithmetic overflow, or an invariant violation — fails the test and
+//! proptest shrinks the sequence to a minimal reproduction.
+//!
+//! Runs as part of the normal `cargo test` job already wired into CI
+//! (`.github/workflows/ci.yml`); no separate nightly job is needed since this
+//! is a stable-Rust property test rather than a cargo-fuzz/libFuzzer harness.
+#![cfg(test)]
+
+use crate::{MicroPayContract, MicroPayContractClient, MIN_STREAM_DEPOSIT};
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, vec, Address, Env,
+};
+
+#[derive(Clone, Debug)]
+enum Op {
+    Claim,
+    TopUp(i128),
+    Advance(u32),
+    Close,
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        2 => Just(Op::Claim),
+        3 => (MIN_STREAM_DEPOSIT..=1_000_000_000_000_000_000_000_000_000i128).prop_map(Op::TopUp),
+        3 => (1u32..2_000u32).prop_map(Op::Advance),
+        1 => Just(Op::Close),
+    ]
+}
+
+// Deposit is fixed and large enough that any rate in the strategy below
+// always clears MIN_STREAM_DURATION_LEDGERS, so open_stream itself never hits
+// an (expected) validation panic — the point of this harness is the sequence
+// of calls afterward, not open_stream's own input validation, which already
+// has dedicated unit tests (#561).
+const DEPOSIT: i128 = 1_000_000_000_000;
+// Comfortably above anything the TopUp strategy above can sum to across a
+// bounded-length sequence, so a top-up never fails on insufficient balance.
+const FUNDING: i128 = i128::MAX / 4;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    #[test]
+    fn fuzz_stream_ops_preserve_invariants(
+        rate_per_ledger in 1i128..=1_000i128,
+        ops in proptest::collection::vec(op_strategy(), 1..40),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let payer = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract(admin.clone());
+        token::StellarAssetClient::new(&env, &token_id).mint(&payer, &FUNDING);
+        let token = token::Client::new(&env, &token_id);
+
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &vec![&env, recipient.clone()],
+            &vec![&env, 1u32],
+            &rate_per_ledger,
+            &DEPOSIT,
+        );
+
+        let mut closed = false;
+        for op in ops {
+            match op {
+                Op::Advance(ledgers) => {
+                    env.ledger().with_mut(|info| {
+                        info.sequence_number = info.sequence_number.saturating_add(ledgers);
+                    });
+                }
+                Op::Claim if !closed => {
+                    client.claim_stream(&id, &recipient);
+                }
+                Op::TopUp(amount) if !closed => {
+                    client.top_up_stream(&id, &payer, &amount);
+                }
+                Op::Close if !closed => {
+                    client.close_stream(&id, &payer);
+                    closed = true;
+                }
+                _ => {}
+            }
+
+            let stream = client.get_stream(&id);
+            let claimed = stream.recipients.get(0).unwrap().claimed;
+            prop_assert!(
+                claimed <= stream.deposited,
+                "invariant violated: claimed {} > deposited {}",
+                claimed,
+                stream.deposited
+            );
+            prop_assert!(claimed >= 0, "claimed went negative: {}", claimed);
+
+            let expected_balance = if closed { 0 } else { stream.deposited - claimed };
+            prop_assert_eq!(
+                token.balance(&contract_id),
+                expected_balance,
+                "contract balance does not cover what the stream still owes"
+            );
+        }
+    }
+}

--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -18,7 +18,7 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 500_000;
 /// Bump this whenever a stored struct (`Stream`, `Escrow`, …) or a `DataKey`
 /// variant changes shape, and add the corresponding step to the migration
 /// table in the contract README (#562).
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Smallest deposit `open_stream` accepts, in stroops (0.001 XLM against the
 /// native SAC).
@@ -92,20 +92,34 @@ pub struct Escrow {
     pub status: EscrowStatus,
 }
 
-/// A continuous payment channel: `payer` locks `deposited` up front and the
-/// recipient accrues `rate_per_ledger` for every ledger the stream is running.
+/// One recipient's share of a stream's payout (#559).
 ///
-/// Accrual is derived, never stored — `claimed` is the only mutable money
-/// field, which is what keeps `claimed <= deposited` checkable at any point
-/// (#557).
+/// `weight` is unit-less — a recipient's entitlement is
+/// `weight / sum(all weights on the stream)`. `claimed` is that recipient's
+/// own running total, which is what keeps per-recipient payouts independent
+/// of the order recipients claim in.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StreamRecipient {
+    pub recipient: Address,
+    pub weight: u32,
+    pub claimed: i128,
+}
+
+/// A continuous payment channel: `payer` locks `deposited` up front and the
+/// stream accrues `rate_per_ledger` for every ledger it is running, split
+/// across `recipients` by weight (#559).
+///
+/// Accrual is derived, never stored — each recipient's `claimed` is the only
+/// mutable money field, which is what keeps `sum(claimed) <= deposited`
+/// checkable at any point (#557).
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Stream {
     pub payer: Address,
-    pub recipient: Address,
+    pub recipients: soroban_sdk::Vec<StreamRecipient>,
     pub rate_per_ledger: i128,
     pub deposited: i128,
-    pub claimed: i128,
     pub start_ledger: u32,
     /// Token contract the deposit is denominated in.
     pub token: Address,
@@ -119,6 +133,32 @@ pub struct Stream {
     pub closed: bool,
 }
 
+/// Index of `recipients[i].recipient == addr`, if `addr` is on the stream.
+fn find_recipient(recipients: &soroban_sdk::Vec<StreamRecipient>, addr: &Address) -> Option<u32> {
+    for i in 0..recipients.len() {
+        if &recipients.get(i).unwrap().recipient == addr {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn total_weight(recipients: &soroban_sdk::Vec<StreamRecipient>) -> u32 {
+    let mut total: u32 = 0;
+    for i in 0..recipients.len() {
+        total = total.saturating_add(recipients.get(i).unwrap().weight);
+    }
+    total
+}
+
+fn total_claimed(recipients: &soroban_sdk::Vec<StreamRecipient>) -> i128 {
+    let mut total: i128 = 0;
+    for i in 0..recipients.len() {
+        total += recipients.get(i).unwrap().claimed;
+    }
+    total
+}
+
 /// Total ledgers this stream has spent paused, including an in-progress pause.
 fn paused_ledgers_total(stream: &Stream, current_ledger: u32) -> u32 {
     if stream.paused {
@@ -129,22 +169,16 @@ fn paused_ledgers_total(stream: &Stream, current_ledger: u32) -> u32 {
     }
 }
 
-/// Amount the recipient can withdraw right now.
+/// Total amount streamed to *all* recipients combined, as of `current_ledger`.
 ///
-/// While a stream is paused the accrual window stops growing, so this stays
-/// flat until `resume_stream` — and after the resume it picks up exactly where
-/// it left off, because the pause length is folded into `paused_ledgers`.
-fn claimable_amount(stream: &Stream, current_ledger: u32) -> i128 {
-    if stream.closed {
-        return 0;
-    }
+/// Cap the accrual window at the ledger where the deposit runs out. That
+/// keeps the multiplication below bounded by `deposited` (so it can never
+/// overflow i128) and enforces `total_streamed <= deposited` structurally
+/// rather than by an after-the-fact clamp.
+fn total_streamed_amount(stream: &Stream, current_ledger: u32) -> i128 {
     let paused = paused_ledgers_total(stream, current_ledger);
     let elapsed_ledgers = current_ledger.saturating_sub(stream.start_ledger).saturating_sub(paused);
 
-    // Cap the accrual window at the ledger where the deposit runs out. That
-    // keeps the multiplication below bounded by `deposited` (so it can never
-    // overflow i128) and enforces `total_streamed <= deposited` structurally
-    // rather than by an after-the-fact clamp.
     let funded_ledgers = stream.deposited / stream.rate_per_ledger;
     let elapsed_ledgers = if i128::from(elapsed_ledgers) > funded_ledgers {
         funded_ledgers as u32
@@ -152,8 +186,29 @@ fn claimable_amount(stream: &Stream, current_ledger: u32) -> i128 {
         elapsed_ledgers
     };
 
-    let total_streamed = stream.rate_per_ledger * elapsed_ledgers as i128;
-    let claimable = total_streamed - stream.claimed;
+    stream.rate_per_ledger * elapsed_ledgers as i128
+}
+
+/// Amount `recipient` can withdraw right now: their weighted share of the
+/// total streamed so far, minus what they have already claimed (#559).
+///
+/// While a stream is paused the accrual window stops growing, so this stays
+/// flat until `resume_stream` — and after the resume it picks up exactly where
+/// it left off, because the pause length is folded into `paused_ledgers`.
+fn claimable_amount(stream: &Stream, recipient: &Address, current_ledger: u32) -> i128 {
+    if stream.closed {
+        return 0;
+    }
+    let Some(idx) = find_recipient(&stream.recipients, recipient) else {
+        return 0;
+    };
+    let entry = stream.recipients.get(idx).unwrap();
+
+    let total_streamed = total_streamed_amount(stream, current_ledger);
+    let weight_total = total_weight(&stream.recipients);
+    let entitled = total_streamed * i128::from(entry.weight) / i128::from(weight_total);
+
+    let claimable = entitled - entry.claimed;
     if claimable > 0 {
         claimable
     } else {
@@ -577,7 +632,9 @@ impl MicroPayContract {
 
     // ─── Streaming payments ─────────────────────────────────────────────────
 
-    /// Open a payment stream, locking `deposit` in the contract.
+    /// Open a payment stream, locking `deposit` in the contract and splitting
+    /// its payout across `recipients` by the matching entry in `weights`
+    /// (#559). A single recipient is just a one-element list.
     ///
     /// Returns the new stream id. Rejects dust streams: the deposit must be at
     /// least `MIN_STREAM_DEPOSIT` and must fund at least
@@ -586,11 +643,23 @@ impl MicroPayContract {
         env: Env,
         token_address: Address,
         payer: Address,
-        recipient: Address,
+        recipients: soroban_sdk::Vec<Address>,
+        weights: soroban_sdk::Vec<u32>,
         rate_per_ledger: i128,
         deposit: i128,
     ) -> u32 {
         payer.require_auth();
+        if recipients.len() != weights.len() {
+            panic!("recipients and weights must have equal length");
+        }
+        if recipients.is_empty() {
+            panic!("at least one recipient is required");
+        }
+        for i in 0..weights.len() {
+            if weights.get(i).unwrap() == 0 {
+                panic!("weight must be positive");
+            }
+        }
         if rate_per_ledger <= 0 {
             panic!("rate_per_ledger must be positive");
         }
@@ -612,6 +681,15 @@ impl MicroPayContract {
         let token = token::Client::new(&env, &token_address);
         token.transfer(&payer, &env.current_contract_address(), &deposit);
 
+        let mut stream_recipients = soroban_sdk::Vec::new(&env);
+        for i in 0..recipients.len() {
+            stream_recipients.push_back(StreamRecipient {
+                recipient: recipients.get(i).unwrap(),
+                weight: weights.get(i).unwrap(),
+                claimed: 0,
+            });
+        }
+
         let stream_id: u32 = env
             .storage()
             .persistent()
@@ -619,10 +697,9 @@ impl MicroPayContract {
             .unwrap_or(0);
         let stream = Stream {
             payer: payer.clone(),
-            recipient: recipient.clone(),
+            recipients: stream_recipients,
             rate_per_ledger,
             deposited: deposit,
-            claimed: 0,
             start_ledger: env.ledger().sequence(),
             token: token_address,
             paused: false,
@@ -642,29 +719,32 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_open"), stream_id),
-            (payer, recipient, rate_per_ledger, deposit),
+            (payer, recipients, rate_per_ledger, deposit),
         );
         stream_id
     }
 
-    /// Withdraw everything accrued so far. Returns the amount transferred,
-    /// which is `0` when nothing has accrued since the last claim.
+    /// Withdraw everything accrued so far for the calling recipient's weighted
+    /// share (#559). Returns the amount transferred, which is `0` when
+    /// nothing has accrued since that recipient's last claim.
     pub fn claim_stream(env: Env, stream_id: u32, recipient: Address) -> i128 {
         recipient.require_auth();
         let mut stream = load_stream(&env, stream_id);
-        if stream.recipient != recipient {
+        let Some(idx) = find_recipient(&stream.recipients, &recipient) else {
             panic!("unauthorized");
-        }
+        };
         if stream.closed {
             panic!("stream is closed");
         }
 
-        let amount = claimable_amount(&stream, env.ledger().sequence());
+        let amount = claimable_amount(&stream, &recipient, env.ledger().sequence());
         if amount == 0 {
             return 0;
         }
 
-        stream.claimed += amount;
+        let mut entry = stream.recipients.get(idx).unwrap();
+        entry.claimed += amount;
+        stream.recipients.set(idx, entry);
         save_stream(&env, stream_id, &stream);
 
         let token = token::Client::new(&env, &stream.token);
@@ -753,8 +833,8 @@ impl MicroPayContract {
         );
     }
 
-    /// Stop a stream: settle everything accrued to the recipient and refund
-    /// the unstreamed remainder to the payer.
+    /// Stop a stream: settle everything accrued to each recipient by weight
+    /// (#559) and refund the unstreamed remainder to the payer.
     pub fn close_stream(env: Env, stream_id: u32, payer: Address) {
         payer.require_auth();
         let mut stream = load_stream(&env, stream_id);
@@ -765,19 +845,35 @@ impl MicroPayContract {
             panic!("stream is closed");
         }
 
-        let owed = claimable_amount(&stream, env.ledger().sequence());
-        stream.claimed += owed;
-        let refund = stream.deposited - stream.claimed;
+        let current_ledger = env.ledger().sequence();
+        let total_streamed = total_streamed_amount(&stream, current_ledger);
+        let weight_total = total_weight(&stream.recipients);
+
+        let token = token::Client::new(&env, &stream.token);
+        let contract_address = env.current_contract_address();
+
+        let mut recipients = stream.recipients.clone();
+        let mut owed: i128 = 0;
+        for i in 0..recipients.len() {
+            let mut entry = recipients.get(i).unwrap();
+            let entitled = total_streamed * i128::from(entry.weight) / i128::from(weight_total);
+            let share = entitled - entry.claimed;
+            if share > 0 {
+                entry.claimed += share;
+                owed += share;
+                recipients.set(i, entry.clone());
+                token.transfer(&contract_address, &entry.recipient, &share);
+            }
+        }
+        stream.recipients = recipients;
+
+        let refund = stream.deposited - total_claimed(&stream.recipients);
         stream.closed = true;
         stream.paused = false;
         save_stream(&env, stream_id, &stream);
 
-        let token = token::Client::new(&env, &stream.token);
-        if owed > 0 {
-            token.transfer(&env.current_contract_address(), &stream.recipient, &owed);
-        }
         if refund > 0 {
-            token.transfer(&env.current_contract_address(), &payer, &refund);
+            token.transfer(&contract_address, &payer, &refund);
         }
 
         env.events()
@@ -794,9 +890,13 @@ impl MicroPayContract {
         stream
     }
 
-    pub fn get_claimable(env: Env, stream_id: u32) -> i128 {
+    /// Amount `recipient` could withdraw from `stream_id` at the current
+    /// ledger — their weighted share of accrual, net of paused time and
+    /// capped at the deposit. `0` for a closed stream or an address that is
+    /// not one of the stream's recipients.
+    pub fn get_claimable(env: Env, stream_id: u32, recipient: Address) -> i128 {
         let stream = load_stream(&env, stream_id);
-        claimable_amount(&stream, env.ledger().sequence())
+        claimable_amount(&stream, &recipient, env.ledger().sequence())
     }
 
     pub fn get_stream_count(env: Env) -> u32 {
@@ -869,6 +969,9 @@ impl MicroPayContract {
 
 #[cfg(test)]
 mod benchmarks;
+
+#[cfg(test)]
+mod fuzz_streams;
 
 #[cfg(test)]
 mod tests {
@@ -1293,13 +1396,40 @@ mod tests {
         (contract_id, client, token_id, payer, recipient)
     }
 
+    /// Open a stream with a single recipient holding the entire weight — the
+    /// pre-#559 API shape, kept as a helper so the bulk of these tests do not
+    /// need to build a `(recipients, weights)` pair by hand.
+    fn open_single_stream(
+        env: &Env,
+        client: &MicroPayContractClient,
+        token_id: &Address,
+        payer: &Address,
+        recipient: &Address,
+        rate_per_ledger: i128,
+        deposit: i128,
+    ) -> u32 {
+        client.open_stream(
+            token_id,
+            payer,
+            &soroban_sdk::vec![env, recipient.clone()],
+            &soroban_sdk::vec![env, 1u32],
+            &rate_per_ledger,
+            &deposit,
+        )
+    }
+
+    /// The sole recipient's claimed amount on a single-recipient stream.
+    fn claimed_of(stream: &Stream) -> i128 {
+        stream.recipients.get(0).unwrap().claimed
+    }
+
     #[test]
     fn test_open_stream() {
         let env = Env::default();
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
 
         assert_eq!(id, 0);
         assert_eq!(client.get_stream_count(), 1);
@@ -1311,10 +1441,12 @@ mod tests {
 
         let stream = client.get_stream(&id);
         assert_eq!(stream.payer, payer);
-        assert_eq!(stream.recipient, recipient);
+        assert_eq!(stream.recipients.len(), 1);
+        assert_eq!(stream.recipients.get(0).unwrap().recipient, recipient);
+        assert_eq!(stream.recipients.get(0).unwrap().weight, 1);
         assert_eq!(stream.rate_per_ledger, RATE);
         assert_eq!(stream.deposited, DEPOSIT);
-        assert_eq!(stream.claimed, 0);
+        assert_eq!(claimed_of(&stream), 0);
         assert_eq!(stream.start_ledger, env.ledger().sequence());
         assert!(!stream.paused);
         assert!(!stream.closed);
@@ -1326,7 +1458,7 @@ mod tests {
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 10);
 
         let claimed = client.claim_stream(&id, &recipient);
@@ -1334,7 +1466,7 @@ mod tests {
         assert_eq!(claimed, RATE * 10);
         assert_eq!(token.balance(&recipient), RATE * 10);
         assert_eq!(token.balance(&contract_id), DEPOSIT - RATE * 10);
-        assert_eq!(client.get_stream(&id).claimed, RATE * 10);
+        assert_eq!(claimed_of(&client.get_stream(&id)), RATE * 10);
     }
 
     #[test]
@@ -1343,7 +1475,7 @@ mod tests {
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
 
         advance_by(&env, 5);
         assert_eq!(client.claim_stream(&id, &recipient), RATE * 5);
@@ -1354,7 +1486,7 @@ mod tests {
         assert_eq!(client.claim_stream(&id, &recipient), 0);
 
         assert_eq!(token.balance(&recipient), RATE * 12);
-        assert_eq!(client.get_stream(&id).claimed, RATE * 12);
+        assert_eq!(claimed_of(&client.get_stream(&id)), RATE * 12);
     }
 
     #[test]
@@ -1363,19 +1495,19 @@ mod tests {
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
 
         // Run far past the funded window: accrual stops at the deposit.
         advance_by(&env, 10_000);
 
-        assert_eq!(client.get_claimable(&id), DEPOSIT);
+        assert_eq!(client.get_claimable(&id, &recipient), DEPOSIT);
         assert_eq!(client.claim_stream(&id, &recipient), DEPOSIT);
         assert_eq!(client.claim_stream(&id, &recipient), 0);
         assert_eq!(token.balance(&recipient), DEPOSIT);
         assert_eq!(token.balance(&contract_id), 0);
 
         let stream = client.get_stream(&id);
-        assert_eq!(stream.claimed, stream.deposited);
+        assert_eq!(claimed_of(&stream), stream.deposited);
     }
 
     #[test]
@@ -1385,9 +1517,9 @@ mod tests {
             stream_fixture(&env, DEPOSIT * 2);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 1_000); // Drain the original runway exactly.
-        assert_eq!(client.get_claimable(&id), DEPOSIT);
+        assert_eq!(client.get_claimable(&id, &recipient), DEPOSIT);
 
         client.top_up_stream(&id, &payer, &DEPOSIT);
 
@@ -1395,9 +1527,9 @@ mod tests {
         assert_eq!(token.balance(&contract_id), DEPOSIT * 2);
 
         // The top-up extends the runway rather than paying out immediately.
-        assert_eq!(client.get_claimable(&id), DEPOSIT);
+        assert_eq!(client.get_claimable(&id, &recipient), DEPOSIT);
         advance_by(&env, 10);
-        assert_eq!(client.get_claimable(&id), DEPOSIT + RATE * 10);
+        assert_eq!(client.get_claimable(&id, &recipient), DEPOSIT + RATE * 10);
     }
 
     #[test]
@@ -1406,7 +1538,7 @@ mod tests {
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 20);
         client.close_stream(&id, &payer);
 
@@ -1417,8 +1549,42 @@ mod tests {
 
         let stream = client.get_stream(&id);
         assert!(stream.closed);
-        assert_eq!(stream.claimed, streamed);
-        assert_eq!(client.get_claimable(&id), 0);
+        assert_eq!(claimed_of(&stream), streamed);
+        assert_eq!(client.get_claimable(&id, &recipient), 0);
+    }
+
+    /// #558 — close_stream must emit an event carrying the stream id and the
+    /// refunded amount, not just return them, so off-chain indexers can track
+    /// closures without polling.
+    #[test]
+    fn test_close_stream_emits_event_with_refund() {
+        use soroban_sdk::{testutils::Events, vec, IntoVal};
+
+        let env = Env::default();
+        let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
+        advance_by(&env, 20);
+        client.close_stream(&id, &payer);
+
+        let streamed = RATE * 20;
+        let refund = DEPOSIT - streamed;
+
+        // close_stream also triggers token-contract transfer events, so check
+        // just the last published event (ours) rather than the full list.
+        let all_events = env.events().all();
+        let last_event = all_events.slice(all_events.len() - 1..);
+        assert_eq!(
+            last_event,
+            vec![
+                &env,
+                (
+                    contract_id,
+                    (Symbol::new(&env, "stream_close"), id).into_val(&env),
+                    (streamed, refund).into_val(&env),
+                ),
+            ]
+        );
     }
 
     #[test]
@@ -1427,7 +1593,7 @@ mod tests {
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 30);
         client.claim_stream(&id, &recipient);
         advance_by(&env, 20);
@@ -1439,7 +1605,7 @@ mod tests {
         assert_eq!(token.balance(&recipient), streamed);
         assert_eq!(token.balance(&payer), DEPOSIT - streamed);
         assert_eq!(token.balance(&contract_id), 0);
-        assert_eq!(client.get_stream(&id).claimed, streamed);
+        assert_eq!(claimed_of(&client.get_stream(&id)), streamed);
     }
 
     #[test]
@@ -1447,14 +1613,14 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
-        assert_eq!(client.get_claimable(&id), 0);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
+        assert_eq!(client.get_claimable(&id, &recipient), 0);
 
         advance_by(&env, 3);
-        assert_eq!(client.get_claimable(&id), RATE * 3);
+        assert_eq!(client.get_claimable(&id, &recipient), RATE * 3);
 
         client.claim_stream(&id, &recipient);
-        assert_eq!(client.get_claimable(&id), 0);
+        assert_eq!(client.get_claimable(&id, &recipient), 0);
     }
 
     #[test]
@@ -1471,7 +1637,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 10);
 
         let stranger = Address::generate(&env);
@@ -1484,7 +1650,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
 
         let stranger = Address::generate(&env);
         client.close_stream(&id, &stranger);
@@ -1495,7 +1661,7 @@ mod tests {
     fn test_invalid_rate() {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
-        client.open_stream(&token_id, &payer, &recipient, &0i128, &DEPOSIT);
+        open_single_stream(&env, &client, &token_id, &payer, &recipient, 0i128, DEPOSIT);
     }
 
     #[test]
@@ -1503,7 +1669,7 @@ mod tests {
     fn test_invalid_deposit() {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
-        client.open_stream(&token_id, &payer, &recipient, &RATE, &0i128);
+        open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, 0i128);
     }
 
     // ── Dust-stream validation (#561) ───────────────────────────────────────
@@ -1514,7 +1680,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let dust = MIN_STREAM_DEPOSIT - 1;
-        client.open_stream(&token_id, &payer, &recipient, &1i128, &dust);
+        open_single_stream(&env, &client, &token_id, &payer, &recipient, 1i128, dust);
     }
 
     #[test]
@@ -1523,7 +1689,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         // Deposit clears the minimum, but this rate drains it in 10 ledgers.
-        client.open_stream(&token_id, &payer, &recipient, &1_000i128, &10_000i128);
+        open_single_stream(&env, &client, &token_id, &payer, &recipient, 1_000i128, 10_000i128);
     }
 
     #[test]
@@ -1532,7 +1698,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         // rate > deposit funds zero whole ledgers.
-        client.open_stream(&token_id, &payer, &recipient, &20_000i128, &10_000i128);
+        open_single_stream(&env, &client, &token_id, &payer, &recipient, 20_000i128, 10_000i128);
     }
 
     #[test]
@@ -1540,8 +1706,164 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, MIN_STREAM_DEPOSIT);
         // 10_000 / 166 == 60 ledgers, exactly MIN_STREAM_DURATION_LEDGERS.
-        let id = client.open_stream(&token_id, &payer, &recipient, &166i128, &MIN_STREAM_DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, 166i128, MIN_STREAM_DEPOSIT);
         assert_eq!(client.get_stream(&id).deposited, MIN_STREAM_DEPOSIT);
+    }
+
+    // ── Multi-recipient streams (#559) ──────────────────────────────────────
+
+    #[test]
+    fn test_open_stream_multiple_recipients_records_shares() {
+        let env = Env::default();
+        let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+        let second = Address::generate(&env);
+
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient.clone(), second.clone()],
+            &soroban_sdk::vec![&env, 1u32, 3u32],
+            &RATE,
+            &DEPOSIT,
+        );
+
+        let stream = client.get_stream(&id);
+        assert_eq!(stream.recipients.len(), 2);
+        assert_eq!(stream.recipients.get(0).unwrap().recipient, recipient);
+        assert_eq!(stream.recipients.get(0).unwrap().weight, 1);
+        assert_eq!(stream.recipients.get(1).unwrap().recipient, second);
+        assert_eq!(stream.recipients.get(1).unwrap().weight, 3);
+    }
+
+    #[test]
+    fn test_claim_stream_multiple_recipients_pays_proportionally() {
+        let env = Env::default();
+        let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+        let token = token::Client::new(&env, &token_id);
+        let second = Address::generate(&env);
+
+        // Weights 1:3 — `recipient` gets a quarter of accrual, `second` gets
+        // three quarters.
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient.clone(), second.clone()],
+            &soroban_sdk::vec![&env, 1u32, 3u32],
+            &RATE,
+            &DEPOSIT,
+        );
+        advance_by(&env, 40);
+
+        assert_eq!(client.get_claimable(&id, &recipient), RATE * 40 / 4);
+        assert_eq!(client.get_claimable(&id, &second), RATE * 40 * 3 / 4);
+
+        assert_eq!(client.claim_stream(&id, &recipient), RATE * 40 / 4);
+        assert_eq!(client.claim_stream(&id, &second), RATE * 40 * 3 / 4);
+        assert_eq!(token.balance(&recipient), RATE * 40 / 4);
+        assert_eq!(token.balance(&second), RATE * 40 * 3 / 4);
+        assert_eq!(token.balance(&contract_id), DEPOSIT - RATE * 40);
+
+        // A second claim with no new accrual pays nothing, for either party.
+        assert_eq!(client.claim_stream(&id, &recipient), 0);
+        assert_eq!(client.claim_stream(&id, &second), 0);
+    }
+
+    #[test]
+    fn test_close_stream_multiple_recipients_settles_each() {
+        let env = Env::default();
+        let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+        let token = token::Client::new(&env, &token_id);
+        let second = Address::generate(&env);
+
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient.clone(), second.clone()],
+            &soroban_sdk::vec![&env, 1u32, 1u32],
+            &RATE,
+            &DEPOSIT,
+        );
+        advance_by(&env, 30);
+        // recipient claims their half early; second never claims.
+        client.claim_stream(&id, &recipient);
+        advance_by(&env, 20);
+        client.close_stream(&id, &payer);
+
+        let streamed = RATE * 50;
+        assert_eq!(token.balance(&recipient), streamed / 2);
+        assert_eq!(token.balance(&second), streamed / 2);
+        assert_eq!(token.balance(&payer), DEPOSIT - streamed);
+        assert_eq!(token.balance(&contract_id), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_claim_rejects_address_not_on_recipient_list() {
+        let env = Env::default();
+        let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+        let second = Address::generate(&env);
+
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient.clone(), second],
+            &soroban_sdk::vec![&env, 1u32, 1u32],
+            &RATE,
+            &DEPOSIT,
+        );
+        advance_by(&env, 10);
+
+        let stranger = Address::generate(&env);
+        client.claim_stream(&id, &stranger);
+    }
+
+    #[test]
+    #[should_panic(expected = "recipients and weights must have equal length")]
+    fn test_open_stream_rejects_mismatched_recipients_and_weights() {
+        let env = Env::default();
+        let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+
+        client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient],
+            &soroban_sdk::vec![&env, 1u32, 1u32],
+            &RATE,
+            &DEPOSIT,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one recipient is required")]
+    fn test_open_stream_rejects_empty_recipients() {
+        let env = Env::default();
+        let (_, client, token_id, payer, _recipient) = stream_fixture(&env, DEPOSIT);
+
+        client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::Vec::new(&env),
+            &soroban_sdk::Vec::new(&env),
+            &RATE,
+            &DEPOSIT,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "weight must be positive")]
+    fn test_open_stream_rejects_zero_weight() {
+        let env = Env::default();
+        let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+        let second = Address::generate(&env);
+
+        client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient, second],
+            &soroban_sdk::vec![&env, 1u32, 0u32],
+            &RATE,
+            &DEPOSIT,
+        );
     }
 
     // ── Pausable streams (#560) ─────────────────────────────────────────────
@@ -1551,16 +1873,16 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 10);
         client.pause_stream(&id, &payer);
 
-        let at_pause = client.get_claimable(&id);
+        let at_pause = client.get_claimable(&id, &recipient);
         assert_eq!(at_pause, RATE * 10);
 
         // 500 ledgers of paused time must not accrue anything.
         advance_by(&env, 500);
-        assert_eq!(client.get_claimable(&id), at_pause);
+        assert_eq!(client.get_claimable(&id, &recipient), at_pause);
 
         let stream = client.get_stream(&id);
         assert!(stream.paused);
@@ -1572,17 +1894,17 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 10);
         client.pause_stream(&id, &payer);
         advance_by(&env, 500);
         client.resume_stream(&id, &payer);
 
         // Resuming does not back-pay the pause…
-        assert_eq!(client.get_claimable(&id), RATE * 10);
+        assert_eq!(client.get_claimable(&id, &recipient), RATE * 10);
         // …and accrual picks up from where it stopped.
         advance_by(&env, 10);
-        assert_eq!(client.get_claimable(&id), RATE * 20);
+        assert_eq!(client.get_claimable(&id, &recipient), RATE * 20);
 
         let stream = client.get_stream(&id);
         assert!(!stream.paused);
@@ -1595,7 +1917,7 @@ mod tests {
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 40);
         client.pause_stream(&id, &payer);
         advance_by(&env, 200);
@@ -1612,7 +1934,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 25);
         client.pause_stream(&id, &payer);
         advance_by(&env, 100);
@@ -1627,7 +1949,7 @@ mod tests {
         let (contract_id, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
         let token = token::Client::new(&env, &token_id);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         advance_by(&env, 15);
         client.pause_stream(&id, &payer);
         advance_by(&env, 400);
@@ -1645,7 +1967,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         client.pause_stream(&id, &payer);
         client.pause_stream(&id, &payer);
     }
@@ -1656,7 +1978,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         client.resume_stream(&id, &payer);
     }
 
@@ -1666,7 +1988,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         client.pause_stream(&id, &recipient);
     }
 
@@ -1676,7 +1998,7 @@ mod tests {
         let env = Env::default();
         let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
 
-        let id = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
         client.close_stream(&id, &payer);
         client.pause_stream(&id, &payer);
     }
@@ -1784,7 +2106,7 @@ mod tests {
 
             let mut ids = [0u32; STREAMS];
             for id_slot in ids.iter_mut() {
-                *id_slot = client.open_stream(&token_id, &payer, &recipient, &RATE, &DEPOSIT);
+                *id_slot = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
             }
             let mut closed = [false; STREAMS];
             let mut paused = [false; STREAMS];
@@ -1833,27 +2155,28 @@ mod tests {
                 let mut outstanding: i128 = 0;
                 for (slot, stream_id) in ids.iter().enumerate() {
                     let stream = client.get_stream(stream_id);
+                    let claimed = claimed_of(&stream);
                     assert!(
-                        stream.claimed <= stream.deposited,
+                        claimed <= stream.deposited,
                         "invariant violated (seed {}, step {}, stream {}): claimed {} > deposited {}",
                         seed,
                         step,
                         slot,
-                        stream.claimed,
+                        claimed,
                         stream.deposited
                     );
                     assert!(
-                        stream.claimed >= 0,
+                        claimed >= 0,
                         "negative claimed (seed {}, step {}, stream {}): {}",
                         seed,
                         step,
                         slot,
-                        stream.claimed
+                        claimed
                     );
 
-                    let claimable = client.get_claimable(stream_id);
+                    let claimable = client.get_claimable(stream_id, &recipient);
                     assert!(
-                        claimable <= stream.deposited - stream.claimed,
+                        claimable <= stream.deposited - claimed,
                         "claimable {} exceeds remaining deposit (seed {}, step {}, stream {})",
                         claimable,
                         seed,
@@ -1862,7 +2185,7 @@ mod tests {
                     );
 
                     if !closed[slot] {
-                        outstanding += stream.deposited - stream.claimed;
+                        outstanding += stream.deposited - claimed;
                     }
                 }
 

--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -660,6 +660,16 @@ impl MicroPayContract {
                 panic!("weight must be positive");
             }
         }
+        // A duplicated address would only ever be reachable through its first
+        // list entry — find_recipient() returns the first match — silently
+        // stranding the rest of that recipient's weight until close_stream.
+        for i in 0..recipients.len() {
+            for j in (i + 1)..recipients.len() {
+                if recipients.get(i).unwrap() == recipients.get(j).unwrap() {
+                    panic!("recipients must not contain duplicate addresses");
+                }
+            }
+        }
         if rate_per_ledger <= 0 {
             panic!("rate_per_ledger must be positive");
         }
@@ -719,7 +729,7 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_open"), stream_id),
-            (payer, recipients, rate_per_ledger, deposit),
+            (payer, recipients, weights, rate_per_ledger, deposit),
         );
         stream_id
     }
@@ -1861,6 +1871,22 @@ mod tests {
             &payer,
             &soroban_sdk::vec![&env, recipient, second],
             &soroban_sdk::vec![&env, 1u32, 0u32],
+            &RATE,
+            &DEPOSIT,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "recipients must not contain duplicate addresses")]
+    fn test_open_stream_rejects_duplicate_recipient() {
+        let env = Env::default();
+        let (_, client, token_id, payer, recipient) = stream_fixture(&env, DEPOSIT);
+
+        client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient.clone(), recipient],
+            &soroban_sdk::vec![&env, 1u32, 1u32],
             &RATE,
             &DEPOSIT,
         );


### PR DESCRIPTION
  Closes #559, closes #558, closes #563, closes #565

  ## Summary

  - **#559** — `open_stream` now accepts a `(recipients, weights)` pair instead of
    a single recipient, splitting a stream's payout proportionally by weight.
    `claim_stream` pays out each recipient's own weighted share; existing
    single-recipient streams work unchanged as a one-element list.
  - **#558** — `close_stream`'s existing `stream_close` event is now covered by
    a test asserting its topics/data (stream id + refunded amount).
  - **#563** — Added a `proptest`-based fuzz harness (`src/fuzz_streams.rs`)
    that runs randomized claim/top_up/close sequences — across a random number
    of recipients and weights — checking the `claimed <= deposited` invariant
    and contract solvency after every call. Runs as part of the existing
    `cargo test` CI job. No panics or overflows found on baseline runs.
  - **#565** — Added `contracts/certora/streaming.spec`, a Certora CVL spec
    documenting the `claimed <= deposited` invariant and the payer/recipient
    authorization rules, mirroring the sister project's escrow spec.

  ## Details

  - `Stream.recipient: Address` + `Stream.claimed: i128` are replaced by
    `Stream.recipients: Vec<StreamRecipient { recipient, weight, claimed }>`.
    `SCHEMA_VERSION` bumped 1 -> 2, with a migration-table entry and an
    upgrade-guide note that (unlike the purely-additive v1) this is a shape
    change and needs a real data rewrite before an in-place upgrade over any
    live v1 stream.
  - `open_stream` rejects mismatched-length recipient/weight lists, an empty
    recipient list, a zero weight, and duplicate recipient addresses (a
    duplicate would otherwise be reachable only through its first list entry).
  - `get_claimable` now takes a `recipient` parameter (ambiguous otherwise with
    multiple recipients).
  - `README.md` function reference, event docs, and fuzz/formal-verification
    sections updated to match.
  - Two incidental one-line fixes in `benchmarks.rs`, unrelated to the above,
    needed to get `cargo test` compiling against the currently-locked
    `soroban-sdk` version: a renamed budget-cost method, and a `no_std`/
    `eprintln!` macro-resolution fix.

  ## Test plan

  - [x] `cargo check --target wasm32-unknown-unknown`
  - [x] `cargo test` — 64/64 passing, including new multi-recipient,
        duplicate-recipient, close-event, and fuzz tests
  - [x] `cargo build --target wasm32-unknown-unknown --release`