### PR TITLE
test: add coverage for contacts e2e, logger, sanitization, and turretsService

### DIFF
--- a/backend/__tests__/logger.test.js
+++ b/backend/__tests__/logger.test.js
@@ -1,0 +1,123 @@
+/**
+ * __tests__/logger.test.js
+ * Unit tests for utils/logger.js (issue #536).
+ *
+ * Verifies log-level filtering and the structured output format (level,
+ * message, timestamp) by capturing what the logger writes to stdout.
+ */
+
+"use strict";
+
+function requireFreshLogger() {
+  jest.resetModules();
+  return require("../src/utils/logger");
+}
+
+function captureStdout() {
+  const lines = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    lines.push(chunk.toString());
+    return true;
+  };
+  return {
+    lines,
+    restore() {
+      process.stdout.write = originalWrite;
+    },
+  };
+}
+
+describe("logger", () => {
+  const originalLogLevel = process.env.LOG_LEVEL;
+  let capture;
+
+  afterEach(() => {
+    capture?.restore();
+    if (originalLogLevel === undefined) {
+      delete process.env.LOG_LEVEL;
+    } else {
+      process.env.LOG_LEVEL = originalLogLevel;
+    }
+  });
+
+  describe("log-level filtering", () => {
+    it("suppresses messages below the configured log level", () => {
+      process.env.LOG_LEVEL = "warn";
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.info("this should be suppressed");
+      logger.debug("this should also be suppressed");
+
+      expect(capture.lines).toHaveLength(0);
+    });
+
+    it("emits messages at or above the configured log level", () => {
+      process.env.LOG_LEVEL = "warn";
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.warn("this should appear");
+      logger.error("this should also appear");
+
+      expect(capture.lines).toHaveLength(2);
+    });
+
+    it("defaults to info level when LOG_LEVEL is unset", () => {
+      delete process.env.LOG_LEVEL;
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.debug("suppressed by default info level");
+      logger.info("visible at default info level");
+
+      expect(logger.level).toBe("info");
+      expect(capture.lines).toHaveLength(1);
+    });
+  });
+
+  describe("structured output format", () => {
+    it("includes level, message, and timestamp fields", () => {
+      process.env.LOG_LEVEL = "info";
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.info("hello world");
+
+      expect(capture.lines).toHaveLength(1);
+      const entry = JSON.parse(capture.lines[0]);
+
+      expect(entry.level).toBe("INFO");
+      expect(entry.msg).toBe("hello world");
+      expect(entry).toHaveProperty("time");
+      expect(new Date(entry.time).toISOString()).toBe(entry.time);
+    });
+
+    it("uppercases the level label for each severity", () => {
+      process.env.LOG_LEVEL = "debug";
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.debug("debug msg");
+      logger.warn("warn msg");
+      logger.error("error msg");
+
+      const levels = capture.lines.map((line) => JSON.parse(line).level);
+      expect(levels).toEqual(["DEBUG", "WARN", "ERROR"]);
+    });
+
+    it("merges structured fields passed alongside the message", () => {
+      process.env.LOG_LEVEL = "info";
+      const logger = requireFreshLogger();
+      capture = captureStdout();
+
+      logger.info({ userId: "abc123", action: "login" }, "user logged in");
+
+      const entry = JSON.parse(capture.lines[0]);
+      expect(entry.msg).toBe("user logged in");
+      expect(entry.userId).toBe("abc123");
+      expect(entry.action).toBe("login");
+    });
+  });
+});

--- a/backend/__tests__/sanitization.test.js
+++ b/backend/__tests__/sanitization.test.js
@@ -1,0 +1,149 @@
+/**
+ * __tests__/sanitization.test.js
+ * Unit tests for the sanitization middleware (issue #535).
+ *
+ * Verifies that script/HTML injection payloads are neutralised while valid
+ * Stellar addresses (and unrelated body fields such as memos/amounts) pass
+ * through unchanged.
+ */
+
+"use strict";
+
+const { sanitizePublicKey, sanitizeUsername } = require("../src/middleware/sanitization");
+
+const VALID_PUBLIC_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function createReq({ params = {}, body = {} } = {}) {
+  return { params, body };
+}
+
+function createRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("sanitizePublicKey", () => {
+  it("calls next() and leaves the request untouched when no publicKey param is present", () => {
+    const req = createReq({ params: {}, body: { memo: "coffee", amount: "5" } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(req.body).toEqual({ memo: "coffee", amount: "5" });
+  });
+
+  it("passes a valid Stellar public key through unchanged", () => {
+    const req = createReq({ params: { publicKey: VALID_PUBLIC_KEY } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(req.params.publicKey).toBe(VALID_PUBLIC_KEY);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("leaves unrelated body fields such as memo and amount unchanged", () => {
+    const req = createReq({
+      params: { publicKey: VALID_PUBLIC_KEY },
+      body: { memo: "Great work! <3", amount: "12.5000000" },
+    });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(req.body).toEqual({ memo: "Great work! <3", amount: "12.5000000" });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips non-alphanumeric injection characters wrapped around a valid key", () => {
+    const req = createReq({ params: { publicKey: `"'><${VALID_PUBLIC_KEY}<script>` } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    // The <script> tag's letters survive stripping (only non-alphanumeric chars
+    // are removed), so the sanitized value is no longer a valid 56-char key and
+    // must be rejected rather than silently passed through.
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pure script/HTML injection payload with a 400 and does not call next()", () => {
+    const req = createReq({ params: { publicKey: "<script>alert('xss')</script>" } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid Stellar public key format" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects a key of the wrong length after sanitization", () => {
+    const req = createReq({ params: { publicKey: "GTOO_SHORT" } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects a 56-character key that does not start with G", () => {
+    const invalidPrefix = `A${VALID_PUBLIC_KEY.slice(1)}`;
+    const req = createReq({ params: { publicKey: invalidPrefix } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizePublicKey(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("sanitizeUsername", () => {
+  it("calls next() when no username param is present", () => {
+    const req = createReq({ params: {} });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizeUsername(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.params.username).toBeUndefined();
+  });
+
+  it("trims and lowercases a valid username", () => {
+    const req = createReq({ params: { username: "  Alice  " } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizeUsername(req, res, next);
+
+    expect(req.params.username).toBe("alice");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes an already-normalised username through unchanged", () => {
+    const req = createReq({ params: { username: "bob" } });
+    const res = createRes();
+    const next = jest.fn();
+
+    sanitizeUsername(req, res, next);
+
+    expect(req.params.username).toBe("bob");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/__tests__/turretsService.test.js
+++ b/backend/__tests__/turretsService.test.js
@@ -1,0 +1,180 @@
+/**
+ * __tests__/turretsService.test.js
+ * Unit tests for turretsService (issue #532).
+ *
+ * Covers job queueing (deployTxFunction produces the expected deployment
+ * record) and signing delegation (a failed/forged signature is surfaced as
+ * an error rather than silently dropped).
+ *
+ * server.loadAccount is mocked to reject so the service falls back to a
+ * fresh Account(publicKey, "0") — no real Horizon network calls are made.
+ * Keypair/Transaction/TransactionBuilder are used for real so the
+ * challenge/sign/verify flow is exercised end-to-end.
+ */
+
+"use strict";
+
+const { Keypair, Transaction, Networks } = require("@stellar/stellar-sdk");
+
+jest.mock("../src/config/stellar", () => ({
+  server: {
+    loadAccount: jest.fn().mockRejectedValue(new Error("account not found")),
+  },
+}));
+
+const turretsService = require("../src/services/turretsService");
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+
+/** Create a signing challenge and sign it with the given keypair, as a wallet would. */
+async function buildSignedChallenge(ownerPublicKey, signerKeypair, type, config) {
+  const challenge = await turretsService.createSigningChallenge({ ownerPublicKey, type, config });
+  const tx = new Transaction(challenge.challengeXDR, NETWORK_PASSPHRASE);
+  tx.sign(signerKeypair);
+  return { ...challenge, signedChallengeXDR: tx.toXDR() };
+}
+
+describe("turretsService", () => {
+  afterEach(() => {
+    turretsService.stopRunner();
+  });
+
+  describe("createSigningChallenge", () => {
+    it("throws for an invalid owner public key", async () => {
+      await expect(
+        turretsService.createSigningChallenge({ ownerPublicKey: "not-a-key", type: "dca", config: {} })
+      ).rejects.toThrow("Invalid Stellar public key format");
+    });
+
+    it("normalizes dca config defaults and returns a signable challenge", async () => {
+      const owner = Keypair.random();
+
+      const result = await turretsService.createSigningChallenge({
+        ownerPublicKey: owner.publicKey(),
+        type: "dca",
+        config: { amountQuote: 25 },
+      });
+
+      expect(typeof result.challengeXDR).toBe("string");
+      expect(result.normalizedConfig).toMatchObject({
+        intervalMinutes: 60,
+        amountQuote: 25,
+        quoteAssetCode: "USDC",
+      });
+      expect(result.networkPassphrase).toBe(NETWORK_PASSPHRASE);
+    });
+
+    it("rejects an invalid stop_loss config", async () => {
+      const owner = Keypair.random();
+
+      await expect(
+        turretsService.createSigningChallenge({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config: { thresholdPrice: -1 },
+        })
+      ).rejects.toThrow("Stop-loss thresholdPrice must be greater than 0");
+    });
+  });
+
+  describe("deployTxFunction — job queueing", () => {
+    it("produces the expected job record for a validly signed deployment", async () => {
+      const owner = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), owner, "stop_loss", config);
+
+      const deployment = turretsService.deployTxFunction({
+        ownerPublicKey: owner.publicKey(),
+        type: "stop_loss",
+        config,
+        deploymentHash: challenge.deploymentHash,
+        signedChallengeXDR: challenge.signedChallengeXDR,
+      });
+
+      expect(deployment).toMatchObject({
+        ownerPublicKey: owner.publicKey(),
+        type: "stop_loss",
+        status: "active",
+        deploymentHash: challenge.deploymentHash,
+        lastExecutedAt: null,
+        lastError: null,
+      });
+      expect(deployment.id).toEqual(expect.any(String));
+      expect(deployment.config).toMatchObject({
+        thresholdPrice: 0.05,
+        amountSell: 100,
+        sellAssetCode: "XLM",
+        cooldownMinutes: 30,
+      });
+      expect(new Date(deployment.nextRunAt).getTime()).toBeGreaterThan(Date.now());
+
+      // The job record is queryable by id and by owner, as the runner expects.
+      expect(turretsService.getDeployment(deployment.id)).toEqual(deployment);
+      expect(turretsService.listDeployments(owner.publicKey())).toContainEqual(deployment);
+    });
+
+    it("throws a 404 for an unknown deployment id", () => {
+      expect(() => turretsService.getDeployment("does-not-exist")).toThrow("txFunction not found");
+    });
+  });
+
+  describe("deployTxFunction — signing delegation failures", () => {
+    it("surfaces a signature mismatch as an error instead of silently dropping the job", async () => {
+      const owner = Keypair.random();
+      const impostor = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+
+      // Challenge is built for `owner`, but signed by an unrelated keypair.
+      const challenge = await buildSignedChallenge(owner.publicKey(), impostor, "stop_loss", config);
+
+      expect(() =>
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config,
+          deploymentHash: challenge.deploymentHash,
+          signedChallengeXDR: challenge.signedChallengeXDR,
+        })
+      ).toThrow("Signed challenge was not signed by the owner account");
+
+      // No job record should have been queued as a result of the failed delegation.
+      expect(turretsService.listDeployments(owner.publicKey())).toHaveLength(0);
+    });
+
+    it("attaches a 401 status to the surfaced signing-delegation error", async () => {
+      const owner = Keypair.random();
+      const impostor = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), impostor, "stop_loss", config);
+
+      expect.assertions(1);
+      try {
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config,
+          deploymentHash: challenge.deploymentHash,
+          signedChallengeXDR: challenge.signedChallengeXDR,
+        });
+      } catch (err) {
+        expect(err.status).toBe(401);
+      }
+    });
+
+    it("rejects a tampered config whose hash no longer matches the signed challenge", async () => {
+      const owner = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), owner, "stop_loss", config);
+
+      expect(() =>
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config: { ...config, amountSell: 999 },
+          deploymentHash: challenge.deploymentHash,
+          signedChallengeXDR: challenge.signedChallengeXDR,
+        })
+      ).toThrow("Configuration hash mismatch");
+    });
+  });
+});

--- a/frontend/e2e/contacts.spec.ts
+++ b/frontend/e2e/contacts.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * E2E tests for the contacts page /contacts (issue #537).
+ * Covers:
+ *  1. Adding a contact and seeing it appear in the list.
+ *  2. Editing and deleting a contact.
+ *  3. Tag-based filtering narrowing the visible contacts.
+ */
+import { test, expect } from './fixtures';
+
+const ALICE_ADDRESS = 'GB2JLUHNVHL64FKADLJVH5TMUWTS6P5BS4Y3WJT6KU7FRXBFQM5PGGVV';
+const BOB_ADDRESS = 'GCFVV3BKTNNXJ46CY2TLAGRYFSP23HKEMP5CJFQU3EBACWSGYRQB5LEE';
+
+test.beforeEach(async ({ page }) => {
+  // Contacts persist in localStorage — start each test with an empty address book.
+  await page.addInitScript(() => {
+    window.localStorage.removeItem('stellar-micropay:contacts');
+    window.localStorage.removeItem('stellar-micropay-contacts');
+    window.localStorage.removeItem('stellar-micropay:favourites');
+  });
+});
+
+async function addContact(page: import('@playwright/test').Page, name: string, address: string, tag?: string) {
+  await page.getByPlaceholder('e.g., Alice, Daily Coffee').fill(name);
+  await page.getByPlaceholder('G... (56 character public key)').fill(address);
+  if (tag) {
+    await page.getByPlaceholder('e.g. exchange, family').fill(tag);
+    await page.getByRole('button', { name: 'Add' }).click();
+  }
+  await page.getByRole('button', { name: 'Save Contact' }).click();
+  await expect(page.getByText('Contact saved')).toBeVisible();
+}
+
+test('adding a contact makes it appear in the list', async ({ page }) => {
+  await page.goto('/contacts');
+
+  await expect(page.getByRole('heading', { name: 'Contacts' })).toBeVisible();
+  await expect(page.getByText('No contacts yet. Add one to get started.')).toBeVisible();
+
+  await addContact(page, 'Alice', ALICE_ADDRESS);
+
+  const card = page.locator('.card-hover').filter({ hasText: 'Alice' });
+  await expect(card).toBeVisible();
+  await expect(card.getByText(ALICE_ADDRESS)).toBeVisible();
+  await expect(page.getByText('1 contact')).toBeVisible();
+});
+
+test('rejects an invalid Stellar address before saving', async ({ page }) => {
+  await page.goto('/contacts');
+
+  await page.getByPlaceholder('e.g., Alice, Daily Coffee').fill('Bad Contact');
+  await page.getByPlaceholder('G... (56 character public key)').fill('not-a-valid-address');
+
+  await expect(page.getByText('Invalid Stellar address')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save Contact' })).toBeDisabled();
+});
+
+test('editing a contact updates it in the list', async ({ page }) => {
+  await page.goto('/contacts');
+  await addContact(page, 'Alice', ALICE_ADDRESS);
+
+  const card = page.locator('.card-hover').filter({ hasText: 'Alice' });
+  await card.getByTitle('Edit contact').click();
+
+  await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeVisible();
+  await page.getByPlaceholder('e.g., Alice, Daily Coffee').fill('Alice Updated');
+  await page.getByRole('button', { name: 'Update Contact' }).click();
+
+  await expect(page.getByText('Contact updated')).toBeVisible();
+  await expect(page.locator('.card-hover').filter({ hasText: 'Alice Updated' })).toBeVisible();
+  await expect(page.locator('.card-hover').filter({ hasText: 'Alice' })).toHaveCount(1);
+});
+
+test('deleting a contact removes it from the list', async ({ page }) => {
+  await page.goto('/contacts');
+  await addContact(page, 'Alice', ALICE_ADDRESS);
+
+  const card = page.locator('.card-hover').filter({ hasText: 'Alice' });
+  await card.getByTitle('Delete contact').click();
+
+  await expect(page.getByText('Contact deleted')).toBeVisible();
+  await expect(page.getByText('No contacts yet. Add one to get started.')).toBeVisible();
+  await expect(page.locator('.card-hover').filter({ hasText: 'Alice' })).toHaveCount(0);
+});
+
+test('tag filter narrows the visible contacts', async ({ page }) => {
+  await page.goto('/contacts');
+
+  await addContact(page, 'Alice', ALICE_ADDRESS, 'family');
+  await addContact(page, 'Bob', BOB_ADDRESS, 'exchange');
+
+  await expect(page.getByText('2 contacts')).toBeVisible();
+
+  const filterBar = page.locator('div').filter({ hasText: 'Filter:' }).last();
+  await filterBar.getByRole('button', { name: 'family' }).click();
+
+  await expect(page.locator('.card-hover').filter({ hasText: 'Alice' })).toBeVisible();
+  await expect(page.locator('.card-hover').filter({ hasText: 'Bob' })).not.toBeVisible();
+  await expect(page.getByText('1 contact')).toBeVisible();
+
+  await filterBar.getByRole('button', { name: 'All' }).click();
+  await expect(page.locator('.card-hover').filter({ hasText: 'Bob' })).toBeVisible();
+  await expect(page.getByText('2 contacts')).toBeVisible();
+});


### PR DESCRIPTION
…

Closes #537
Closes #536
Closes #535
Closes #532.

- frontend/e2e/contacts.spec.ts: add/edit/delete a contact, tag-filter narrowing, and invalid-address rejection on the contacts page.
- backend/__tests__/logger.test.js: log-level filtering and structured output fields (level, msg, time) for the pino logger.
- backend/__tests__/sanitization.test.js: sanitizePublicKey/sanitizeUsername neutralise injection payloads while valid keys, usernames, and unrelated body fields (memo, amount) pass through unchanged.
- backend/__tests__/turretsService.test.js: deployTxFunction produces the expected job record, and forged/mismatched signing delegation surfaces as a thrown error (401/400) instead of being silently dropped.

Note: contacts.spec.ts is verified via static review and `tsc --noEmit` only, not a live Playwright run — the frontend currently fails to build on main due to an unrelated pre-existing bug (components/Navbar.tsx and two other files call a useTranslation() hook that lib/i18n.ts never exports). Left out of scope here; worth a separate fix.

## Summary

<!-- What does this PR do? 1-2 sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made -->
- 
- 

## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`
