### PR TITLE
fix(auth): add CSRF origin check to cookie-authenticated token refresh

### DIFF
--- a/backend/__tests__/authRefreshCsrf.test.js
+++ b/backend/__tests__/authRefreshCsrf.test.js
@@ -1,0 +1,74 @@
+/**
+ * #780 — POST /api/auth/refresh must reject cookie-authenticated requests
+ * whose Origin/Referer isn't one of ALLOWED_ORIGINS, while leaving the
+ * bearer-token (non-browser) flow untouched.
+ */
+"use strict";
+
+const express = require("express");
+const request = require("supertest");
+const cookieParser = require("cookie-parser");
+const jwt = require("jsonwebtoken");
+
+process.env.ALLOWED_ORIGINS = "https://app.example.com";
+
+const { JWT_SECRET, SIGN_OPTIONS } = require("../src/middleware/auth");
+const authRoutes = require("../src/routes/auth");
+
+const PUBLIC_KEY = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA";
+
+function app() {
+  const server = express();
+  server.use(express.json());
+  server.use(cookieParser());
+  server.use("/api/auth", authRoutes);
+  return server;
+}
+
+function makeToken() {
+  return jwt.sign({ publicKey: PUBLIC_KEY }, JWT_SECRET, SIGN_OPTIONS);
+}
+
+describe("POST /api/auth/refresh — CSRF origin check", () => {
+  it("rejects a cookie-authenticated request from a disallowed origin", async () => {
+    const token = makeToken();
+
+    const res = await request(app())
+      .post("/api/auth/refresh")
+      .set("Cookie", `jwt=${token}`)
+      .set("Origin", "https://evil.test");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a cookie-authenticated request with no Origin/Referer at all", async () => {
+    const token = makeToken();
+
+    const res = await request(app()).post("/api/auth/refresh").set("Cookie", `jwt=${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts a cookie-authenticated request from an allowed origin", async () => {
+    const token = makeToken();
+
+    const res = await request(app())
+      .post("/api/auth/refresh")
+      .set("Cookie", `jwt=${token}`)
+      .set("Origin", "https://app.example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("does not require Origin for the bearer-token (non-browser) flow", async () => {
+    const token = makeToken();
+
+    const res = await request(app())
+      .post("/api/auth/refresh")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@stellar/stellar-sdk": "^15.1.0",
         "axios": "^1.6.8",
         "compression": "^1.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -3888,6 +3889,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "@stellar/stellar-sdk": "^15.1.0",
     "axios": "^1.6.8",
     "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/backend/src/middleware/csrf.js
+++ b/backend/src/middleware/csrf.js
@@ -1,0 +1,69 @@
+/**
+ * src/middleware/csrf.js
+ * Origin verification for cookie-authenticated, state-changing requests (#780).
+ *
+ * SameSite=Strict on the `jwt` cookie is useful defense-in-depth, but it isn't
+ * sufficient on its own (some browsers/extensions relax SameSite handling, and
+ * relying on a single header is fragile). This middleware adds an explicit
+ * check: any request that would authenticate via the `jwt` cookie must also
+ * present an Origin (or Referer, as a fallback for older/non-fetch clients)
+ * header naming one of our own allowed origins.
+ *
+ * Non-browser / bearer-token flows are unaffected: a request carrying an
+ * `Authorization: Bearer <token>` header never relies on the ambient cookie,
+ * so it is not a CSRF target and skips this check entirely.
+ */
+"use strict";
+
+const { parseAllowedOrigins } = require("../config/validateEnv");
+
+function hasBearerToken(req) {
+  const authHeader = req.headers.authorization;
+  return typeof authHeader === "string" && authHeader.startsWith("Bearer ");
+}
+
+function originFromReferer(referer) {
+  try {
+    return new URL(referer).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the CSRF-guard middleware. Only rejects requests that would
+ * authenticate via the httpOnly `jwt` cookie and whose Origin/Referer does
+ * not match an allowed origin.
+ *
+ * @param {string} [allowedOriginsEnv] Defaults to process.env.ALLOWED_ORIGINS.
+ */
+function csrfOriginCheck(allowedOriginsEnv = process.env.ALLOWED_ORIGINS) {
+  const { origins: allowedOrigins } = parseAllowedOrigins(allowedOriginsEnv);
+
+  return function (req, res, next) {
+    // Bearer-authenticated (non-browser) requests are not cookie-driven and
+    // therefore cannot be forged cross-site — nothing to check.
+    if (hasBearerToken(req)) {
+      return next();
+    }
+
+    // No cookie present either — extractToken will fail auth downstream with
+    // its own 401; this middleware only guards the cookie path.
+    const hasCookieToken = typeof req.cookies?.jwt === "string";
+    if (!hasCookieToken) {
+      return next();
+    }
+
+    const origin = req.headers.origin || originFromReferer(req.headers.referer);
+
+    if (!origin || !allowedOrigins.includes(origin)) {
+      return res.status(403).json({
+        error: "Forbidden: request origin is not allowed for cookie-authenticated requests",
+      });
+    }
+
+    return next();
+  };
+}
+
+module.exports = { csrfOriginCheck };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -16,6 +16,7 @@ const {
   VERIFY_OPTIONS,
   extractToken,
 } = require("../middleware/auth");
+const { csrfOriginCheck } = require("../middleware/csrf");
 
 const router = express.Router();
 
@@ -110,7 +111,13 @@ router.post("/", (req, res) => {
 // expired long ago is rejected and must re-authenticate.
 const REFRESH_GRACE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-router.post("/refresh", (req, res) => {
+// CSRF defense-in-depth (#780): SameSite=strict already stops the cookie from
+// being sent on cross-site requests in modern browsers, but this middleware
+// adds an explicit Origin/Referer check for the cookie-authenticated path so
+// a browser or extension that relaxes SameSite handling doesn't silently
+// reopen the hole. Requests authenticating via `Authorization: Bearer` (the
+// non-browser / server-to-server flow) are untouched.
+router.post("/refresh", csrfOriginCheck(), (req, res) => {
   const token = extractToken(req) || req.body?.token;
   if (!token) {
     return res.status(401).json({ error: "Unauthorized: missing token" });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,7 @@
 
 const express = require("express");
 const cors = require("cors");
+const cookieParser = require("cookie-parser");
 const compression = require("compression");
 const helmet = require("helmet");
 const pinoHttp = require("pino-http");
@@ -176,6 +177,10 @@ app.use(
 // shared pino logger so HTTP logs are machine-parseable (Datadog/CloudWatch).
 app.use(pinoHttp({ logger }));
 app.use(express.json({ limit: "10kb" }));
+// Parses the Cookie header into req.cookies so the SEP-0010 session cookie
+// (set in routes/auth.js) can be read back by middleware/auth.js's
+// extractToken and by the CSRF origin check (#780).
+app.use(cookieParser());
 
 // JSON parsing error handler
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary

Closes #780

`POST /api/auth/refresh` accepts a session via the httpOnly `jwt` cookie (SameSite=strict) as well as via `Authorization: Bearer`. SameSite alone is useful defense-in-depth but isn't sufficient as the only CSRF control — it depends on correct, universal browser enforcement, which isn't guaranteed across all browsers/extensions. The endpoint had no explicit check that a cookie-bearing request actually originated from our own frontend.

Separately, while wiring this up I found `req.cookies` was **always `undefined`** — `cookie-parser` was never registered in `server.js`, so the cookie half of the documented auth flow (`extractToken`'s cookie fallback, and this refresh endpoint) could never actually read the `jwt` cookie from an incoming request. Fixed as part of this PR since the CSRF check is meaningless without a working cookie path.

## Changes

- **`backend/src/middleware/csrf.js`** (new): `csrfOriginCheck()` middleware.
  - Requests authenticating via `Authorization: Bearer <token>` skip the check entirely — that's the non-browser / server-to-server flow, which never relies on the ambient cookie and isn't a CSRF target.
  - Requests with no `jwt` cookie present pass through (auth will 401 downstream anyway).
  - Requests authenticating via the `jwt` cookie must present an `Origin` header (falling back to `Referer`) matching one of `ALLOWED_ORIGINS` (reusing the existing `parseAllowedOrigins` from `config/validateEnv.js`); otherwise `403`.
- **`backend/src/server.js`**: registered `cookie-parser` (new dependency) so `req.cookies.jwt` is actually populated.
- **`backend/src/routes/auth.js`**: applied `csrfOriginCheck()` to `POST /api/auth/refresh`.
- **`backend/__tests__/authRefreshCsrf.test.js`** (new): cross-origin cookie request → 403; cookie request with no Origin/Referer → 403; cookie request from an allowed origin → 200; bearer-token request with no Origin header at all → 200 (untouched, documents the non-browser flow).

## Acceptance criteria

- [x] Validate Origin or a CSRF token
- [x] Keep non-browser bearer flows documented
- [x] Add cross-origin rejection tests

## Validation

- `npx jest __tests__/authRefreshCsrf.test.js` — 4/4 passing.
- Full `npx jest` run: 223 passing (up from 219 on `main`), same 30 pre-existing failures as `main` (verified via `git stash`) — none introduced by this change.
- `eslint` currently fails to run at all on `main` due to an unrelated `.eslintrc.json` `import/order` config error — pre-existing, not touched by this PR.

## Network behavior

No network-facing behavior changes — this only affects request-origin validation for the auth-refresh endpoint, identical on testnet and mainnet.