### PR TITLE
feat(webhooks): Add event id, attempt, created-at, network to webhook payload

### DIFF
--- a/backend/__tests__/webhookSignature.test.js
+++ b/backend/__tests__/webhookSignature.test.js
@@ -10,7 +10,15 @@ const {
 } = require("../src/utils/webhookSignature");
 
 const SECRET = "supersecret-webhook-key";
-const PAYLOAD = { event: "payment.received", amount: "10.5", asset: "XLM" };
+const PAYLOAD = {
+  eventId: "12345",
+  attempt: 1,
+  createdAt: "2026-08-27T10:00:00Z",
+  network: "testnet",
+  event: "payment.received",
+  amount: "10.5",
+  asset: "XLM"
+};
 
 function sign(payload, secret) {
   return generateWebhookSignature(payload, secret);

--- a/backend/src/services/paymentMonitor.js
+++ b/backend/src/services/paymentMonitor.js
@@ -50,8 +50,14 @@ function startMonitoring(publicKey) {
             ? "native"
             : `${record.asset_code}:${record.asset_issuer}`;
 
+        const network = HORIZON_URL.includes("testnet") ? "testnet" : "mainnet";
+        
         /** @type {import('./webhookDelivery').PaymentPayload} */
         const payload = {
+          eventId: record.id,
+          attempt: 1,
+          createdAt: new Date().toISOString(),
+          network,
           event: "payment_received",
           publicKey,
           amount: record.amount,

--- a/backend/src/services/webhookDelivery.js
+++ b/backend/src/services/webhookDelivery.js
@@ -20,6 +20,10 @@ const { generateWebhookSignature } = require("../utils/webhookSignature");
 
 /**
  * @typedef {Object} PaymentPayload
+ * @property {string} eventId
+ * @property {number} attempt
+ * @property {string} createdAt
+ * @property {string} network
  * @property {'payment_received'} event
  * @property {string} publicKey
  * @property {string} amount

--- a/docs/api.md
+++ b/docs/api.md
@@ -1141,18 +1141,24 @@ Register Horizon SSE listeners that POST to your URL when payments are received.
 **Outbound webhook payload** (POST to your `url`)
 ```json
 {
-  "event": "payment.received",
+  "eventId": "12345",
+  "attempt": 1,
+  "createdAt": "2026-08-27T10:00:00Z",
+  "network": "testnet",
+  "event": "payment_received",
   "publicKey": "GABC...",
-  "payment": {
-    "id": "...",
-    "from": "G...",
-    "to": "G...",
-    "amount": "10.0000000",
-    "asset": "XLM",
-    "createdAt": "2025-01-01T12:00:00Z"
-  }
+  "amount": "10.0000000",
+  "asset": "XLM",
+  "from": "G...",
+  "transactionHash": "...",
+  "ledger": 123456,
+  "timestamp": "2026-08-27T10:00:00Z"
 }
 ```
+
+**Consumer Idempotency**:
+Consumers should use the `eventId` to deduplicate webhook events and safely handle retries (should they occur). The `eventId` is globally unique for each stellar event and network, preventing duplicate processing if the webhook is delivered multiple times for the same occurrence.
+
 
 Header: `X-Webhook-Signature` — HMAC-SHA256 hex of the JSON body using `secret`.
 


### PR DESCRIPTION
Closes #771 

## Summary

This PR adds stable identifiers (`eventId`), `attempt` counters, and `createdAt` timestamps to webhook payloads. This enables downstream consumers to safely deduplicate retries, track event generation times, and explicitly verify network state (`testnet` vs `mainnet`).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #771 

## Changes

- Added `eventId`, `attempt`, and `createdAt` fields to the `PaymentPayload` type and webhook generator.
- Appended an explicit `network` field (`testnet` or `mainnet`) to the webhook payload.
- Added documentation to `docs/api.md` outlining consumer idempotency behavior and safe retry handling.
- Updated mock payloads in `webhookSignature.test.js` to assert that signatures securely cover the exact new versioned bytes.

## Testing

- [ ] Tested locally on Testnet
- [x] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

N/A

## Checklist

- [x] My code follows the project style
- [x] I've updated docs if needed
- [x] No console errors or warnings
- [x] I've rebased on latest `main`