### PR TITLE
ci: publish per-route bundle size reports with budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
       - name: Bundle size budget
         run: npm run size
 
+      - name: Route bundle and hydration budgets
+        run: npm run bundle-report
+        env:
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+
+      - name: Upload route bundle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-route-bundle-report
+          path: frontend/bundle-reports/
+
   # ─── Backend ───────────────────────────────────────────────────────────────
   backend:
     name: Backend (Node.js)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "test:e2e:report": "playwright show-report",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "size": "size-limit"
+    "size": "size-limit",
+    "bundle-report": "node scripts/bundle-budget.mjs",
+    "test:bundle-report": "node --test scripts/bundle-budget.test.mjs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/frontend/scripts/bundle-budget.mjs
+++ b/frontend/scripts/bundle-budget.mjs
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const ROUTE_BUDGETS = {
+  "/dashboard": { label: "Dashboard", initial: 450, hydration: 250 },
+  "/pay": { label: "Pay", initial: 350, hydration: 180 },
+  "/trade": { label: "Trade", initial: 450, hydration: 250 },
+  "/settings": { label: "Settings", initial: 450, hydration: 250 },
+};
+
+const DEFAULT_BUILD_DIR = ".next";
+const REPORT_DIR = "bundle-reports";
+
+function bytesForFiles(files, sizes) {
+  return [...new Set(files)].reduce((total, file) => {
+    const size = sizes.get(file);
+    if (size === undefined) {
+      throw new Error(`Build manifest references missing file: ${file}`);
+    }
+    return total + size;
+  }, 0);
+}
+
+export function createRouteReport(manifest, sizes, routeBudgets = ROUTE_BUDGETS) {
+  const sharedFiles = manifest.pages?.["/_app"] ?? [];
+
+  return Object.entries(routeBudgets).map(([route, budget]) => {
+    const routeFiles = manifest.pages?.[route];
+    if (!routeFiles) {
+      throw new Error(`Build manifest is missing required route: ${route}`);
+    }
+
+    const initialFiles = [...new Set([...sharedFiles, ...routeFiles])];
+    const sharedBytes = bytesForFiles(sharedFiles, sizes);
+    const initialBytes = bytesForFiles(initialFiles, sizes);
+    const hydrationFiles = routeFiles.filter((file) => !sharedFiles.includes(file));
+    const hydrationBytes = bytesForFiles(hydrationFiles, sizes);
+
+    return {
+      route,
+      label: budget.label,
+      sharedBytes,
+      initialBytes,
+      hydrationBytes,
+      initialBudgetBytes: budget.initial * 1024,
+      hydrationBudgetBytes: budget.hydration * 1024,
+      initialPass: initialBytes <= budget.initial * 1024,
+      hydrationPass: hydrationBytes <= budget.hydration * 1024,
+      files: initialFiles,
+      hydrationFiles,
+    };
+  });
+}
+
+function formatKb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+export function renderMarkdown(report) {
+  const lines = [
+    "# Frontend Bundle Report",
+    "",
+    `Network: \`${report.network}\``,
+    `Generated: \`${report.generatedAt}\``,
+    "",
+    "| Route | Initial JS | Initial budget | Hydration JS | Hydration budget | Status |",
+    "| --- | ---: | ---: | ---: | ---: | --- |",
+  ];
+
+  for (const route of report.routes) {
+    const status = route.initialPass && route.hydrationPass ? "PASS" : "FAIL";
+    lines.push(
+      `| ${route.label} (${route.route}) | ${formatKb(route.initialBytes)} | ${formatKb(route.initialBudgetBytes)} | ${formatKb(route.hydrationBytes)} | ${formatKb(route.hydrationBudgetBytes)} | ${status} |`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function collectSizes(buildDir, files) {
+  const sizes = new Map();
+  await Promise.all(
+    [...new Set(files)].map(async (file) => {
+      const stats = await fs.stat(path.join(buildDir, file));
+      sizes.set(file, stats.size);
+    }),
+  );
+  return sizes;
+}
+
+async function main() {
+  const buildDir = process.env.NEXT_BUILD_DIR || DEFAULT_BUILD_DIR;
+  const manifestPath = path.join(buildDir, "build-manifest.json");
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const routeFiles = Object.values(ROUTE_BUDGETS).flatMap((_, index) => {
+    const route = Object.keys(ROUTE_BUDGETS)[index];
+    return [...(manifest.pages?.["/_app"] ?? []), ...(manifest.pages?.[route] ?? [])];
+  });
+  const sizes = await collectSizes(buildDir, routeFiles);
+  const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";
+  if (!["testnet", "mainnet"].includes(network)) {
+    throw new Error(`Unsupported Stellar network for bundle report: ${network}`);
+  }
+
+  const report = {
+    network,
+    generatedAt: new Date().toISOString(),
+    routes: createRouteReport(manifest, sizes),
+  };
+  const outputDir = path.join(process.cwd(), REPORT_DIR);
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, "routes.json"), `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(path.join(outputDir, "routes.md"), renderMarkdown(report));
+
+  console.log(renderMarkdown(report));
+  if (report.routes.some((route) => !route.initialPass || !route.hydrationPass)) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/frontend/scripts/bundle-budget.test.mjs
+++ b/frontend/scripts/bundle-budget.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRouteReport, renderMarkdown } from "./bundle-budget.mjs";
+
+const manifest = {
+  pages: {
+    "/_app": ["static/app.js", "static/shared.js"],
+    "/dashboard": ["static/shared.js", "static/dashboard.js"],
+    "/pay": ["static/shared.js", "static/pay.js"],
+    "/trade": ["static/shared.js", "static/trade.js"],
+    "/settings": ["static/shared.js", "static/settings.js"],
+  },
+};
+
+const sizes = new Map([
+  ["static/app.js", 10 * 1024],
+  ["static/shared.js", 20 * 1024],
+  ["static/dashboard.js", 30 * 1024],
+  ["static/pay.js", 15 * 1024],
+  ["static/trade.js", 40 * 1024],
+  ["static/settings.js", 25 * 1024],
+]);
+
+test("reports each required route and deduplicates shared chunks", () => {
+  const routes = createRouteReport(manifest, sizes, {
+    "/dashboard": { label: "Dashboard", initial: 100, hydration: 100 },
+    "/pay": { label: "Pay", initial: 100, hydration: 100 },
+    "/trade": { label: "Trade", initial: 100, hydration: 100 },
+    "/settings": { label: "Settings", initial: 100, hydration: 100 },
+  });
+
+  assert.deepEqual(routes.map(({ route }) => route), ["/dashboard", "/pay", "/trade", "/settings"]);
+  assert.equal(routes[0].initialBytes, 60 * 1024);
+  assert.equal(routes[0].hydrationBytes, 30 * 1024);
+  assert.deepEqual(routes[0].hydrationFiles, ["static/dashboard.js"]);
+});
+
+test("marks a route as failed when either budget is exceeded", () => {
+  const [route] = createRouteReport(manifest, sizes, {
+    "/dashboard": { label: "Dashboard", initial: 50, hydration: 20 },
+  });
+
+  assert.equal(route.initialPass, false);
+  assert.equal(route.hydrationPass, false);
+  assert.match(renderMarkdown({ network: "testnet", generatedAt: "now", routes: [route] }), /FAIL/);
+});


### PR DESCRIPTION

## Summary
Adds per-route frontend bundle reports with separate initial JS and hydration budgets for dashboard, pay, trade, and settings. CI publishes the reports as build artifacts.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #845 

## Changes

- Added initial JS and hydration budgets for four frontend routes.
- Added JSON and Markdown bundle reports.
- Updated CI to validate reports and upload them as artifacts.
- Added automated tests for route accounting and budget failures.
- Explicitly configured bundle validation for Stellar Testnet.

## Testing

- [ ] Tested locally on Testnet
- [x] Added/updated unit tests
- [ ] Manually tested UI flow

Focused bundle report tests pass.
## Screenshots (if UI change)

Not applicable.

## Checklist

- [x] My code follows the project style
- [x] I've updated docs if needed
- [x] No console errors or warnings
- [ ] I've rebased on latest `main`