### PR TITLE
fix(frontend): remove duplicate React hook imports in SendPaymentForm (#707)

### DIFF
--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -53,7 +53,6 @@ import clsx from "clsx";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useEffect, useRef, useState } from "react";
 import { useToastContext } from "@/lib/ToastContext";
 import { useTranslation } from "@/lib/i18n";
 


### PR DESCRIPTION
Closes #707

## What

Removed duplicate React hook import in `SendPaymentForm.tsx`. The file had two separate `import { ... } from "react"` statements — line 54 imported `useCallback, useEffect, useRef, useState` and line 56 imported `useEffect, useRef, useState`. Consolidated to the single import on line 54 which includes all four hooks.

## Why

TypeScript reported duplicate identifiers for `useEffect`, `useRef`, and `useState`, preventing a clean `npx tsc --noEmit` and breaking the SendPaymentForm test module in Jest.

## Verification

- `npx tsc --noEmit` should pass without duplicate identifier errors
