### PR TITLE
Add controller JSDoc types, dedupe Horizon server, virtualize long lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           NEXT_PUBLIC_HORIZON_URL: https://horizon-testnet.stellar.org
           NEXT_PUBLIC_API_URL: http://localhost:4000
 
+      - name: Bundle size budget
+        run: npm run size
+
   # ─── Backend ───────────────────────────────────────────────────────────────
   backend:
     name: Backend (Node.js)

--- a/backend/src/controllers/accountController.js
+++ b/backend/src/controllers/accountController.js
@@ -9,7 +9,30 @@ const stellarService = require("../services/stellarService");
 const usernameService = require("../services/usernameService");
 
 /**
+ * @typedef {object} AccountBalanceEntry
+ * @property {string} assetCode
+ * @property {string} balance
+ * @property {string} [assetIssuer]
+ * @property {string} asset_type
+ */
+
+/**
+ * @typedef {object} AccountResponse
+ * @property {string} publicKey
+ * @property {string} sequence
+ * @property {AccountBalanceEntry[]} balances
+ * @property {number} subentryCount
+ */
+
+/**
  * GET /api/accounts/:publicKey
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: AccountResponse }`
  */
 async function getAccount(req, res, next) {
   try {
@@ -23,6 +46,13 @@ async function getAccount(req, res, next) {
 
 /**
  * GET /api/accounts/:publicKey/balance
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { publicKey: string, xlm: string } }`
  */
 async function getBalance(req, res, next) {
   try {
@@ -37,6 +67,15 @@ async function getBalance(req, res, next) {
 /**
  * POST /api/accounts/register
  * Register a new username with a public key.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.body
+ * @param {string} req.body.username - Desired username (3-20 alphanumeric chars)
+ * @param {string} req.body.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} 201 JSON: `{ success: true, data: { username: string, publicKey: string }, message: string }`,
+ *   or 400 JSON: `{ error: string }` when username/publicKey are missing
  */
 async function registerUsername(req, res, next) {
   try {
@@ -62,6 +101,14 @@ async function registerUsername(req, res, next) {
 /**
  * GET /api/accounts/resolve/:username
  * Resolve a username to its associated public key.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.username - Registered username to resolve
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { username: string, publicKey: string } }`,
+ *   or 501 JSON: `{ error: string }` for the reserved "alice" username
  */
 async function resolveUsername(req, res, next) {
   try {

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -9,8 +9,54 @@ const analyticsService = require("../services/analyticsService");
 const stellarService = require("../services/stellarService");
 
 /**
+ * @typedef {object} AnalyticsSummary
+ * @property {string} publicKey
+ * @property {string} totalSentXLM
+ * @property {string} totalReceivedXLM
+ * @property {number} uniqueCounterparties
+ * @property {string} averageTransactionSize
+ * @property {number} totalTransactions
+ * @property {object} comparison
+ * @property {number} comparison.thisWeekCount
+ * @property {number} comparison.lastWeekCount
+ * @property {number} comparison.countChangePercent
+ * @property {string} comparison.thisWeekVolume
+ * @property {string} comparison.lastWeekVolume
+ * @property {number} comparison.volumeChangePercent
+ */
+
+/**
+ * @typedef {object} TopRecipientsResponse
+ * @property {string} publicKey
+ * @property {Array<{address: string, totalXLMSent: string}>} topRecipients
+ * @property {number} count
+ */
+
+/**
+ * @typedef {object} ActivityByDayResponse
+ * @property {string} publicKey
+ * @property {Array<{day: string, dayIndex: number, transactionCount: number}>} activityByDay
+ */
+
+/**
+ * @typedef {object} CohortBreakdownResponse
+ * @property {string} publicKey
+ * @property {"week"|"month"} period
+ * @property {number} periods
+ * @property {{start: string|null, end: string|null}} range
+ * @property {Array<object>} cohorts
+ */
+
+/**
  * GET /api/analytics/:publicKey/summary
  * Returns: total sent, received, unique counterparties, avg transaction size.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: AnalyticsSummary }`
  */
 async function getSummary(req, res, next) {
   try {
@@ -25,6 +71,13 @@ async function getSummary(req, res, next) {
 /**
  * GET /api/analytics/:publicKey/top-recipients
  * Returns: top 5 addresses by total XLM sent.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: TopRecipientsResponse }`
  */
 async function getTopRecipients(req, res, next) {
   try {
@@ -39,6 +92,13 @@ async function getTopRecipients(req, res, next) {
 /**
  * GET /api/analytics/:publicKey/activity
  * Returns: payment count by day of week (all 7 days).
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: ActivityByDayResponse }`
  */
 async function getActivityByDay(req, res, next) {
   try {
@@ -53,6 +113,16 @@ async function getActivityByDay(req, res, next) {
 /**
  * GET /api/analytics/:publicKey/cohorts
  * Returns repeat vs one-time counterparties grouped by period.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} req.query
+ * @param {"week"|"month"} [req.query.period] - Cohort bucket size, defaults to "month"
+ * @param {string} [req.query.periods] - Number of buckets to return (max 12, default 6)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: CohortBreakdownResponse }`
  */
 async function getCohortBreakdown(req, res, next) {
   try {
@@ -68,6 +138,15 @@ async function getCohortBreakdown(req, res, next) {
 /**
  * GET /api/analytics/:publicKey/stream
  * Server-sent events stream for new payment operations.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response (kept open as a `text/event-stream`)
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} SSE stream emitting `event: payment` with a JSON-encoded
+ *   PaymentRecord-like payload, `event: error` with `{ message: string }`, and periodic
+ *   `: heartbeat` comments
  */
 async function streamPayments(req, res, next) {
   try {
@@ -120,6 +199,17 @@ async function streamPayments(req, res, next) {
 /**
  * POST /api/analytics/:publicKey/export-schedule
  * Set up recurring email export.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} req.body
+ * @param {string} req.body.email - Destination email address
+ * @param {"daily"|"weekly"} req.body.frequency - Export cadence
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} 201 JSON: `{ success: true, data: { publicKey: string, email: string,
+ *   frequency: string, nextRunAt: string }, message: string }`
  */
 async function scheduleExport(req, res, next) {
   try {
@@ -135,6 +225,14 @@ async function scheduleExport(req, res, next) {
 /**
  * GET /api/analytics/:publicKey/export-schedule
  * Get scheduled export configuration.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { publicKey: string, email: string,
+ *   frequency: string, nextRunAt: string } | null }`
  */
 async function getExportSchedule(req, res, next) {
   try {
@@ -149,6 +247,14 @@ async function getExportSchedule(req, res, next) {
 /**
  * POST /api/analytics/:publicKey/export-trigger
  * Manually trigger sending export email.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { success: true }, message: string }`,
+ *   or 404 (via next) when no export schedule exists for this public key
  */
 async function triggerExport(req, res, next) {
   try {

--- a/backend/src/controllers/federationController.js
+++ b/backend/src/controllers/federationController.js
@@ -9,8 +9,24 @@ const axios = require("axios");
 const usernameService = require("../services/usernameService");
 
 /**
+ * @typedef {object} FederationResponse
+ * @property {string} stellar_address - `username*domain` federated address
+ * @property {string} account_id - Stellar public key (G...)
+ */
+
+/**
  * GET /federation?q=<query>&type=<type>
  * Federation endpoint per SEP-0002.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.query
+ * @param {string} req.query.q - Stellar address (`type=name`) or account ID (`type=id`) to resolve
+ * @param {"name"|"id"} req.query.type - Resolution direction
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `FederationResponse` (or the forwarded external federation
+ *   server's response body when the domain isn't ours), or `{ error: string }` with
+ *   400/404 status on invalid input or unresolvable lookups
  */
 async function resolveFederation(req, res, next) {
   try {

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -8,7 +8,32 @@
 const stellarService = require("../services/stellarService");
 
 /**
+ * @typedef {object} PaymentRecord
+ * @property {string} id
+ * @property {"sent"|"received"} type
+ * @property {string} amount
+ * @property {string} asset
+ * @property {string} from
+ * @property {string} to
+ * @property {string} createdAt
+ * @property {string} transactionHash
+ * @property {string} pagingToken
+ * @property {string} [memo]
+ */
+
+/**
  * GET /api/payments/:publicKey
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} req.query
+ * @param {string} [req.query.limit] - Max records to return (1-100, default 20)
+ * @param {string} [req.query.cursor] - Horizon paging token to continue from
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: PaymentRecord[] }`,
+ *   or 400 JSON: `{ error: string }` when limit is not a positive integer
  */
 async function getPayments(req, res, next) {
   try {
@@ -37,6 +62,14 @@ async function getPayments(req, res, next) {
 /**
  * GET /api/payments/:publicKey/stats
  * Computes aggregate payment statistics for a wallet.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.publicKey - Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { publicKey: string, totalSentXLM: string,
+ *   totalReceivedXLM: string, sentCount: number, receivedCount: number, totalTransactions: number } }`
  */
 async function getStats(req, res, next) {
   try {

--- a/backend/src/controllers/tipsController.js
+++ b/backend/src/controllers/tipsController.js
@@ -8,8 +8,41 @@
 const tipsService = require("../services/tipsService");
 
 /**
+ * @typedef {object} TipRecord
+ * @property {number} id
+ * @property {string} senderPublicKey
+ * @property {string} creatorPublicKey
+ * @property {string} amount
+ * @property {string} asset
+ * @property {string} memo
+ * @property {string} txHash
+ * @property {string} timestamp
+ */
+
+/**
+ * @typedef {object} TipsStats
+ * @property {number} totalTips
+ * @property {Object<string, {count: number, amount: string}>} totalByAsset
+ * @property {string|null} averageTip
+ * @property {string|null} largestTip
+ * @property {string|null} smallestTip
+ */
+
+/**
  * POST /api/tips
  * Record a new tip.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.body
+ * @param {string} req.body.senderPublicKey - Sender's Stellar public key (G...)
+ * @param {string} req.body.creatorPublicKey - Creator's Stellar public key (G...)
+ * @param {string|number} req.body.amount - Positive tip amount
+ * @param {string} [req.body.asset] - Asset code, defaults to "XLM"
+ * @param {string} [req.body.memo] - Optional message from sender
+ * @param {string} [req.body.txHash] - On-chain transaction hash
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} 201 JSON: `{ success: true, data: TipRecord, message: string }`
  */
 async function recordTip(req, res, next) {
   try {
@@ -40,6 +73,17 @@ async function recordTip(req, res, next) {
 /**
  * GET /api/tips/received/:creatorPublicKey
  * Get all tips received by a creator.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.creatorPublicKey - Creator's Stellar public key (G...)
+ * @param {object} req.query
+ * @param {string} [req.query.limit] - Max tips to return
+ * @param {string} [req.query.offset] - Number of tips to skip
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { tips: TipRecord[], total: number,
+ *   limit: number, offset: number, stats: TipsStats } }`
  */
 async function getTipsReceived(req, res, next) {
   try {
@@ -69,6 +113,13 @@ async function getTipsReceived(req, res, next) {
 /**
  * GET /api/tips/stats/:creatorPublicKey
  * Get statistics for tips received by a creator.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.creatorPublicKey - Creator's Stellar public key (G...)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: TipsStats }`
  */
 async function getTipsStats(req, res, next) {
   try {
@@ -86,6 +137,17 @@ async function getTipsStats(req, res, next) {
 /**
  * GET /api/tips/sent/:senderPublicKey
  * Get all tips sent by a user.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.senderPublicKey - Sender's Stellar public key (G...)
+ * @param {object} req.query
+ * @param {string} [req.query.limit] - Max tips to return
+ * @param {string} [req.query.offset] - Number of tips to skip
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { tips: TipRecord[], total: number,
+ *   limit: number, offset: number } }`
  */
 async function getTipsSent(req, res, next) {
   try {
@@ -109,6 +171,15 @@ async function getTipsSent(req, res, next) {
 /**
  * GET /api/tips/leaderboard/:creatorPublicKey
  * Get top tippers for a creator.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.creatorPublicKey - Creator's Stellar public key (G...)
+ * @param {object} req.query
+ * @param {string} [req.query.limit] - Max tippers to return, defaults to 5
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: Array<{ senderPublicKey: string, totalAmount: string }> }`
  */
 async function getTopTippers(req, res, next) {
   try {

--- a/backend/src/controllers/turretsController.js
+++ b/backend/src/controllers/turretsController.js
@@ -7,6 +7,58 @@
 
 const turretsService = require("../services/turretsService");
 
+/**
+ * @typedef {object} TxFunctionDeployment
+ * @property {string} id
+ * @property {string} ownerPublicKey
+ * @property {"dca"|"stop_loss"|"escrow_release"} type
+ * @property {"active"|"paused"|"completed"} status
+ * @property {object} config - Normalized txFunction config for the given type
+ * @property {string} deploymentHash
+ * @property {string} signedChallengeXDR
+ * @property {string} createdAt
+ * @property {number} createdAtMs
+ * @property {string} nextRunAt
+ * @property {string|null} lastExecutedAt
+ * @property {string|null} lastCheckedAt
+ * @property {number|null} lastObservedPriceUsd
+ * @property {string|null} lastError
+ */
+
+/**
+ * @typedef {object} ExecutionHistoryEntry
+ * @property {string} id
+ * @property {string} deploymentId
+ * @property {"created"|"executed"|"error"|"status"} status
+ * @property {string} message
+ * @property {object|null} result
+ * @property {string} createdAt
+ */
+
+/**
+ * @typedef {object} AuditLogEntry
+ * @property {string} id
+ * @property {string} action
+ * @property {string} actor
+ * @property {string} deploymentId
+ * @property {object} details
+ * @property {string} timestamp
+ */
+
+/**
+ * POST /api/turrets/challenge
+ * Build an unsigned challenge transaction the owner must sign to authorize deployment.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.body
+ * @param {string} req.body.ownerPublicKey - Owner's Stellar public key (G...)
+ * @param {"dca"|"stop_loss"|"escrow_release"} req.body.type - txFunction type
+ * @param {object} req.body.config - Type-specific configuration (validated/normalized server-side)
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {Promise<void>} JSON: `{ success: true, data: { challengeXDR: string, deploymentHash: string,
+ *   normalizedConfig: object, networkPassphrase: string } }`
+ */
 async function createChallenge(req, res, next) {
   try {
     const { ownerPublicKey, type, config } = req.body;
@@ -17,6 +69,21 @@ async function createChallenge(req, res, next) {
   }
 }
 
+/**
+ * POST /api/turrets/deploy
+ * Deploy a signed txFunction after verifying the owner's signature.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.body
+ * @param {string} req.body.ownerPublicKey - Owner's Stellar public key (G...)
+ * @param {"dca"|"stop_loss"|"escrow_release"} req.body.type - txFunction type
+ * @param {object} req.body.config - Type-specific configuration
+ * @param {string} req.body.deploymentHash - Hash returned by the challenge step
+ * @param {string} req.body.signedChallengeXDR - Challenge transaction signed by the owner
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} 201 JSON: `{ success: true, data: TxFunctionDeployment }`
+ */
 function deploy(req, res, next) {
   try {
     const { ownerPublicKey, type, config, deploymentHash, signedChallengeXDR } = req.body;
@@ -33,6 +100,17 @@ function deploy(req, res, next) {
   }
 }
 
+/**
+ * GET /api/turrets?ownerPublicKey=<publicKey>
+ * List deployed txFunctions, optionally filtered by owner.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.query
+ * @param {string} [req.query.ownerPublicKey] - Filter to deployments owned by this public key
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: TxFunctionDeployment[] }`
+ */
 function list(req, res, next) {
   try {
     const ownerPublicKey = req.query.ownerPublicKey;
@@ -43,6 +121,18 @@ function list(req, res, next) {
   }
 }
 
+/**
+ * GET /api/turrets/:id
+ * Get a single txFunction deployment by ID.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.id - Deployment ID
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: TxFunctionDeployment }`, or 404 (via next)
+ *   when the deployment doesn't exist
+ */
 function getOne(req, res, next) {
   try {
     const { id } = req.params;
@@ -53,6 +143,18 @@ function getOne(req, res, next) {
   }
 }
 
+/**
+ * GET /api/turrets/:id/history
+ * Get execution history for a txFunction deployment.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.id - Deployment ID
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: ExecutionHistoryEntry[] }`, or 404 (via next)
+ *   when the deployment doesn't exist
+ */
 function getHistory(req, res, next) {
   try {
     const { id } = req.params;
@@ -64,6 +166,17 @@ function getHistory(req, res, next) {
   }
 }
 
+/**
+ * POST /api/turrets/:id/pause
+ * Pause an active txFunction deployment.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.id - Deployment ID
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: TxFunctionDeployment }`
+ */
 function pause(req, res, next) {
   try {
     const { id } = req.params;
@@ -75,6 +188,17 @@ function pause(req, res, next) {
   }
 }
 
+/**
+ * POST /api/turrets/:id/resume
+ * Resume a paused txFunction deployment.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.params
+ * @param {string} req.params.id - Deployment ID
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: TxFunctionDeployment }`
+ */
 function resume(req, res, next) {
   try {
     const { id } = req.params;
@@ -86,6 +210,20 @@ function resume(req, res, next) {
   }
 }
 
+/**
+ * GET /api/turrets/audit-log
+ * Get audit log entries, optionally filtered.
+ *
+ * @param {object} req - Express request
+ * @param {object} req.query
+ * @param {string} [req.query.actor] - Filter by actor's Stellar public key
+ * @param {string} [req.query.deploymentId] - Filter by deployment ID
+ * @param {string} [req.query.action] - Filter by action name (e.g. "deploy", "paused")
+ * @param {string} [req.query.limit] - Max entries to return
+ * @param {object} res - Express response
+ * @param {function} next - Express error-handling callback
+ * @returns {void} JSON: `{ success: true, data: AuditLogEntry[] }`
+ */
 function getAuditLog(req, res, next) {
   try {
     const { actor, deploymentId, action, limit } = req.query;

--- a/backend/src/services/turretsService.js
+++ b/backend/src/services/turretsService.js
@@ -9,20 +9,17 @@ const crypto = require("crypto");
 const {
   Account,
   Asset,
-  Horizon,
   Keypair,
   Networks,
   Operation,
   Transaction,
   TransactionBuilder,
 } = require("@stellar/stellar-sdk");
+const { server } = require("../config/stellar");
 const logger = require("../utils/logger");
 
-const HORIZON_URL = process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
 const NETWORK_PASSPHRASE =
   process.env.STELLAR_NETWORK === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-
-const server = new Horizon.Server(HORIZON_URL);
 
 const deployments = new Map();
 const executionHistory = [];

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -1,12 +1,8 @@
 "use strict";
 
 const crypto = require("crypto");
-const { Horizon } = require("@stellar/stellar-sdk");
+const { server } = require("../config/stellar");
 const logger = require("../utils/logger");
-require("dotenv").config();
-
-const HORIZON_URL = process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
-const server = new Horizon.Server(HORIZON_URL);
 
 // In-memory store: { id, publicKey, url, secret, createdAt }
 const webhooks = new Map();

--- a/frontend/components/CreatorTipsDashboard.tsx
+++ b/frontend/components/CreatorTipsDashboard.tsx
@@ -5,7 +5,13 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
+import VirtualizedList from "@/components/VirtualizedList";
 import { formatXLM, shortenAddress, formatUSD, exportTipsToCSV } from "@/utils/format";
+
+// Tip rows render virtualized past this count so long tip histories stay cheap to render.
+const VIRTUALIZE_THRESHOLD = 100;
+const ROW_HEIGHT_PX = 76;
+const VIRTUAL_VIEWPORT_HEIGHT_PX = ROW_HEIGHT_PX * 6;
 
 interface TipRecord {
   id: number;
@@ -96,6 +102,34 @@ export default function CreatorTipsDashboard({
     if (!stats?.totalByAsset?.XLM) return "0";
     return stats.totalByAsset.XLM.amount;
   };
+
+  const renderTipRow = (tip: TipRecord) => (
+    <div className="flex items-center justify-between p-3 rounded-lg bg-white/[0.02] border border-white/5 hover:border-stellar-500/20 transition-colors">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-full bg-stellar-500/10 border border-stellar-500/20 flex items-center justify-center">
+          <GiftIcon className="w-5 h-5 text-stellar-400" />
+        </div>
+        <div>
+          <p className="text-sm text-white font-medium">
+            {tip.amount} {tip.asset}
+          </p>
+          <p className="text-xs text-slate-400">
+            From: {shortenAddress(tip.senderPublicKey)}
+          </p>
+        </div>
+      </div>
+      <div className="text-right">
+        <p className="text-xs text-slate-400">
+          {formatTimestamp(tip.timestamp)}
+        </p>
+        {tip.memo && (
+          <p className="text-xs text-slate-400 mt-1 max-w-[200px] truncate">
+            &quot;{tip.memo}&quot;
+          </p>
+        )}
+      </div>
+    </div>
+  );
 
   if (!username) {
     return (
@@ -237,38 +271,16 @@ export default function CreatorTipsDashboard({
           </div>
         ) : (
           <>
-            <div className="space-y-2">
-              {tips.map((tip) => (
-                <div
-                  key={tip.id}
-                  className="flex items-center justify-between p-3 rounded-lg bg-white/[0.02] border border-white/5 hover:border-stellar-500/20 transition-colors"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-stellar-500/10 border border-stellar-500/20 flex items-center justify-center">
-                      <GiftIcon className="w-5 h-5 text-stellar-400" />
-                    </div>
-                    <div>
-                      <p className="text-sm text-white font-medium">
-                        {tip.amount} {tip.asset}
-                      </p>
-                      <p className="text-xs text-slate-400">
-                        From: {shortenAddress(tip.senderPublicKey)}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-xs text-slate-400">
-                      {formatTimestamp(tip.timestamp)}
-                    </p>
-                    {tip.memo && (
-                      <p className="text-xs text-slate-400 mt-1 max-w-[200px] truncate">
-                        &quot;{tip.memo}&quot;
-                      </p>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+            <VirtualizedList
+              items={tips}
+              itemKey={(tip) => tip.id}
+              renderItem={renderTipRow}
+              itemHeight={ROW_HEIGHT_PX}
+              height={VIRTUAL_VIEWPORT_HEIGHT_PX}
+              threshold={VIRTUALIZE_THRESHOLD}
+              ariaLabel="Tips received"
+              className="space-y-2"
+            />
 
             {/* Pagination */}
             {stats && stats.totalTips > pageSize && (

--- a/frontend/components/TransactionList.tsx
+++ b/frontend/components/TransactionList.tsx
@@ -5,7 +5,9 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
+import type { FixedSizeList, ListOnItemsRenderedProps } from "react-window";
 import { withErrorBoundary } from "@/components/ErrorBoundary";
+import VirtualizedList from "@/components/VirtualizedList";
 import {
   getPaymentHistory,
   shortenAddress,
@@ -24,6 +26,11 @@ import {
   PrinterIcon,
 } from "@/components/icons";
 import clsx from "clsx";
+
+// Rows render virtualized past this count so long payment histories stay cheap to render.
+const VIRTUALIZE_THRESHOLD = 100;
+const ROW_HEIGHT_PX = 76;
+const VIRTUAL_VIEWPORT_HEIGHT_PX = ROW_HEIGHT_PX * 6;
 
 export type TransactionDirectionFilter = "all" | "sent" | "received";
 
@@ -145,6 +152,10 @@ function TransactionList({
 
   const lastPagingTokenRef = useRef<string | undefined>(undefined);
   const [infiniteScroll, setInfiniteScroll] = useState(false);
+  const virtualListRef = useRef<FixedSizeList>(null);
+  const fetchingMoreRef = useRef(false);
+
+  const visiblePayments = filterPayments(payments, filters);
 
   // Sentinel ref for IntersectionObserver — defer initial fetch until visible
   const containerRef = useRef<HTMLDivElement>(null);
@@ -287,6 +298,28 @@ function TransactionList({
     upsertAddressBookContact({ nickname, address });
   };
 
+  // When virtualized, "Load more" / infinite scroll can't rely on a DOM
+  // sentinel below the list (react-window scrolls its own inner viewport),
+  // so trigger the next page once the rendered window nears the end instead.
+  const handleVirtualItemsRendered = useCallback(
+    ({ visibleStopIndex }: ListOnItemsRenderedProps) => {
+      if (!infiniteScroll || !hasMore || loading || fetchingMoreRef.current) return;
+      if (visibleStopIndex < visiblePayments.length - 5) return;
+
+      fetchingMoreRef.current = true;
+      fetchPayments(true).finally(() => {
+        fetchingMoreRef.current = false;
+      });
+    },
+    [infiniteScroll, hasMore, loading, fetchPayments, visiblePayments.length]
+  );
+
+  // Keep the focused row scrolled into view for keyboard navigation once virtualized.
+  useEffect(() => {
+    if (focusedIndex < 0) return;
+    virtualListRef.current?.scrollToItem(focusedIndex, "smart");
+  }, [focusedIndex]);
+
   // Prepend a newly streamed payment if it doesn't already exist
   useEffect(() => {
     if (!incomingPayment) return;
@@ -300,9 +333,133 @@ function TransactionList({
     });
   }, [incomingPayment, onPaymentsChange]);
 
-  const visiblePayments = filterPayments(payments, filters);
   const hasActiveFilters =
     filters.direction !== "all" || filters.minAmount.trim() !== "" || filters.memoSearch.trim() !== "";
+
+  const renderPaymentRow = (tx: PaymentRecord, index: number) => (
+    <div
+      role="listitem"
+      tabIndex={focusedIndex === index ? 0 : -1}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setFocusedIndex((prev) => Math.min(prev + 1, visiblePayments.length - 1));
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setFocusedIndex((prev) => Math.max(prev - 1, 0));
+        } else if (e.key === "Enter" && focusedIndex === index) {
+          e.preventDefault();
+          const address = tx.type === "sent" ? tx.to : tx.from;
+          copyToClipboard(address);
+          setCopiedId(tx.id);
+          setTimeout(() => setCopiedId(null), 2000);
+        }
+      }}
+      onBlur={() => setFocusedIndex(-1)}
+      onFocus={() => setFocusedIndex(index)}
+      className={clsx(
+        "flex items-center gap-3 p-3 rounded-xl bg-white/3 hover:bg-white/5 transition-colors group relative",
+        focusedIndex === index && "outline-none ring-2 ring-stellar-500 ring-offset-2"
+      )}
+      aria-label={`${tx.type === "sent" ? "Sent" : "Received"} ${formatAsset(tx.amount, tx.asset)} ${tx.type === "sent" ? "to" : "from"} ${tx.type === "sent" ? tx.to : tx.from}`}
+    >
+      {/* Direction icon */}
+      <div
+        className={clsx(
+          "w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0",
+          tx.type === "sent"
+            ? "bg-red-500/10 border border-red-500/20"
+            : "bg-emerald-500/10 border border-emerald-500/20"
+        )}
+      >
+        {tx.type === "sent" ? (
+          <ArrowUpIcon className="w-4 h-4 text-red-400" />
+        ) : (
+          <ArrowDownIcon className="w-4 h-4 text-emerald-400" />
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-slate-200 capitalize">
+            {tx.type === "sent" ? "Sent to" : "Received from"}
+          </span>
+          <button
+            onClick={() =>
+              handleCopy(
+                tx.type === "sent" ? tx.to : tx.from,
+                tx.id
+              )
+            }
+            aria-label={`Copy ${tx.type === "sent" ? "recipient" : "sender"} address`}
+            className="address-pill hover:border-stellar-500/40 transition-colors text-xs"
+          >
+            {copiedId === tx.id
+              ? "Copied!"
+              : shortenAddress(tx.type === "sent" ? tx.to : tx.from, 5)}
+          </button>
+        </div>
+        <div className="flex items-center gap-2 mt-0.5">
+          <span className="text-xs text-slate-400">
+            {timeAgo(tx.createdAt)}
+          </span>
+          {tx.memo && (
+            <span className="text-xs text-slate-600 truncate max-w-32">
+              · &ldquo;{tx.memo}&rdquo;
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Amount + link */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <span
+          className={clsx(
+            "text-sm font-mono font-medium",
+            tx.type === "sent" ? "text-red-400" : "text-emerald-400"
+          )}
+        >
+          {tx.type === "sent" ? "-" : "+"}
+          {formatAsset(tx.amount, tx.asset)}
+        </span>
+
+        <button
+          onClick={() => handleSaveContact(tx.type === "sent" ? tx.to : tx.from)}
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-xs text-slate-400 hover:text-stellar-300 font-medium whitespace-nowrap"
+          title="Save this address to contacts"
+          aria-label={`Save ${tx.type === "sent" ? "recipient" : "sender"} to contacts`}
+        >
+          Save contact
+        </button>
+
+        {/* Send Again — only for sent transactions */}
+        {tx.type === "sent" && (
+          <button
+            onClick={() =>
+              router.push(`/dashboard?to=${encodeURIComponent(tx.to)}&amount=${encodeURIComponent(tx.amount)}`)
+            }
+            className="opacity-0 group-hover:opacity-100 transition-opacity text-xs text-stellar-400 hover:text-stellar-300 font-medium whitespace-nowrap"
+            title="Pre-fill send form with this transaction"
+            aria-label="Send again to this recipient"
+          >
+            Send again
+          </button>
+        )}
+
+        <a
+          href={explorerUrl(tx.transactionHash) ?? undefined}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-400 hover:text-stellar-400"
+          title="View on Stellar Expert"
+          aria-label="View transaction on Stellar Expert"
+        >
+          <ExternalLinkIcon className="w-3.5 h-3.5" />
+        </a>
+      </div>
+    </div>
+  );
 
   if (loading) {
     return (
@@ -435,136 +592,18 @@ function TransactionList({
             <span>Keyboard navigation: ↑ ↓ to navigate, Enter to copy address</span>
           </div>
           
-          <div
-            role="list"
-            aria-label="Payment history"
+          <VirtualizedList
+            items={visiblePayments}
+            itemKey={(tx) => tx.id}
+            renderItem={renderPaymentRow}
+            itemHeight={ROW_HEIGHT_PX}
+            height={VIRTUAL_VIEWPORT_HEIGHT_PX}
+            threshold={VIRTUALIZE_THRESHOLD}
+            ariaLabel="Payment history"
             className="space-y-2"
-          >
-        {visiblePayments.map((tx, index) => (
-          <div
-            key={tx.id}
-            role="listitem"
-            tabIndex={focusedIndex === index ? 0 : -1}
-            onKeyDown={(e) => {
-              if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                setFocusedIndex((prev) => Math.min(prev + 1, visiblePayments.length - 1));
-              } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                setFocusedIndex((prev) => Math.max(prev - 1, 0));
-              } else if (e.key === 'Enter' && focusedIndex === index) {
-                e.preventDefault();
-                const address = tx.type === "sent" ? tx.to : tx.from;
-                copyToClipboard(address);
-                setCopiedId(tx.id);
-                setTimeout(() => setCopiedId(null), 2000);
-              }
-            }}
-            onBlur={() => setFocusedIndex(-1)}
-            onFocus={() => setFocusedIndex(index)}
-            className={clsx(
-              "flex items-center gap-3 p-3 rounded-xl bg-white/3 hover:bg-white/5 transition-colors group relative",
-              focusedIndex === index && "outline-none ring-2 ring-stellar-500 ring-offset-2"
-            )}
-            aria-label={`${tx.type === "sent" ? "Sent" : "Received"} ${formatAsset(tx.amount, tx.asset)} ${tx.type === "sent" ? "to" : "from"} ${tx.type === "sent" ? tx.to : tx.from}`}
-          >
-            {/* Direction icon */}
-            <div
-              className={clsx(
-                "w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0",
-                tx.type === "sent"
-                  ? "bg-red-500/10 border border-red-500/20"
-                  : "bg-emerald-500/10 border border-emerald-500/20"
-              )}
-            >
-              {tx.type === "sent" ? (
-                <ArrowUpIcon className="w-4 h-4 text-red-400" />
-              ) : (
-                <ArrowDownIcon className="w-4 h-4 text-emerald-400" />
-              )}
-            </div>
-
-            {/* Details */}
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-slate-200 capitalize">
-                  {tx.type === "sent" ? "Sent to" : "Received from"}
-                </span>
-                <button
-                  onClick={() =>
-                    handleCopy(
-                      tx.type === "sent" ? tx.to : tx.from,
-                      tx.id
-                    )
-                  }
-                  aria-label={`Copy ${tx.type === "sent" ? "recipient" : "sender"} address`}
-                  className="address-pill hover:border-stellar-500/40 transition-colors text-xs"
-                >
-                  {copiedId === tx.id
-                    ? "Copied!"
-                    : shortenAddress(tx.type === "sent" ? tx.to : tx.from, 5)}
-                </button>
-              </div>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span className="text-xs text-slate-400">
-                  {timeAgo(tx.createdAt)}
-                </span>
-                {tx.memo && (
-                  <span className="text-xs text-slate-600 truncate max-w-32">
-                    · &ldquo;{tx.memo}&rdquo;
-                  </span>
-                )}
-              </div>
-            </div>
-
-            {/* Amount + link */}
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <span
-                className={clsx(
-                  "text-sm font-mono font-medium",
-                  tx.type === "sent" ? "text-red-400" : "text-emerald-400"
-                )}
-              >
-                {tx.type === "sent" ? "-" : "+"}
-                {formatAsset(tx.amount, tx.asset)}
-              </span>
-
-              <button
-                onClick={() => handleSaveContact(tx.type === "sent" ? tx.to : tx.from)}
-                className="opacity-0 group-hover:opacity-100 transition-opacity text-xs text-slate-400 hover:text-stellar-300 font-medium whitespace-nowrap"
-                title="Save this address to contacts"
-                aria-label={`Save ${tx.type === "sent" ? "recipient" : "sender"} to contacts`}
-              >
-                Save contact
-              </button>
-
-              {/* Send Again — only for sent transactions */}
-              {tx.type === "sent" && (
-                <button
-                  onClick={() =>
-                    router.push(`/dashboard?to=${encodeURIComponent(tx.to)}&amount=${encodeURIComponent(tx.amount)}`)
-                  }
-                  className="opacity-0 group-hover:opacity-100 transition-opacity text-xs text-stellar-400 hover:text-stellar-300 font-medium whitespace-nowrap"
-                  title="Pre-fill send form with this transaction"
-                  aria-label="Send again to this recipient"
-                >
-                  Send again
-                </button>
-              )}
-              
-              <a
-                href={explorerUrl(tx.transactionHash) ?? undefined}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="opacity-0 group-hover:opacity-100 transition-opacity text-slate-400 hover:text-stellar-400"
-                title="View on Stellar Expert"
-                aria-label="View transaction on Stellar Expert"
-              >
-                <ExternalLinkIcon className="w-3.5 h-3.5" />
-              </a>
-            </div>
-          </div>
-        ))}
+            listRef={virtualListRef}
+            onItemsRendered={handleVirtualItemsRendered}
+          />
 
         {/* Infinite Scroll Sentinel / Loading Indicator */}
         {infiniteScroll && (
@@ -597,7 +636,6 @@ function TransactionList({
             </button>
           </div>
         )}
-      </div>
     </div>
   );
 }

--- a/frontend/components/VirtualizedList.tsx
+++ b/frontend/components/VirtualizedList.tsx
@@ -1,0 +1,73 @@
+/**
+ * components/VirtualizedList.tsx
+ * Renders a list of items normally until it crosses a configurable size
+ * threshold, then switches to windowed rendering (react-window) so only the
+ * rows visible in the viewport are mounted into the DOM.
+ */
+
+import { Fragment } from "react";
+import type { ReactNode, RefObject } from "react";
+import { FixedSizeList, ListOnItemsRenderedProps } from "react-window";
+
+interface VirtualizedListProps<T> {
+  items: T[];
+  itemKey: (item: T, index: number) => string | number;
+  renderItem: (item: T, index: number) => ReactNode;
+  /** Fixed row height in px, required for windowed rendering. */
+  itemHeight: number;
+  /** Height of the scroll viewport once virtualized. */
+  height: number;
+  /** Item count above which windowed rendering kicks in. Defaults to 100. */
+  threshold?: number;
+  className?: string;
+  listClassName?: string;
+  onItemsRendered?: (props: ListOnItemsRenderedProps) => void;
+  ariaLabel?: string;
+  /** Ref to the underlying react-window list, only populated once virtualized. */
+  listRef?: RefObject<FixedSizeList>;
+}
+
+function VirtualizedList<T>({
+  items,
+  itemKey,
+  renderItem,
+  itemHeight,
+  height,
+  threshold = 100,
+  className,
+  listClassName,
+  onItemsRendered,
+  ariaLabel,
+  listRef,
+}: VirtualizedListProps<T>) {
+  if (items.length <= threshold) {
+    return (
+      <div role="list" aria-label={ariaLabel} className={className}>
+        {items.map((item, index) => (
+          <Fragment key={itemKey(item, index)}>{renderItem(item, index)}</Fragment>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div role="list" aria-label={ariaLabel} className={listClassName}>
+      <FixedSizeList
+        ref={listRef}
+        height={height}
+        width="100%"
+        itemCount={items.length}
+        itemSize={itemHeight}
+        onItemsRendered={onItemsRendered}
+      >
+        {({ index, style }) => (
+          <div key={itemKey(items[index], index)} style={style}>
+            {renderItem(items[index], index)}
+          </div>
+        )}
+      </FixedSizeList>
+    </div>
+  );
+}
+
+export default VirtualizedList;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,10 +21,12 @@
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-window": "^1.8.11",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@size-limit/file": "^13.0.1",
         "@storybook/addon-a11y": "^8.6.14",
         "@storybook/addon-essentials": "^8.6.14",
         "@storybook/blocks": "^8.6.14",
@@ -38,6 +40,7 @@
         "@types/qrcode.react": "^1.0.5",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/react-window": "^1.8.8",
         "autoprefixer": "^10.0.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.3",
@@ -47,6 +50,7 @@
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
         "postcss": "^8",
+        "size-limit": "^13.0.1",
         "storybook": "^8.6.14",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.6",
@@ -126,6 +130,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2054,7 +2059,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2224,6 +2228,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2247,6 +2252,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2828,6 +2834,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
       "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -4235,6 +4242,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4292,6 +4300,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
       "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.56.0",
         "@types/shimmer": "^1.2.0",
@@ -4805,6 +4814,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4854,6 +4864,7 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -5652,6 +5663,19 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@size-limit/file": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-13.0.1.tgz",
+      "integrity": "sha512-qdbGUxRAjym5gnkYEjsNsdOfmkDUvDX06FLhLGUxQ0oJtIWDd2lsOmTMwh5JuAV1XmJCplbqpMJ2b5eIhHl7Lg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "13.0.1"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -6524,6 +6548,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6630,6 +6655,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7015,6 +7041,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7069,6 +7096,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -7080,8 +7108,19 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -7839,6 +7878,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7934,6 +7974,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9025,6 +9066,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9115,6 +9157,16 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -10843,6 +10895,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11784,6 +11837,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13435,6 +13489,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -14480,6 +14535,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -14519,6 +14575,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -14904,6 +14961,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -15107,6 +15170,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -15142,6 +15215,7 @@
       "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
       "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.3",
         "@swc/helpers": "0.5.5",
@@ -16135,6 +16209,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16751,6 +16826,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16830,6 +16906,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16842,13 +16919,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -16873,8 +16952,26 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -16993,7 +17090,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -17435,6 +17533,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
       "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17906,6 +18005,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/size-limit": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-13.0.1.tgz",
+      "integrity": "sha512-LKWgnVUfw79W5gcKGIHqjEqBMoZ+YgfYYzlDheYwbRJq1DaaRgOjotFm61YOI/4hbgh4V1Es0uGGp6HLktI3Vw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || ^24.0.0 || >=26.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -18030,6 +18149,7 @@
       "integrity": "sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.18"
       },
@@ -19009,6 +19129,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -19188,6 +19309,7 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19278,6 +19400,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19648,6 +19771,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -19724,6 +19848,7 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "size": "size-limit"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
@@ -29,10 +30,12 @@
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-window": "^1.8.11",
     "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@size-limit/file": "^13.0.1",
     "@storybook/addon-a11y": "^8.6.14",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/blocks": "^8.6.14",
@@ -46,15 +49,17 @@
     "@types/qrcode.react": "^1.0.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-window": "^1.8.8",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
-    "eslint-plugin-import": "^2.29.0",
     "eslint-import-resolver-typescript": "^3.6.0",
+    "eslint-plugin-import": "^2.29.0",
     "fast-check": "^3.22.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "postcss": "^8",
+    "size-limit": "^13.0.1",
     "storybook": "^8.6.14",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.4.6",
@@ -63,5 +68,21 @@
   },
   "engines": {
     "node": "20.19.5"
-  }
+  },
+  "size-limit": [
+    {
+      "name": "App shared bundle (_app)",
+      "path": "out/_next/static/chunks/pages/_app-*.js",
+      "limit": "270 KB"
+    },
+    {
+      "name": "Framework & runtime chunks",
+      "path": [
+        "out/_next/static/chunks/framework-*.js",
+        "out/_next/static/chunks/main-*.js",
+        "out/_next/static/chunks/polyfills-*.js"
+      ],
+      "limit": "105 KB"
+    }
+  ]
 }


### PR DESCRIPTION
  ## Summary

  - Add JSDoc typedefs documenting request/response shapes for every backend controller function,
  with no behavior change (#629)
  - Consolidate Horizon `Server` instantiation: `turretsService.js` and `webhookService.js` now
  reuse the shared instance from `config/stellar.js` instead of creating their own (#630)
  - Add a `size-limit` budget for the frontend's shared/app bundle and wire it into CI so PRs
  that exceed the budget fail the build (#607)
  - Virtualize `TransactionList` and `CreatorTipsDashboard` rows past a 100-item threshold via a
  new shared `VirtualizedList` component, preserving scroll, keyboard navigation, and click
  behavior (#609)

  ## Details

  - **Controllers**: added `@typedef` blocks + per-function `@param`/`@returns` JSDoc across
  `accountController`, `paymentController`, `tipsController`, `analyticsController`,
  `federationController`, and `turretsController`. Purely additive comments, no logic changes.
  - **Horizon config**: removed the duplicate `new Horizon.Server(...)` calls in
  `turretsService.js` and `webhookService.js`; both now `require("../config/stellar")` for the
  shared `server` singleton.
  - **Bundle budget**: added `size-limit` + `@size-limit/file`, configured against the real
  Next.js export output (`out/_next/static/chunks/...`) with budgets set ~10% above current
  measured sizes, and added a `Bundle size budget` step to the frontend CI job.
  - **Virtualization**: new `frontend/components/VirtualizedList.tsx` renders items normally
  below the threshold and switches to `react-window`'s `FixedSizeList` above it.
  `TransactionList` keeps keyboard navigation (scrolls the focused row into view) and infinite
  scroll (via `onItemsRendered` instead of a DOM sentinel, since virtualization has its own
  scroll viewport) working correctly once virtualized.

  ## Testing

  - Backend: `npm test` — same 26 pre-existing failures before/after (unrelated to this change),
  no regressions
  - Frontend: `npx tsc --noEmit` — same 53 pre-existing errors before/after (unrelated to this
  change), no regressions
  - Frontend: relevant Jest tests (`TransactionList` snapshot, `CreatorTipsDashboard`) pass
  - Verified `npm run size` passes at real build sizes and fails (non-zero exit) when a budget is
  deliberately lowered below actual size

  Closes #629
  Closes #630
  Closes #607
  Closes #609