### PR TITLE
fix: enforce Stellar memo UTF-8 byte limits

### DIFF
--- a/frontend/__tests__/sep0007.test.ts
+++ b/frontend/__tests__/sep0007.test.ts
@@ -76,6 +76,22 @@ describe('sep0007 URI parsing', () => {
   });
 
   describe('Rejects malformed or unsupported URIs', () => {
+    it('rejects MEMO_TEXT values over 28 UTF-8 bytes', () => {
+      const memo = encodeURIComponent('😀'.repeat(8));
+      const result = parseStellarURI(`stellar:pay?destination=GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234&memo_type=MEMO_TEXT&memo=${memo}`);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('28-byte UTF-8 limit');
+    });
+
+    it('counts combining marks by encoded byte length', () => {
+      const memo = encodeURIComponent('e\u0301'.repeat(14));
+      const result = parseStellarURI(`stellar:pay?destination=GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234&memo_type=MEMO_TEXT&memo=${memo}`);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('28-byte UTF-8 limit');
+    });
+
     it('rejects URI without stellar: or web+stellar: scheme', () => {
       const uri = 'http://example.com?destination=GABC123456789012345678901234567890123456789012345678';
       const result = parseStellarURI(uri);

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -54,7 +54,7 @@ import {
 } from "@/components/icons";
 import clsx from "clsx";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useToastContext } from "@/lib/ToastContext";
 import { useTranslation } from "@/lib/i18n";
 
@@ -529,7 +529,7 @@ function SendPaymentForm({
     !/[eE]/.test(amount);
   
   const memoBytes = new TextEncoder().encode(memo).length;
-  const isMemoValid = memoBytes <= 28;
+  const isMemoValid = memoBytes <= STELLAR_MEMO_TEXT_MAX_BYTES;
   
   const canSubmit =
     (isValidDest || isFederationDestination || isUsernameDestination || (isStellarName(trimmedDestination) && !!snsResolvedAddress)) &&
@@ -1136,8 +1136,8 @@ function SendPaymentForm({
           <div>
             <div className="mb-2 flex items-center justify-between">
               <label className="label mb-0">{t("memo_optional")}</label>
-              <span className={clsx("text-xs transition-colors", memoBytes > 28 ? "text-red-400 font-bold" : "text-slate-400")}>
-                {memoBytes}/28 bytes
+              <span className={clsx("text-xs transition-colors", memoBytes > STELLAR_MEMO_TEXT_MAX_BYTES ? "text-red-400 font-bold" : "text-slate-400")}>
+                {memoBytes}/{STELLAR_MEMO_TEXT_MAX_BYTES} bytes
               </span>
             </div>
             <input
@@ -1145,10 +1145,10 @@ function SendPaymentForm({
               value={memo}
               onChange={(e) => handleMemoChange(e.target.value)}
               placeholder={t("memo_placeholder")}
-              className={clsx("input-field", memoBytes > 28 && "border-red-500/50")}
+              className={clsx("input-field", memoBytes > STELLAR_MEMO_TEXT_MAX_BYTES && "border-red-500/50")}
               disabled={status !== "idle"}
             />
-            {memoBytes > 28 && (
+            {memoBytes > STELLAR_MEMO_TEXT_MAX_BYTES && (
               <p className="mt-1 text-xs text-red-400">{t("memo_limit")}</p>
             )}
           </div>

--- a/frontend/lib/sep0007.ts
+++ b/frontend/lib/sep0007.ts
@@ -25,6 +25,8 @@ export interface URIParseResult {
   isExternal?: boolean; // Whether this came from an external URI handler
 }
 
+const MEMO_TEXT_MAX_BYTES = 28;
+
 /**
  * Parse a SEP-0007 URI string
  * Supports both stellar:pay and web+stellar:pay formats
@@ -87,6 +89,13 @@ export function parseStellarURI(uri: string): URIParseResult {
     const memoType = memoTypeRaw && validMemoTypes.includes(memoTypeRaw as typeof validMemoTypes[number])
       ? (memoTypeRaw as ParsedStellarURI['memoType'])
       : undefined;
+
+    if (memo && memoType === 'MEMO_TEXT' && new TextEncoder().encode(memo).length > MEMO_TEXT_MAX_BYTES) {
+      return {
+        success: false,
+        error: `MEMO_TEXT exceeds the ${MEMO_TEXT_MAX_BYTES}-byte UTF-8 limit`
+      };
+    }
     const msg = params.get('msg') || undefined;
     const networkPassphrase = params.get('network_passphrase') || undefined;
 

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -120,6 +120,11 @@ export function truncateMemoText(memo: string): string {
   return truncated;
 }
 
+/** Return the encoded UTF-8 size of a Stellar MEMO_TEXT value. */
+export function memoTextByteLength(memo: string): number {
+  return new TextEncoder().encode(memo).length;
+}
+
 /**
  * USDC issuer (Circle) for the active network.
  *
@@ -1288,7 +1293,7 @@ export async function buildReceiptMintTransaction({
   const contract = new Contract(CONTRACT_ID);
 
   const stroops = BigInt(Math.round(parseFloat(amount) * 10_000_000));
-  const memoStr = (memo ?? "").slice(0, 28);
+  const memoStr = truncateMemoText(memo ?? "");
   const memoScVal = nativeToScVal(memoStr, { type: "symbol" });
 
   const tx = new TransactionBuilder(sourceAccount, {


### PR DESCRIPTION
Closes #751

## Summary
- validate SEP-0007 MEMO_TEXT values using the Stellar 28-byte UTF-8 limit
- use byte-safe truncation for receipt memo values
- keep the payment form limit tied to the shared protocol constant and remove a duplicate hook declaration
- add emoji and combining-mark regression coverage

## Verification
- New UTF-8 boundary regression cases pass
- Full legacy SEP-0007 suite remains blocked by pre-existing invalid 52-character destination fixtures
- Frontend type-check remains blocked by unrelated pre-existing errors elsewhere in the checkout
- `git diff --check`: passed