### PR TITLE
feat: Add endpoint validation with aria-invalid and field focus

### DIFF
--- a/frontend/__tests__/settingsSNS.test.tsx
+++ b/frontend/__tests__/settingsSNS.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -57,6 +57,7 @@ global.fetch = jest.fn().mockResolvedValue({
 } as any);
 
 import SettingsPage from "../pages/settings";
+import { setNetworkConfig } from "@/lib/stellar";
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -67,6 +68,41 @@ const defaultProps = {
 };
 
 describe("SettingsPage — Stellar Name Service section", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("associates custom endpoint errors and focuses the first invalid field", () => {
+    render(<SettingsPage {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+    const horizonInput = screen.getByLabelText("Custom Horizon URL");
+    fireEvent.change(horizonInput, { target: { value: "http://horizon.example.com" } });
+    fireEvent.blur(horizonInput);
+
+    expect(horizonInput).toHaveAttribute("aria-invalid", "true");
+    expect(horizonInput).toHaveAttribute("aria-describedby", "custom-horizon-error");
+    expect(screen.getByText("Horizon URL must use HTTPS.")).toBeInTheDocument();
+    expect(horizonInput).toHaveFocus();
+    expect(setNetworkConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects RPC endpoints on a different explicit network", () => {
+    render(<SettingsPage {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+    const horizonInput = screen.getByLabelText("Custom Horizon URL");
+    const rpcInput = screen.getByLabelText("Custom Soroban RPC URL");
+    fireEvent.change(horizonInput, { target: { value: "https://horizon-testnet.example.com" } });
+    fireEvent.change(rpcInput, { target: { value: "https://soroban-mainnet.example.com" } });
+    fireEvent.blur(rpcInput);
+
+    expect(rpcInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByText("RPC URL must use the same network as the Horizon URL.")).toBeInTheDocument();
+    expect(rpcInput).toHaveFocus();
+    expect(setNetworkConfig).not.toHaveBeenCalled();
+  });
+
   it("renders the 'Stellar Name Service' heading", () => {
     render(<SettingsPage {...defaultProps} />);
     expect(

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -145,6 +145,9 @@ export function getKnownAssets() {
 /** Soroban RPC server URL. Defaults to testnet. */
 export function getSorobanRpcUrl(): string {
   const config = getNetworkConfig();
+  if (config.rpcUrl?.trim()) {
+    return config.rpcUrl.trim();
+  }
   if (config.network === "mainnet") {
     return "https://soroban.stellar.org";
   } else if (config.network === "testnet") {

--- a/frontend/lib/stellarConfig.ts
+++ b/frontend/lib/stellarConfig.ts
@@ -8,6 +8,7 @@ import { Horizon, Networks } from "@stellar/stellar-sdk";
 export interface NetworkConfig {
   network: "testnet" | "mainnet" | "custom";
   horizonUrl: string;
+  rpcUrl?: string;
 }
 
 export const DEFAULT_CONFIGS: Record<"testnet" | "mainnet", NetworkConfig> = {

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -3,7 +3,7 @@
  * Settings page with network switcher for testnet/mainnet/custom Horizon URL.
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { getNetworkConfig, setNetworkConfig, NetworkConfig } from "@/lib/stellar";
@@ -38,6 +38,10 @@ export default function SettingsPage({
     horizonUrl: "https://horizon-testnet.stellar.org",
   });
   const [customUrl, setCustomUrl] = useState("");
+  const [customRpcUrl, setCustomRpcUrl] = useState("");
+  const [endpointErrors, setEndpointErrors] = useState({ horizon: "", rpc: "" });
+  const customHorizonRef = useRef<HTMLInputElement>(null);
+  const customRpcRef = useRef<HTMLInputElement>(null);
   const [showMainnetWarning, setShowMainnetWarning] = useState(false);
   const [pendingNetwork, setPendingNetwork] = useState<"testnet" | "mainnet" | "custom" | null>(null);
 
@@ -128,10 +132,16 @@ export default function SettingsPage({
     setConfig(currentConfig);
     if (currentConfig.network === "custom") {
       setCustomUrl(currentConfig.horizonUrl);
+      setCustomRpcUrl(currentConfig.rpcUrl || "");
     }
   }, []);
 
   const handleNetworkChange = (network: "testnet" | "mainnet" | "custom") => {
+    if (network === "custom") {
+      setConfig((current) => ({ ...current, network: "custom" }));
+      setEndpointErrors({ horizon: "", rpc: "" });
+      return;
+    }
     if (network === "mainnet" && config.network !== "mainnet") {
       setPendingNetwork(network);
       setShowMainnetWarning(true);
@@ -235,6 +245,62 @@ export default function SettingsPage({
     }
   };
 
+  const validateEndpoint = (value: string, label: string, required = true) => {
+    if (!value.trim()) return required ? `${label} URL is required.` : "";
+    try {
+      const url = new URL(value.trim());
+      if (url.protocol !== "https:") return `${label} URL must use HTTPS.`;
+      if (!url.hostname) return `${label} URL must include a hostname.`;
+    } catch {
+      return `${label} URL is invalid.`;
+    }
+    return "";
+  };
+
+  const endpointNetwork = (value: string) => {
+    try {
+      const hostname = new URL(value).hostname.toLowerCase();
+      if (hostname.includes("testnet")) return "testnet";
+      if (hostname.includes("mainnet")) return "mainnet";
+    } catch {
+      return null;
+    }
+    return null;
+  };
+
+  const handleCustomEndpointsBlur = () => {
+    const horizonError = validateEndpoint(customUrl, "Horizon");
+    const rpcError = validateEndpoint(customRpcUrl, "RPC", false);
+    const horizonNetwork = endpointNetwork(customUrl);
+    const rpcNetwork = endpointNetwork(customRpcUrl);
+    const networkError =
+      !horizonError && !rpcError && horizonNetwork && rpcNetwork && horizonNetwork !== rpcNetwork
+        ? "RPC URL must use the same network as the Horizon URL."
+        : "";
+    const errors = { horizon: horizonError, rpc: rpcError || networkError };
+    setEndpointErrors(errors);
+    if (errors.horizon) {
+      customHorizonRef.current?.focus();
+      return;
+    }
+    if (errors.rpc) {
+      customRpcRef.current?.focus();
+      return;
+    }
+
+    const newConfig: NetworkConfig = {
+      network: "custom",
+      horizonUrl: customUrl.trim(),
+      ...(customRpcUrl.trim() ? { rpcUrl: customRpcUrl.trim() } : {}),
+    };
+    setNetworkConfig(newConfig);
+    setConfig(newConfig);
+    if (publicKey) {
+      disconnectWallet();
+      onDisconnect();
+    }
+  };
+
   const applyNetworkChange = (network: "testnet" | "mainnet" | "custom") => {
     let horizonUrl: string;
     if (network === "testnet") {
@@ -242,8 +308,8 @@ export default function SettingsPage({
     } else if (network === "mainnet") {
       horizonUrl = "https://horizon.stellar.org";
     } else {
-      horizonUrl = customUrl.trim();
-      if (!horizonUrl) return; // Don't allow empty custom URL
+      handleCustomEndpointsBlur();
+      return;
     }
 
     const newConfig: NetworkConfig = { network, horizonUrl };
@@ -258,21 +324,6 @@ export default function SettingsPage({
 
     setShowMainnetWarning(false);
     setPendingNetwork(null);
-  };
-
-  const handleCustomUrlChange = (url: string) => {
-    setCustomUrl(url);
-    if (config.network === "custom") {
-      const newConfig: NetworkConfig = { network: "custom", horizonUrl: url };
-      setNetworkConfig(newConfig);
-      setConfig(newConfig);
-
-      // Disconnect wallet on URL change
-      if (publicKey) {
-        disconnectWallet();
-        onDisconnect();
-      }
-    }
   };
 
   // Username registration handler
@@ -511,19 +562,41 @@ export default function SettingsPage({
 
                 {config.network === "custom" && (
                   <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                    <label htmlFor="custom-horizon-url" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                       Custom Horizon URL
                     </label>
                     <input
+                      id="custom-horizon-url"
                       type="url"
                       value={customUrl}
                       onChange={(e) => setCustomUrl(e.target.value)}
-                      onBlur={() => handleCustomUrlChange(customUrl)}
+                      onBlur={handleCustomEndpointsBlur}
+                      ref={customHorizonRef}
+                      aria-invalid={Boolean(endpointErrors.horizon)}
+                      aria-describedby={endpointErrors.horizon ? "custom-horizon-error" : "custom-horizon-help"}
                       placeholder="https://horizon.example.com"
                       className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-cosmos-900 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-stellar-500 focus:border-transparent"
                     />
-                    <p className="text-xs text-slate-400 dark:text-slate-400 mt-1">
-                      Enter a custom Horizon server URL. Changes take effect immediately.
+                    <p id={endpointErrors.horizon ? "custom-horizon-error" : "custom-horizon-help"} role={endpointErrors.horizon ? "alert" : undefined} className={`text-xs mt-1 ${endpointErrors.horizon ? "text-red-400" : "text-slate-400 dark:text-slate-400"}`}>
+                      {endpointErrors.horizon || "Enter a custom Horizon server URL. Changes take effect after both endpoints are valid."}
+                    </p>
+                    <label htmlFor="custom-rpc-url" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mt-4 mb-2">
+                      Custom Soroban RPC URL
+                    </label>
+                    <input
+                      id="custom-rpc-url"
+                      type="url"
+                      value={customRpcUrl}
+                      onChange={(e) => setCustomRpcUrl(e.target.value)}
+                      onBlur={handleCustomEndpointsBlur}
+                      ref={customRpcRef}
+                      aria-invalid={Boolean(endpointErrors.rpc)}
+                      aria-describedby={endpointErrors.rpc ? "custom-rpc-error" : "custom-rpc-help"}
+                      placeholder="https://soroban.example.com"
+                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-cosmos-900 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-stellar-500 focus:border-transparent"
+                    />
+                    <p id={endpointErrors.rpc ? "custom-rpc-error" : "custom-rpc-help"} role={endpointErrors.rpc ? "alert" : undefined} className={`text-xs mt-1 ${endpointErrors.rpc ? "text-red-400" : "text-slate-400 dark:text-slate-400"}`}>
+                      {endpointErrors.rpc || "Use an RPC endpoint on the same network as Horizon."}
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
- Validate custom Horizon and RPC URLs before save
- Reject non-HTTPS schemes
- Detect testnet/mainnet network mismatch
- Focus first invalid field
- Add aria-invalid and aria-describedby attributes
- Add automated test coverage for endpoint validation

Fixes custom endpoint errors surfacing at field level.

## Summary

<!-- What does this PR do? 1-2 sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue


## Changes

<!-- List the key changes made -->
- 
- 

## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`

Closes #833 