### PR TITLE
fix: enforce price freshness and add fallback in turretsService

### DIFF
--- a/backend/__tests__/turretsService.test.js
+++ b/backend/__tests__/turretsService.test.js
@@ -170,11 +170,228 @@ describe("turretsService", () => {
         turretsService.deployTxFunction({
           ownerPublicKey: owner.publicKey(),
           type: "stop_loss",
+/**
+ * __tests__/turretsService.test.js
+ * Unit tests for turretsService (issue #532).
+ *
+ * Covers job queueing (deployTxFunction produces the expected deployment
+ * record) and signing delegation (a failed/forged signature is surfaced as
+ * an error rather than silently dropped).
+ *
+ * server.loadAccount is mocked to reject so the service falls back to a
+ * fresh Account(publicKey, "0") — no real Horizon network calls are made.
+ * Keypair/Transaction/TransactionBuilder are used for real so the
+ * challenge/sign/verify flow is exercised end-to-end.
+ */
+
+"use strict";
+
+const { Keypair, Transaction, Networks } = require("@stellar/stellar-sdk");
+
+jest.mock("../src/config/stellar", () => ({
+  server: {
+    loadAccount: jest.fn().mockRejectedValue(new Error("account not found")),
+  },
+}));
+
+const turretsService = require("../src/services/turretsService");
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+
+/** Create a signing challenge and sign it with the given keypair, as a wallet would. */
+async function buildSignedChallenge(ownerPublicKey, signerKeypair, type, config) {
+  const challenge = await turretsService.createSigningChallenge({ ownerPublicKey, type, config });
+  const tx = new Transaction(challenge.challengeXDR, NETWORK_PASSPHRASE);
+  tx.sign(signerKeypair);
+  return { ...challenge, signedChallengeXDR: tx.toXDR() };
+}
+
+describe("turretsService", () => {
+  afterEach(() => {
+    turretsService.stopRunner();
+  });
+
+  describe("createSigningChallenge", () => {
+    it("throws for an invalid owner public key", async () => {
+      await expect(
+        turretsService.createSigningChallenge({ ownerPublicKey: "not-a-key", type: "dca", config: {} })
+      ).rejects.toThrow("Invalid Stellar public key format");
+    });
+
+    it("normalizes dca config defaults and returns a signable challenge", async () => {
+      const owner = Keypair.random();
+
+      const result = await turretsService.createSigningChallenge({
+        ownerPublicKey: owner.publicKey(),
+        type: "dca",
+        config: { amountQuote: 25 },
+      });
+
+      expect(typeof result.challengeXDR).toBe("string");
+      expect(result.normalizedConfig).toMatchObject({
+        intervalMinutes: 60,
+        amountQuote: 25,
+        quoteAssetCode: "USDC",
+      });
+      expect(result.networkPassphrase).toBe(NETWORK_PASSPHRASE);
+    });
+
+    it("rejects an invalid stop_loss config", async () => {
+      const owner = Keypair.random();
+
+      await expect(
+        turretsService.createSigningChallenge({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config: { thresholdPrice: -1 },
+        })
+      ).rejects.toThrow("Stop-loss thresholdPrice must be greater than 0");
+    });
+  });
+
+  describe("deployTxFunction — job queueing", () => {
+    it("produces the expected job record for a validly signed deployment", async () => {
+      const owner = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), owner, "stop_loss", config);
+
+      const deployment = turretsService.deployTxFunction({
+        ownerPublicKey: owner.publicKey(),
+        type: "stop_loss",
+        config,
+        deploymentHash: challenge.deploymentHash,
+        signedChallengeXDR: challenge.signedChallengeXDR,
+      });
+
+      expect(deployment).toMatchObject({
+        ownerPublicKey: owner.publicKey(),
+        type: "stop_loss",
+        status: "active",
+        deploymentHash: challenge.deploymentHash,
+        lastExecutedAt: null,
+        lastError: null,
+      });
+      expect(deployment.id).toEqual(expect.any(String));
+      expect(deployment.config).toMatchObject({
+        thresholdPrice: 0.05,
+        amountSell: 100,
+        sellAssetCode: "XLM",
+        cooldownMinutes: 30,
+      });
+      expect(new Date(deployment.nextRunAt).getTime()).toBeGreaterThan(Date.now());
+
+      // The job record is queryable by id and by owner, as the runner expects.
+      expect(turretsService.getDeployment(deployment.id)).toEqual(deployment);
+      expect(turretsService.listDeployments(owner.publicKey())).toContainEqual(deployment);
+    });
+
+    it("throws a 404 for an unknown deployment id", () => {
+      expect(() => turretsService.getDeployment("does-not-exist")).toThrow("txFunction not found");
+    });
+  });
+
+  describe("deployTxFunction — signing delegation failures", () => {
+    it("surfaces a signature mismatch as an error instead of silently dropping the job", async () => {
+      const owner = Keypair.random();
+      const impostor = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+
+      // Challenge is built for `owner`, but signed by an unrelated keypair.
+      const challenge = await buildSignedChallenge(owner.publicKey(), impostor, "stop_loss", config);
+
+      expect(() =>
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config,
+          deploymentHash: challenge.deploymentHash,
+          signedChallengeXDR: challenge.signedChallengeXDR,
+        })
+      ).toThrow("Signed challenge was not signed by the owner account");
+
+      // No job record should have been queued as a result of the failed delegation.
+      expect(turretsService.listDeployments(owner.publicKey())).toHaveLength(0);
+    });
+
+    it("attaches a 401 status to the surfaced signing-delegation error", async () => {
+      const owner = Keypair.random();
+      const impostor = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), impostor, "stop_loss", config);
+
+      expect.assertions(1);
+      try {
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
+          config,
+          deploymentHash: challenge.deploymentHash,
+          signedChallengeXDR: challenge.signedChallengeXDR,
+        });
+      } catch (err) {
+        expect(err.status).toBe(401);
+      }
+    });
+
+    it("rejects a tampered config whose hash no longer matches the signed challenge", async () => {
+      const owner = Keypair.random();
+      const config = { thresholdPrice: 0.05, amountSell: 100 };
+      const challenge = await buildSignedChallenge(owner.publicKey(), owner, "stop_loss", config);
+
+      expect(() =>
+        turretsService.deployTxFunction({
+          ownerPublicKey: owner.publicKey(),
+          type: "stop_loss",
           config: { ...config, amountSell: 999 },
           deploymentHash: challenge.deploymentHash,
           signedChallengeXDR: challenge.signedChallengeXDR,
         })
       ).toThrow("Configuration hash mismatch");
+    });
+  });
+
+  describe("getXlmUsdPrice", () => {
+    let originalFetch;
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("uses CoinGecko successfully", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ stellar: { usd: 0.15, last_updated_at: Date.now() / 1000 } })
+      });
+      const price = await turretsService._getXlmUsdPrice();
+      expect(price).toBe(0.15);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to Binance if CoinGecko is stale", async () => {
+      global.fetch = jest.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ stellar: { usd: 0.15, last_updated_at: (Date.now() / 1000) - 10000 } }) // Stale
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ lastPrice: "0.16", closeTime: Date.now() }) // Fresh
+        });
+
+      const price = await turretsService._getXlmUsdPrice();
+      expect(price).toBe(0.16);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws if all sources fail or return invalid data", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}) // Missing data
+      });
+
+      await expect(turretsService._getXlmUsdPrice()).rejects.toThrow(/All price oracles failed/);
     });
   });
 });

--- a/backend/src/services/turretsService.js
+++ b/backend/src/services/turretsService.js
@@ -341,31 +341,89 @@ function addExecutionLog(deploymentId, status, message, result = null) {
   }
 }
 
-let priceCache = { value: null, fetchedAt: 0 };
+const PRICE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+const PRICE_MIN_VALID = 0.0001;
+const PRICE_MAX_VALID = 10.0;
+
+async function fetchCoinGeckoPrice() {
+  const res = await fetch("https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd&include_last_updated_at=true");
+  if (!res.ok) throw new Error(`CoinGecko failed (${res.status})`);
+  const data = await res.json();
+  const value = Number(data?.stellar?.usd);
+  const updatedAt = Number(data?.stellar?.last_updated_at) * 1000;
+  return { value, updatedAt, source: "coingecko" };
+}
+
+async function fetchBinancePrice() {
+  const res = await fetch("https://api.binance.com/api/v3/ticker/24hr?symbol=XLMUSDT");
+  if (!res.ok) throw new Error(`Binance failed (${res.status})`);
+  const data = await res.json();
+  const value = Number(data?.lastPrice);
+  const updatedAt = Number(data?.closeTime);
+  return { value, updatedAt, source: "binance" };
+}
+
+function validatePriceData(data, now) {
+  if (!data || !Number.isFinite(data.value) || !Number.isFinite(data.updatedAt)) {
+    throw new Error("Malformed price data: missing or invalid value/timestamp");
+  }
+  if (data.value < PRICE_MIN_VALID || data.value > PRICE_MAX_VALID) {
+    throw new Error(`Price out of sanity range (${PRICE_MIN_VALID} - ${PRICE_MAX_VALID}): ${data.value}`);
+  }
+  
+  const age = now - data.updatedAt;
+  if (age < -60_000) {
+    throw new Error(`Price timestamp is in the future: ${data.updatedAt}`);
+  } else if (age > PRICE_MAX_AGE_MS) {
+    throw new Error(`Price data is stale. Age: ${age}ms, Max: ${PRICE_MAX_AGE_MS}ms`);
+  }
+  return true;
+}
+
+let priceCache = { value: null, fetchedAt: 0, updatedAt: 0 };
 
 async function getXlmUsdPrice() {
   const now = Date.now();
-  if (priceCache.value !== null && now - priceCache.fetchedAt < 30_000) {
+  
+  if (
+    priceCache.value !== null && 
+    (now - priceCache.fetchedAt < 30_000) && 
+    (now - priceCache.updatedAt < PRICE_MAX_AGE_MS)
+  ) {
     return priceCache.value;
   }
 
-  const res = await fetch(
-    "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd"
-  );
+  let priceData = null;
+  let errors = [];
 
-  if (!res.ok) {
-    throw new Error(`Price lookup failed (${res.status})`);
+  // Primary: CoinGecko
+  try {
+    const cgData = await fetchCoinGeckoPrice();
+    validatePriceData(cgData, now);
+    priceData = cgData;
+  } catch (err) {
+    errors.push(err.message);
+    logger.warn({ err: err.message }, "CoinGecko price fetch failed, attempting fallback");
   }
 
-  const data = await res.json();
-  const value = Number(data?.stellar?.usd);
-
-  if (!Number.isFinite(value) || value <= 0) {
-    throw new Error("Invalid price response from upstream provider");
+  // Fallback: Binance (Documented fallback strategy)
+  if (!priceData) {
+    try {
+      const binData = await fetchBinancePrice();
+      validatePriceData(binData, now);
+      priceData = binData;
+    } catch (err) {
+      errors.push(err.message);
+      logger.warn({ err: err.message }, "Binance price fetch failed");
+    }
   }
 
-  priceCache = { value, fetchedAt: now };
-  return value;
+  if (!priceData) {
+    throw new Error(`All price oracles failed or returned invalid data: ${errors.join(" | ")}`);
+  }
+
+  priceCache = { value: priceData.value, fetchedAt: now, updatedAt: priceData.updatedAt };
+  return priceData.value;
 }
 
 function nextRunIso(intervalMinutes) {
@@ -590,4 +648,5 @@ module.exports = {
   getAuditLog,
   startRunner,
   stopRunner,
+  _getXlmUsdPrice: getXlmUsdPrice,
 };


### PR DESCRIPTION
Closes #777 

## Summary
Stop-loss execution previously depended on an external price response without an explicit freshness and sanity policy. This PR adds timestamp, age, and range checks, and falls back to a secondary price source (Binance) if the primary source (CoinGecko) fails or returns stale data.

## Changes
- Added age check (max 5 minutes) and future timestamp check.
- Added price range sanity checks ($0.0001 - $10.0).
- Implemented fallback strategy with Binance's 24hr ticker API.
- Fails closed on stale, malformed, or missing data from all sources.
- Added test coverage.