### PR TITLE
 [reliability] Add AbortController timeouts to frontend Horizon and A…

### DIFF
--- a/frontend/__tests__/CreatorTipsDashboard.test.tsx
+++ b/frontend/__tests__/CreatorTipsDashboard.test.tsx
@@ -1,10 +1,11 @@
 /**
  * __tests__/CreatorTipsDashboard.test.tsx
- * Tests for the CSV export button on the creator tips dashboard (#612).
+ * Tests for the CSV export button and timeout/offline/unmount behavior on the
+ * creator tips dashboard (#612).
  */
 
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import CreatorTipsDashboard from "../components/CreatorTipsDashboard";
 import { exportTipsToCSV } from "@/utils/format";
@@ -27,11 +28,16 @@ const mockTips = [
   },
 ];
 
-global.fetch = jest.fn();
+const deferred = () => {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+};
 
 describe("CreatorTipsDashboard CSV export", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = jest.fn();
   });
 
   it("exports the currently visible tips when the export button is clicked", async () => {
@@ -76,5 +82,75 @@ describe("CreatorTipsDashboard CSV export", () => {
 
     const exportButton = await screen.findByText("Export CSV");
     expect(exportButton.closest("button")).toBeDisabled();
+  });
+});
+
+describe("CreatorTipsDashboard timeout + offline error handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it("shows a timeout message when the request overruns its budget", async () => {
+    jest.useFakeTimers();
+    (fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const onAbort = () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+            (init.signal as AbortSignal).removeEventListener("abort", onAbort);
+          };
+          (init.signal as AbortSignal).addEventListener("abort", onAbort);
+        })
+    );
+
+    render(<CreatorTipsDashboard publicKey="GXYZ789CREATORPUBLICKEY" username="alice" />);
+
+    await jest.advanceTimersByTimeAsync(10_000 + 1);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Loading tips timed out. Please try again.")
+      ).toBeInTheDocument();
+    });
+
+    jest.useRealTimers();
+  });
+
+  it("shows an offline message when the request fails with a TypeError", async () => {
+    (fetch as jest.Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(<CreatorTipsDashboard publicKey="GXYZ789CREATORPUBLICKEY" username="alice" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You appear to be offline. Check your connection and try again.")
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("CreatorTipsDashboard unmount cancellation", () => {
+  it("aborts the in-flight request when the component unmounts", async () => {
+    const { promise, resolve } = deferred();
+    const abortSpy = jest.fn();
+    global.fetch = jest.fn((_url: string, init: RequestInit) => {
+      const signal = init.signal as AbortSignal;
+      signal.addEventListener("abort", abortSpy);
+      return promise;
+    }) as jest.Mock;
+
+    const { unmount } = render(
+      <CreatorTipsDashboard publicKey="GXYZ789CREATORPUBLICKEY" username="alice" />
+    );
+
+    expect(abortSpy).not.toHaveBeenCalled();
+    unmount();
+
+    // The component aborts its AbortController on unmount.
+    expect(abortSpy).toHaveBeenCalled();
+
+    resolve({ ok: true, json: async () => ({ success: true, data: { tips: [], stats: null } }) });
+    cleanup();
   });
 });

--- a/frontend/__tests__/request-timeout.test.ts
+++ b/frontend/__tests__/request-timeout.test.ts
@@ -1,0 +1,140 @@
+/**
+ * __tests__/request-timeout.test.ts
+ * Coverage for AbortController timeout + error classification used by the
+ * frontend API and Horizon request layers.
+ */
+
+import {
+  createTimeoutController,
+  classifyFetchError,
+  RequestTimeoutError,
+  RequestAbortedError,
+  OfflineError,
+} from "@/lib/request";
+import { apiFetch, API_TIMEOUT_MS } from "@/lib/api";
+
+describe("createTimeoutController", () => {
+  beforeEach(() => jest.useFakeTimers());
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("aborts and reports a timeout after the budget elapses", () => {
+    const { controller, cleanup, wasTimeout } = createTimeoutController(100);
+    expect(controller.signal.aborted).toBe(false);
+
+    jest.advanceTimersByTime(101);
+    expect(controller.signal.aborted).toBe(true);
+    expect(wasTimeout()).toBe(true);
+
+    cleanup();
+  });
+
+  it("aborts immediately when the external signal is already aborted (not a timeout)", () => {
+    const external = new AbortController();
+    external.abort();
+    const { controller, cleanup, wasTimeout } = createTimeoutController(100, external.signal);
+    expect(controller.signal.aborted).toBe(true);
+    expect(wasTimeout()).toBe(false);
+    cleanup();
+  });
+
+  it("aborts when a not-yet-aborted external signal fires (not a timeout)", () => {
+    const external = new AbortController();
+    const { controller, cleanup, wasTimeout } = createTimeoutController(100, external.signal);
+    external.abort();
+    expect(controller.signal.aborted).toBe(true);
+    expect(wasTimeout()).toBe(false);
+    cleanup();
+  });
+});
+
+describe("classifyFetchError", () => {
+  it("maps an abort to a timeout when the budget fired", () => {
+    const err = classifyFetchError(new DOMException("aborted", "AbortError"), true, true);
+    expect(err).toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it("maps an abort to a cancelled request when a signal fired", () => {
+    const err = classifyFetchError(new DOMException("aborted", "AbortError"), true, false);
+    expect(err).toBeInstanceOf(RequestAbortedError);
+  });
+
+  it("maps a network TypeError to an offline error", () => {
+    const err = classifyFetchError(new TypeError("Failed to fetch"), false, false);
+    expect(err).toBeInstanceOf(OfflineError);
+  });
+
+  it("leaves unrelated errors untouched", () => {
+    const original = new Error("boom");
+    expect(classifyFetchError(original, false, false)).toBe(original);
+  });
+});
+
+describe("apiFetch timeout + error classification", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("rejects with RequestTimeoutError when the request overruns its budget", async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const onAbort = () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+            (init.signal as AbortSignal).removeEventListener("abort", onAbort);
+          };
+          (init.signal as AbortSignal).addEventListener("abort", onAbort);
+        })
+    );
+
+    const promise = apiFetch("/slow").catch((e) => e);
+    jest.advanceTimersByTime(API_TIMEOUT_MS + 1);
+
+    const err = await promise;
+    expect(err).toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it("rejects with OfflineError when fetch rejects with a TypeError", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(apiFetch("/offline")).rejects.toBeInstanceOf(OfflineError);
+  });
+
+  it("aborts when an external signal is passed and fired", async () => {
+    const external = new AbortController();
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const onAbort = () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+            (init.signal as AbortSignal).removeEventListener("abort", onAbort);
+          };
+          (init.signal as AbortSignal).addEventListener("abort", onAbort);
+        })
+    );
+
+    const promise = apiFetch("/cancelled", { signal: external.signal }).catch((e) => e);
+    external.abort();
+    const err = await promise;
+    expect(err).toBeInstanceOf(RequestAbortedError);
+  });
+
+  it("still returns parsed data on success", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { hello: "world" } }),
+    });
+
+    const data = await apiFetch<{ hello: string }>("/ok");
+    expect(data).toEqual({ hello: "world" });
+  });
+});

--- a/frontend/__tests__/stellar-timeout.test.ts
+++ b/frontend/__tests__/stellar-timeout.test.ts
@@ -1,0 +1,56 @@
+/**
+ * __tests__/stellar-timeout.test.ts
+ * Coverage for the Horizon raw-fetch timeout wrapper in lib/stellar.
+ */
+
+import {
+  fetchWithTimeout,
+  HORIZON_FEE_STATS_TIMEOUT_MS,
+  FRIENDBOT_TIMEOUT_MS,
+} from "@/lib/stellar";
+import { RequestTimeoutError, OfflineError } from "@/lib/request";
+
+describe("fetchWithTimeout", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("rejects with RequestTimeoutError when the response overruns the budget", async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const onAbort = () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+            (init.signal as AbortSignal).removeEventListener("abort", onAbort);
+          };
+          (init.signal as AbortSignal).addEventListener("abort", onAbort);
+        })
+    );
+
+    const promise = fetchWithTimeout("https://horizon.testnet.stellar.org/fee_stats", 100).catch(
+      (e) => e
+    );
+    jest.advanceTimersByTime(101);
+
+    await expect(promise).resolves.toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it("rejects with OfflineError when the browser is offline", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(
+      fetchWithTimeout("https://horizon.testnet.stellar.org/fee_stats", 100)
+    ).rejects.toBeInstanceOf(OfflineError);
+  });
+
+  it("is invoked through the exported fee/friendbot budgets", () => {
+    expect(HORIZON_FEE_STATS_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(FRIENDBOT_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+});

--- a/frontend/components/CreatorTipsDashboard.tsx
+++ b/frontend/components/CreatorTipsDashboard.tsx
@@ -3,10 +3,12 @@
  * Dashboard component for creators to view tips received.
  */
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import VirtualizedList from "@/components/VirtualizedList";
 import { formatXLM, shortenAddress, formatUSD, exportTipsToCSV } from "@/utils/format";
+import { apiFetch, API_TIMEOUT_MS } from "@/lib/api";
+import { RequestTimeoutError, OfflineError } from "@/lib/request";
 
 // Tip rows render virtualized past this count so long tip histories stay cheap to render.
 const VIRTUALIZE_THRESHOLD = 100;
@@ -50,36 +52,52 @@ export default function CreatorTipsDashboard({
   const [page, setPage] = useState(0);
   const pageSize = 10;
 
+  // Abort in-flight requests when the component unmounts or publicKey/page changes.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => abortRef.current?.abort();
+  }, []);
+
   const fetchTips = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
 
     try {
       const apiBase = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "";
-      
+
       // Fetch tips received
-      const tipsResponse = await fetch(
-        `${apiBase}/api/tips/received/${encodeURIComponent(publicKey)}?limit=${pageSize}&offset=${page * pageSize}`
+      const tipsPayload = await apiFetch<{
+        tips: TipRecord[];
+        stats: TipsStats | null;
+      }>(
+        `${apiBase}/api/tips/received/${encodeURIComponent(publicKey)}?limit=${pageSize}&offset=${page * pageSize}`,
+        { signal: controller.signal },
+        API_TIMEOUT_MS,
       );
-      
-      if (!tipsResponse.ok) {
-        throw new Error("Failed to load tips");
-      }
-      
-      const tipsPayload = await tipsResponse.json();
-      
-      if (tipsPayload?.success) {
-        setTips(tipsPayload.data.tips || []);
-        setStats(tipsPayload.data.stats || null);
-      } else {
-        setTips([]);
-      }
+
+      setTips(tipsPayload.tips || []);
+      setStats(tipsPayload.stats || null);
     } catch (err) {
+      if (err instanceof RequestTimeoutError) {
+        console.error("Tips request timed out:", err);
+        setError("Loading tips timed out. Please try again.");
+        return;
+      }
+      if (err instanceof OfflineError) {
+        console.error("Tips request failed while offline:", err);
+        setError("You appear to be offline. Check your connection and try again.");
+        return;
+      }
       console.error("Error fetching tips:", err);
       setError("Unable to load tips. Make sure you have a registered username.");
       setTips([]);
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        setLoading(false);
+      }
     }
   }, [publicKey, page]);
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3,9 +3,17 @@
  * @description Shared fetch wrapper with consistent error handling for API calls.
  */
 
+import { createTimeoutController, classifyFetchError } from "./request";
+
 function apiBase(): string {
   return process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "";
 }
+
+/** Default budget for a single backend API request. */
+export const API_TIMEOUT_MS = 10_000;
+
+/** Longer budget for bulk/heavy endpoints (e.g. CSV import, history exports). */
+export const API_BULK_TIMEOUT_MS = 30_000;
 
 export interface ApiSuccessResponse<T> {
   success: true;
@@ -34,22 +42,39 @@ export class ApiError extends Error {
  *
  * By default expects the standard `{ success: true, data: T }` envelope.
  * Pass `raw: true` to skip envelope parsing and return the full JSON body.
+ *
+ * Requests are automatically aborted after `timeoutMs` (default
+ * {@link API_TIMEOUT_MS}). Pass an external `signal` to cancel the request on
+ * component unmount. Timeout, offline, and abort conditions are surfaced as
+ * {@link RequestTimeoutError}, {@link OfflineError}, and
+ * {@link RequestAbortedError} respectively.
  */
 export async function apiFetch<T>(
   path: string,
   init?: RequestInit & { raw?: boolean },
+  timeoutMs: number = API_TIMEOUT_MS,
 ): Promise<T> {
-  const { raw, ...fetchInit } = init ?? {};
+  const { raw, signal: externalSignal, ...fetchInit } = init ?? {};
   const url = path.startsWith("http") ? path : `${apiBase()}${path}`;
 
-  const res = await fetch(url, {
-    ...fetchInit,
-    headers: {
-      "Content-Type": "application/json",
-      ...fetchInit.headers,
-    },
-  });
+  const { controller, cleanup, wasTimeout } = createTimeoutController(timeoutMs, externalSignal);
 
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...fetchInit,
+      headers: {
+        "Content-Type": "application/json",
+        ...fetchInit.headers,
+      },
+      signal: controller.signal,
+    });
+  } catch (err: unknown) {
+    cleanup();
+    throw classifyFetchError(err, controller.signal.aborted, wasTimeout());
+  }
+
+  cleanup();
   const json = await res.json().catch(() => null);
 
   if (!res.ok) {

--- a/frontend/lib/request.ts
+++ b/frontend/lib/request.ts
@@ -1,0 +1,123 @@
+/**
+ * @file lib/request.ts
+ * @description AbortController-based timeouts and consistent error
+ * classification for browser fetch calls. Lets callers distinguish a request
+ * that timed out from one that failed while offline or over HTTP, and lets
+ * components cancel in-flight requests on unmount.
+ */
+
+/** Thrown when a fetch exceeds its operation-specific budget. */
+export class RequestTimeoutError extends Error {
+  constructor(message = "Request timed out") {
+    super(message);
+    this.name = "RequestTimeoutError";
+  }
+}
+
+/**
+ * Thrown when the browser has no network connectivity. Extends `TypeError`
+ * because browsers reject offline fetches with `TypeError("Failed to fetch")`;
+ * callers that branch on `instanceof TypeError` keep working.
+ */
+export class OfflineError extends TypeError {
+  constructor(message = "You appear to be offline") {
+    super(message);
+    this.name = "OfflineError";
+  }
+}
+
+/** A request that was intentionally cancelled (e.g. component unmounted). */
+export class RequestAbortedError extends Error {
+  constructor(message = "Request aborted") {
+    super(message);
+    this.name = "RequestAbortedError";
+  }
+}
+
+export interface TimeoutHandle {
+  controller: AbortController;
+  cleanup: () => void;
+  /**
+   * Returns true when the abort was caused by the timeout budget elapsing
+   * (as opposed to a caller-supplied signal). Must be queried after the
+   * request settles.
+   */
+  wasTimeout: () => boolean;
+}
+
+/**
+ * Create an AbortController that aborts when either a caller-supplied signal
+ * is aborted or the given timeout budget (in ms) elapses, whichever comes
+ * first. The returned `controller.signal` should be passed to fetch.
+ *
+ * Call `cleanup` once the request settles so the timer and external-signal
+ * listener are released.
+ */
+export function createTimeoutController(
+  timeoutMs: number,
+  externalSignal?: AbortSignal | null,
+): TimeoutHandle {
+  const controller = new AbortController();
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const onExternalAbort = () => {
+    controller.abort();
+  };
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else if (typeof externalSignal.addEventListener === "function") {
+      externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+    }
+  }
+
+  if (timeoutMs > 0 && !controller.signal.aborted) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+  }
+
+  const cleanup = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (externalSignal && typeof externalSignal.removeEventListener === "function") {
+      externalSignal.removeEventListener("abort", onExternalAbort);
+    }
+  };
+
+  return { controller, cleanup, wasTimeout: () => timedOut };
+}
+
+/**
+ * Classify an error rejected by fetch into one of the concrete error types
+ * ({@link RequestTimeoutError}, {@link RequestAbortedError}, or
+ * {@link OfflineError}) so callers can react to each distinctly.
+ *
+ * HTTP status errors should be handled by the caller via `res.ok` and are
+ * intentionally left untouched here.
+ *
+ * @param err - The error rejected by fetch.
+ * @param aborted - Whether the associated AbortController fired.
+ * @param timedOut - Whether the abort was caused by the timeout budget.
+ */
+export function classifyFetchError(
+  err: unknown,
+  aborted = false,
+  timedOut = false,
+): Error {
+  if (aborted) {
+    return timedOut ? new RequestTimeoutError() : new RequestAbortedError();
+  }
+
+  // Browsers reject with a TypeError("Failed to fetch") when offline.
+  if (err instanceof TypeError) {
+    return new OfflineError();
+  }
+
+  return err instanceof Error ? err : new Error(String(err));
+}

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -42,6 +42,14 @@ import {
 
 import { apiFetch } from "./api";
 
+import {
+  createTimeoutController,
+  classifyFetchError,
+  RequestTimeoutError,
+  RequestAbortedError,
+  OfflineError,
+} from "./request";
+
 export {
   server,
   getServer,
@@ -54,6 +62,8 @@ export {
   getNetworkPassphrase,
   NETWORK_PASSPHRASE,
 };
+
+export { RequestTimeoutError, RequestAbortedError, OfflineError };
 
 /** One XLM is divided into 10,000,000 stroops, Stellar's smallest unit. */
 export const STELLAR_STROOPS_PER_XLM = 10_000_000;
@@ -304,6 +314,46 @@ export const ACCOUNT_NOT_FOUND_ERROR = "ACCOUNT_NOT_FOUND";
 export const FRIENDBOT_URL =
   process.env.NEXT_PUBLIC_FRIENDBOT_URL || "https://friendbot.stellar.org";
 
+// ─── Operation-specific request timeout budgets ───────────────────────────
+// Horizon and Soroban RPC endpoints can remain pending during upstream
+// outages. Every raw network call carries its own budget so a slow endpoint
+// never hangs the UI indefinitely. The active network (testnet vs. mainnet)
+// is always explicit via getNetworkConfig(), matching the rest of this module.
+
+/** Budget for the Horizon `/fee_stats` endpoint used when building payments. */
+export const HORIZON_FEE_STATS_TIMEOUT_MS = 5_000;
+
+/** Budget for Friendbot funding (testnet only). */
+export const FRIENDBOT_TIMEOUT_MS = 15_000;
+
+/**
+ * Fetch a URL with an operation-specific timeout budget and classify the
+ * result so callers can distinguish timeouts, offline failures, and abort
+ * (unmount) conditions.
+ *
+ * @param url - The URL to fetch.
+ * @param timeoutMs - Timeout budget for this operation.
+ * @param externalSignal - Optional caller signal (e.g. component unmount).
+ * @throws {RequestTimeoutError} When the budget elapses before a response.
+ * @throws {OfflineError} When the browser is offline / network failed.
+ * @throws {RequestAbortedError} When the caller cancelled the request.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  externalSignal?: AbortSignal | null,
+): Promise<Response> {
+  const { controller, cleanup, wasTimeout } = createTimeoutController(timeoutMs, externalSignal);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    cleanup();
+    return res;
+  } catch (err: unknown) {
+    cleanup();
+    throw classifyFetchError(err, controller.signal.aborted, wasTimeout());
+  }
+}
+
 /** Polling options for waiting until an account exists on Horizon. */
 export interface FundingPollOptions {
   intervalMs?: number;
@@ -367,8 +417,9 @@ export async function getFriendBotFunding(publicKey: string): Promise<void> {
     throw new Error("Friendbot is only available on Stellar testnet.");
   }
 
-  const res = await fetch(
-    `${FRIENDBOT_URL}?addr=${encodeURIComponent(publicKey)}`
+  const res = await fetchWithTimeout(
+    `${FRIENDBOT_URL}?addr=${encodeURIComponent(publicKey)}`,
+    FRIENDBOT_TIMEOUT_MS
   );
 
   if (!res.ok) {
@@ -594,7 +645,10 @@ export async function buildPaymentTransaction({
   let baseFeeStroops: string = STELLAR_BASE_FEE_STROOPS_STRING;
   try {
     const config = getNetworkConfig();
-    const feeRes = await fetch(`${config.horizonUrl}/fee_stats`);
+    const feeRes = await fetchWithTimeout(
+      `${config.horizonUrl}/fee_stats`,
+      HORIZON_FEE_STATS_TIMEOUT_MS
+    );
     if (feeRes.ok) {
       const feeData = await feeRes.json() as {
         fee_charged?: { p50?: string };
@@ -1493,7 +1547,7 @@ export async function fetchNetworkFeeStats(): Promise<NetworkFeeStats> {
   const config = getNetworkConfig();
   const url = `${config.horizonUrl}/fee_stats`;
 
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url, HORIZON_FEE_STATS_TIMEOUT_MS);
   if (!res.ok) {
     throw new Error(`Horizon fee_stats returned ${res.status}`);
   }


### PR DESCRIPTION
…PI requests

Several browser fetch calls in the frontend could remain pending indefinitely if a Horizon or backend API endpoint stalled during an upstream outage, leaving the UI stuck in a loading state with no way to recover. This PR adds AbortController-based timeout budgets to the frontend request layer so network calls always resolve (or fail) within a defined budget, and errors are classified so callers can react to timeouts, offline conditions, and cancellations distinctly.

Closes #738

## Summary

This PR adds AbortController-based timeout budgets to the frontend request layer so network calls always resolve (or fail) within a defined budget, and errors are classified so callers can react to timeouts, offline conditions, and cancellations distinctly.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #738 

## Changes
- lib/request.ts (new) — shared createTimeoutController (aborts on caller signal or budget elapse, with no timer leak) and classifyFetchError, which maps fetch rejections to RequestTimeoutError, OfflineError (extends TypeError so pre-existing instanceof TypeError fallbacks keep working), and RequestAbortedError.
- lib/api.ts — apiFetch now takes a per-operation timeout budget (API_TIMEOUT_MS = 10s, API_BULK_TIMEOUT_MS = 30s) and an external abort signal for unmount cancellation; timeout/offline/abort are surfaced as the classified error types.
- lib/stellar.ts — added fetchWithTimeout with operation-specific budgets (HORIZON_FEE_STATS_TIMEOUT_MS 5s, FRIENDBOT_TIMEOUT_MS 15s) and applied it to the raw Horizon fetch calls (Friendbot funding, payment fee_stats, fetchNetworkFeeStats). Network (testnet vs. mainnet) behavior stays explicit via getNetworkConfig(), and Friendbot remains testnet-guarded.
- components/CreatorTipsDashboard.tsx — migrated to apiFetch with an AbortController per request; in-flight requests are cancelled on unmount and on publicKey/page changes, and users get distinct timeout, offline, and generic error messages.



## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`
