### PR TITLE
fix(frontend): export clearNameCache for test isolation

### DIFF
--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -1893,6 +1893,15 @@ const SNS_CACHE_TTL_MS = 600_000;
 export const resolvedNameCache = new Map<string, { address: string; expiry: number }>();
 
 /**
+ * Clear the module-level Stellar name resolution cache.
+ * Exported for tests — use `clearNameCache()` to reset cached
+ * resolutions between test cases or on logout.
+ */
+export function clearNameCache(): void {
+  resolvedNameCache.clear();
+}
+
+/**
  * Resolves a human-readable Stellar name to a public key (G... address).
  *
  * - Accepts federation addresses: `alice*domain.com`


### PR DESCRIPTION
## Summary

Export `clearNameCache()` so the resolver tests can reset the name cache between test cases. The test file already imports and uses this function, but the production module does not export it.

## Changes

- Add `clearNameCache()` export that calls `resolvedNameCache.clear()`
- Keep cache TTL behavior unchanged (the cache itself is unchanged)
- Tests pass in isolation and full suite

Closes #719