### PR TITLE
fix: explicit pagination validation for limit and offset

### DIFF
--- a/backend/__tests__/tipsController.test.js
+++ b/backend/__tests__/tipsController.test.js
@@ -160,7 +160,7 @@ describe("tipsController", () => {
 
       expect(tipsService.getTipsReceived).toHaveBeenCalledWith(
         req.params.creatorPublicKey,
-        { limit: 10, offset: 20 }
+        { limit: "10", offset: "20" }
       );
 
       expect(res.json).toHaveBeenCalledWith({
@@ -194,7 +194,7 @@ describe("tipsController", () => {
 
       expect(tipsService.getTipsSent).toHaveBeenCalledWith(
         req.params.senderPublicKey,
-        { limit: 15, offset: 5 }
+        { limit: "15", offset: "5" }
       );
 
       expect(res.json).toHaveBeenCalledWith({
@@ -220,7 +220,7 @@ describe("tipsController", () => {
       );
     });
 
-    it("parses pagination params as integers", async () => {
+    it("passes pagination params to service", async () => {
       req.params = {
         senderPublicKey: "GABC123456789012345678901234567890123456789012345678",
       };
@@ -235,7 +235,7 @@ describe("tipsController", () => {
 
       expect(tipsService.getTipsSent).toHaveBeenCalledWith(
         req.params.senderPublicKey,
-        { limit: 25, offset: 50 }
+        { limit: "25", offset: "50" }
       );
     });
 
@@ -375,7 +375,7 @@ describe("tipsController", () => {
 
       expect(tipsService.getTopTippers).toHaveBeenCalledWith(
         req.params.creatorPublicKey,
-        10
+        "10"
       );
 
       expect(res.json).toHaveBeenCalledWith({
@@ -396,7 +396,7 @@ describe("tipsController", () => {
 
       expect(tipsService.getTopTippers).toHaveBeenCalledWith(
         req.params.creatorPublicKey,
-        5 // Default limit
+        undefined
       );
     });
   });

--- a/backend/__tests__/tipsService.test.js
+++ b/backend/__tests__/tipsService.test.js
@@ -341,4 +341,46 @@ describe("tipsService", () => {
       expect(() => tipsService.validateTipInput(data)).toThrow("amount must be a positive number");
     });
   });
+
+  describe("validatePagination", () => {
+    it("uses defaults when no params provided", () => {
+      const result = tipsService.validatePagination(undefined, undefined);
+      expect(result.limit).toBe(50);
+      expect(result.offset).toBe(0);
+    });
+
+    it("parses valid integer strings", () => {
+      const result = tipsService.validatePagination("10", "20");
+      expect(result.limit).toBe(10);
+      expect(result.offset).toBe(20);
+    });
+
+    it("rejects negative limit", () => {
+      expect(() => tipsService.validatePagination("-5", "0")).toThrow("limit must be an integer between 1 and 100");
+    });
+
+    it("rejects zero limit", () => {
+      expect(() => tipsService.validatePagination("0", "0")).toThrow("limit must be an integer between 1 and 100");
+    });
+
+    it("rejects fractional limit", () => {
+      expect(() => tipsService.validatePagination("10.5", "0")).toThrow("limit must be an integer between 1 and 100");
+    });
+
+    it("rejects limit over max", () => {
+      expect(() => tipsService.validatePagination("101", "0")).toThrow("limit must be an integer between 1 and 100");
+    });
+
+    it("rejects negative offset", () => {
+      expect(() => tipsService.validatePagination("10", "-1")).toThrow("offset must be a non-negative integer");
+    });
+
+    it("rejects fractional offset", () => {
+      expect(() => tipsService.validatePagination("10", "5.5")).toThrow("offset must be a non-negative integer");
+    });
+
+    it("rejects non-numeric limit", () => {
+      expect(() => tipsService.validatePagination("abc", "0")).toThrow("limit must be an integer between 1 and 100");
+    });
+  });
 });

--- a/backend/src/controllers/tipsController.js
+++ b/backend/src/controllers/tipsController.js
@@ -91,8 +91,8 @@ async function getTipsReceived(req, res, next) {
     const { limit, offset } = req.query;
 
     const result = tipsService.getTipsReceived(creatorPublicKey, {
-      limit: limit ? parseInt(limit, 10) : undefined,
-      offset: offset ? parseInt(offset, 10) : undefined,
+      limit,
+      offset,
     });
 
     // Also get stats
@@ -155,8 +155,8 @@ async function getTipsSent(req, res, next) {
     const { limit, offset } = req.query;
 
     const result = tipsService.getTipsSent(senderPublicKey, {
-      limit: limit ? parseInt(limit, 10) : undefined,
-      offset: offset ? parseInt(offset, 10) : undefined,
+      limit,
+      offset,
     });
 
     res.json({
@@ -186,9 +186,7 @@ async function getTopTippers(req, res, next) {
     const { creatorPublicKey } = req.params;
     const { limit } = req.query;
     
-    const parsedLimit = limit ? parseInt(limit, 10) : 5;
-    
-    const result = tipsService.getTopTippers(creatorPublicKey, parsedLimit);
+    const result = tipsService.getTopTippers(creatorPublicKey, limit);
     
     res.json({
       success: true,

--- a/backend/src/services/tipsService.js
+++ b/backend/src/services/tipsService.js
@@ -53,6 +53,39 @@ function recordTip({ senderPublicKey, creatorPublicKey, amount, asset = "XLM", m
 }
 
 /**
+ * Validate pagination parameters.
+ * @param {any} limit - The limit parameter
+ * @param {any} offset - The offset parameter
+ * @param {number} defaultLimit - The default limit
+ * @param {number} maxLimit - The maximum allowed limit (documented maximum page size)
+ * @returns {object} { limit: number, offset: number }
+ */
+function validatePagination(limit, offset, defaultLimit = 50, maxLimit = 100) {
+  let parsedLimit = defaultLimit;
+  let parsedOffset = 0;
+
+  if (limit !== undefined) {
+    parsedLimit = Number(limit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > maxLimit) {
+      const error = new Error(`limit must be an integer between 1 and ${maxLimit}`);
+      error.status = 400;
+      throw error;
+    }
+  }
+
+  if (offset !== undefined) {
+    parsedOffset = Number(offset);
+    if (!Number.isInteger(parsedOffset) || parsedOffset < 0) {
+      const error = new Error("offset must be a non-negative integer");
+      error.status = 400;
+      throw error;
+    }
+  }
+
+  return { limit: parsedLimit, offset: parsedOffset };
+}
+
+/**
  * Get all tips received by a creator.
  * @param {string} creatorPublicKey - The Stellar public key of the creator
  * @param {object} [options] - Optional filters
@@ -67,7 +100,7 @@ function getTipsReceived(creatorPublicKey, options = {}) {
     throw error;
   }
 
-  const { limit = 50, offset = 0 } = options;
+  const { limit, offset } = validatePagination(options.limit, options.offset, 50, 100);
 
   const tips = tipsByCreator.get(creatorPublicKey) || [];
   const total = tips.length;
@@ -144,7 +177,7 @@ function getTipsSent(senderPublicKey, options = {}) {
     throw error;
   }
 
-  const { limit = 50, offset = 0 } = options;
+  const { limit, offset } = validatePagination(options.limit, options.offset, 50, 100);
 
   // Search all tips to find ones sent by this user
   const allTips = [];
@@ -209,12 +242,14 @@ function validateTipInput(data) {
  * @param {number} limit - The number of tippers to return
  * @returns {Array} Sorted array of top tippers
  */
-function getTopTippers(creatorPublicKey, limit = 5) {
+function getTopTippers(creatorPublicKey, limit) {
   if (!creatorPublicKey) {
     const error = new Error("creatorPublicKey is required");
     error.status = 400;
     throw error;
   }
+
+  const { limit: validLimit } = validatePagination(limit, undefined, 5, 100);
 
   const tips = tipsByCreator.get(creatorPublicKey) || [];
   
@@ -237,7 +272,7 @@ function getTopTippers(creatorPublicKey, limit = 5) {
   entries.sort((a, b) => parseFloat(b.totalAmount) - parseFloat(a.totalAmount));
 
   // Limit result count
-  const result = entries.slice(0, limit);
+  const result = entries.slice(0, validLimit);
 
   return result;
 }
@@ -250,4 +285,5 @@ module.exports = {
   validateTipInput,
   getTopTippers,
   tipsByCreator,
+  validatePagination,
 };


### PR DESCRIPTION
Closes #761 

## Summary

This PR adds explicit integer, range, and default validation for pagination parameters (`limit` and `offset`) across all tips-related endpoints to reject negative, fractional, and non-numeric values.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #761 

## Changes

- Introduced a `validatePagination` helper in `tipsService.js` to enforce strict validation on pagination limits and offsets (maximum page size 100).
- Removed inline `parseInt` logic in `tipsController.js` so that raw query parameters can be fully validated by the service layer.
- Added comprehensive unit test coverage for pagination validation edge cases in `tipsService.test.js`.
- Updated test expectations in `tipsController.test.js` to align with the new controller logic passing raw strings.

## Testing

- [ ] Tested locally on Testnet
- [x] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

NIL

## Checklist

- [x] My code follows the project style
- [ ] I've updated docs if needed
- [x] No console errors or warnings
- [x] I've rebased on latest `main`