### PR TITLE
fix: require wallet proof for username registration

### DIFF
--- a/backend/__tests__/accountsAuth.test.js
+++ b/backend/__tests__/accountsAuth.test.js
@@ -44,3 +44,22 @@ describe("account routes authorization (#278)", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("username registration wallet ownership (#755)", () => {
+  const app = appWithAccounts();
+
+  it("rejects registration without a wallet proof", async () => {
+    const res = await request(app)
+      .post("/api/accounts/register")
+      .send({ username: "alice", publicKey: ME });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a key that differs from the authenticated wallet subject", async () => {
+    const res = await request(app)
+      .post("/api/accounts/register")
+      .set("Authorization", `Bearer ${tokenFor(ME)}`)
+      .send({ username: "alice", publicKey: OTHER });
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend/src/controllers/accountController.js
+++ b/backend/src/controllers/accountController.js
@@ -7,6 +7,7 @@
 
 const stellarService = require("../services/stellarService");
 const usernameService = require("../services/usernameService");
+const logger = require("../utils/logger");
 
 /**
  * @typedef {object} AccountBalanceEntry
@@ -82,12 +83,25 @@ async function registerUsername(req, res, next) {
     const { username, publicKey } = req.body;
 
     if (!username || !publicKey) {
+      logger.warn({ event: "username_registration_rejected", reason: "missing_fields" }, "Username registration rejected");
       return res.status(400).json({
         error: "Username and public key are required",
       });
     }
 
+    if (!req.user?.publicKey || req.user.publicKey !== publicKey) {
+      logger.warn(
+        { event: "username_registration_rejected", subject: req.user?.publicKey, requestedKey: publicKey },
+        "Username registration rejected: wallet ownership mismatch",
+      );
+      return res.status(403).json({ error: "Forbidden: wallet ownership proof does not match public key" });
+    }
+
     const result = usernameService.registerUsername(username, publicKey);
+    logger.info(
+      { event: "username_registered", username, publicKey: req.user.publicKey },
+      "Username registered",
+    );
     res.status(201).json({
       success: true,
       data: result,

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -48,6 +48,6 @@ router.get("/:publicKey/balance", sensitiveLimiter, verifyJWT, sanitizePublicKey
  * POST /api/accounts/register
  * Register a new username with a public key.
  */
-router.post("/register", strictLimiter, accountController.registerUsername);
+router.post("/register", strictLimiter, verifyJWT, accountController.registerUsername);
 
 module.exports = router;


### PR DESCRIPTION
Require a valid JWT wallet proof before registering a username, and reject requests where the authenticated wallet differs from the submitted public key. Adds focused authorization regression tests.

Closes #755

Verification: npm test -- --runInBand __tests__/accountsAuth.test.js passed (5 tests). Repository lint is currently blocked by an existing invalid import/order rule configuration.