### PR TITLE
Fix SEP-0007 validation for asset code, issuer, and network passphrase

### DIFF
--- a/frontend/__tests__/sep0007.test.ts
+++ b/frontend/__tests__/sep0007.test.ts
@@ -140,5 +140,29 @@ describe('sep0007 URI parsing', () => {
       expect(result.success).toBe(true);
       expect(result.data?.amount).toBe('100');
     });
+
+    it('rejects URI with asset_issuer but missing asset_code', () => {
+      const uri = 'stellar:pay?destination=GABC123456789012345678901234567890123456789012345678&asset_issuer=GDEF456789012345678901234567890123456789012345678901';
+      const result = parseStellarURI(uri);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('asset_code is required');
+    });
+
+    it('rejects unsupported network passphrase', () => {
+      const uri = 'stellar:pay?destination=GABC123456789012345678901234567890123456789012345678&network_passphrase=Fake%20Network';
+      const result = parseStellarURI(uri);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported network passphrase');
+    });
+
+    it('allows valid network passphrases', () => {
+      const uri = 'stellar:pay?destination=GABC123456789012345678901234567890123456789012345678&network_passphrase=Test%20SDF%20Network%20%3B%20September%202015';
+      const result = parseStellarURI(uri);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    });
   });
 });

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -29,6 +29,9 @@ import {
   STELLAR_MINIMUM_ACCOUNT_BALANCE_XLM,
   submitTransaction,
   truncateMemoText,
+  getNetworkPassphrase,
+  setNetworkConfig,
+  getNetworkConfig
 } from "@/lib/stellar";
 import { MULTISIG_THRESHOLD_XLM } from "@/components/MultiSigFlow";
 import { signTransactionWithWallet } from "@/lib/wallet";
@@ -80,6 +83,9 @@ interface SendPaymentFormProps {
     memo?: string;
     validUntil?: number | null;
     fromHistory?: boolean;
+    networkPassphrase?: string;
+    assetCode?: string;
+    assetIssuer?: string;
   } | null;
   aiPrefill?: {
     destination: string;
@@ -159,6 +165,9 @@ function SendPaymentForm({
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [pendingNetworkPassphrase, setPendingNetworkPassphrase] = useState<string | null>(null);
+  const [showNetworkMismatch, setShowNetworkMismatch] = useState(false);
+  const [unsupportedAssetError, setUnsupportedAssetError] = useState<string | null>(null);
   const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
   const [isTipOnChain, setIsTipOnChain] = useState(false);
   const [failedStep, setFailedStep] = useState<PaymentStepId | null>(null);
@@ -368,9 +377,34 @@ function SendPaymentForm({
     if (prefill.destination) setDestination(prefill.destination);
     if (prefill.amount) setAmount(prefill.amount);
     if (prefill.memo) setMemo(truncateMemoText(prefill.memo));
+    
+    // Check network passphrase
+    if (prefill.networkPassphrase && prefill.networkPassphrase !== getNetworkPassphrase()) {
+      setPendingNetworkPassphrase(prefill.networkPassphrase);
+      setShowNetworkMismatch(true);
+    }
+    
+    // Check asset code and issuer
+    if (prefill.assetCode && prefill.assetCode !== 'XLM') {
+      const isUSDC = prefill.assetCode === 'USDC' && prefill.assetIssuer === process.env.NEXT_PUBLIC_USDC_ISSUER;
+      const isCustomKnown = accountBalances.some(b => b.code === prefill.assetCode && b.issuer === prefill.assetIssuer);
+      
+      if (isUSDC) {
+        setSelectedAsset('USDC');
+      } else if (isCustomKnown) {
+        setSelectedAsset('CUSTOM');
+        setCustomAsset({ code: prefill.assetCode, issuer: prefill.assetIssuer! });
+        setShowCustomAssetForm(true);
+      } else {
+        setUnsupportedAssetError(`Asset ${prefill.assetCode} from issuer ${prefill.assetIssuer} is not supported or not in your trustlines.`);
+      }
+    } else {
+      setSelectedAsset('XLM');
+    }
+    
     setDestinationResolutionError(null);
     setResolvedPaymentDestination(null);
-  }, [prefill]);
+  }, [prefill, accountBalances]);
 
   // Debounced SNS resolution — fires 400ms after the user stops typing a
   // .xlm name or federation address.  Shows an inline spinner during lookup
@@ -510,7 +544,9 @@ function SendPaymentForm({
     isValidAmt &&
     status === "idle" &&
     trimmedDestination !== publicKey &&
-    isMemoValid;
+    isMemoValid &&
+    !showNetworkMismatch &&
+    !unsupportedAssetError;
 
   const resolveUsername = async (username: string): Promise<string> => {
     const cleanUsername = username.replace(/^@/, "").toLowerCase();
@@ -853,6 +889,43 @@ function SendPaymentForm({
         <SendIcon className="w-5 h-5 text-stellar-400" />
         {title}
       </h2>
+      
+      {showNetworkMismatch && pendingNetworkPassphrase && (
+        <div className="mb-6 rounded-lg border border-orange-500/30 bg-orange-500/10 p-4">
+          <p className="text-sm text-orange-200 font-semibold mb-2">Network Mismatch</p>
+          <p className="text-xs text-orange-200/80 mb-4">
+            This payment request is for a different network. Do you want to switch your wallet to the required network?
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => {
+                const isMainnet = pendingNetworkPassphrase.includes('Public Global');
+                setNetworkConfig({
+                  network: isMainnet ? 'mainnet' : 'testnet',
+                  horizonUrl: isMainnet ? 'https://horizon.stellar.org' : 'https://horizon-testnet.stellar.org'
+                });
+                window.location.reload();
+              }}
+              className="btn-primary text-xs py-1.5 px-3"
+            >
+              Switch Network
+            </button>
+            <button
+              onClick={() => setShowNetworkMismatch(false)}
+              className="btn-secondary text-xs py-1.5 px-3"
+            >
+              Ignore
+            </button>
+          </div>
+        </div>
+      )}
+
+      {unsupportedAssetError && (
+        <div className="mb-6 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+          <p className="text-sm text-red-200 font-semibold mb-2">Unsupported Asset</p>
+          <p className="text-xs text-red-200/80">{unsupportedAssetError}</p>
+        </div>
+      )}
 
       <div className="space-y-5">
         {!hideAssetSelector && (

--- a/frontend/lib/sep0007.ts
+++ b/frontend/lib/sep0007.ts
@@ -89,6 +89,18 @@ export function parseStellarURI(uri: string): URIParseResult {
       : undefined;
     const msg = params.get('msg') || undefined;
     const networkPassphrase = params.get('network_passphrase') || undefined;
+
+    if (networkPassphrase) {
+      if (
+        networkPassphrase !== 'Public Global Stellar Network ; September 2015' &&
+        networkPassphrase !== 'Test SDF Network ; September 2015'
+      ) {
+        return {
+          success: false,
+          error: 'Unsupported network passphrase'
+        };
+      }
+    }
     const originDomain = params.get('origin_domain') || undefined;
     const signature = params.get('signature') || undefined;
     const callback = params.get('callback') || undefined;
@@ -112,11 +124,17 @@ export function parseStellarURI(uri: string): URIParseResult {
       }
     }
 
-    // Validate asset issuer if asset code is present but not XLM
+    // Validate asset issuer and asset code together
     if (assetCode && assetCode !== 'XLM' && !assetIssuer) {
       return {
         success: false,
         error: 'asset_issuer is required when asset_code is not XLM'
+      };
+    }
+    if (assetIssuer && (!assetCode || assetCode === 'XLM')) {
+      return {
+        success: false,
+        error: 'asset_code is required and cannot be XLM when asset_issuer is provided'
       };
     }
 
@@ -185,6 +203,9 @@ export function uriToPrefillData(parsed: ParsedStellarURI) {
   return {
     destination: parsed.destination,
     amount: parsed.amount || '',
-    memo: parsed.memo || ''
+    memo: parsed.memo || '',
+    assetCode: parsed.assetCode,
+    assetIssuer: parsed.assetIssuer,
+    networkPassphrase: parsed.networkPassphrase
   };
 }


### PR DESCRIPTION
Closes #735 

## Description

Resolves the issue where decoded SEP-0007 payment requests could prefill values without validating compatibility with the selected Stellar network and supported asset list.

This PR implements strict validation rules and user confirmations to ensure network safety and asset compatibility before payments can be processed.

### Changes Included
- **Asset Validation:** Ensures `asset_code` and `asset_issuer` are evaluated together in `lib/sep0007.ts`. Specifically:
  - Requires `asset_issuer` when `asset_code` is not XLM.
  - Requires a valid `asset_code` (and not XLM) when an `asset_issuer` is provided.
- **Network Hint Validation:** Rejects unsupported network passphrases during the initial URI parsing step to prevent accidental prefills.
- **Network Mismatch UI:** Updates `SendPaymentForm.tsx` to detect mismatches between the current application network and the requested URI network. 
  - Explicitly prompts the user for confirmation before allowing a network change (mainnet/testnet).
  - Temporarily blocks the form submission until the mismatch is explicitly resolved.
- **Asset Compatibility UI:** Displays a localized error and blocks the form if the requested custom asset is not within the user's known trustlines or default supported list (XLM/USDC).
- **Test Coverage:** Added new scenarios in `sep0007.test.ts` for network passphrases, asset validation combinations, and gracefully handling missing/invalid queries.

### Acceptance Criteria Satisfied
- [x] Reject unsupported network/passphrase hints
- [x] Validate issued-asset code and issuer together
- [x] Require confirmation before changing a selected network
- [x] Add or update automated coverage for the changed behavior
- [x] Confirm testnet/mainnet behavior is explicit where network state is involved