### PR TITLE
[security] Prevent SSRF in webhook delivery

### DIFF
--- a/backend/__tests__/webhookDelivery.ssrf.test.js
+++ b/backend/__tests__/webhookDelivery.ssrf.test.js
@@ -1,0 +1,78 @@
+"use strict";
+
+jest.mock("node:dns", () => ({
+  promises: { lookup: jest.fn() },
+}));
+
+const { promises: dns } = require("node:dns");
+const {
+  deliverWebhook,
+  isBlockedAddress,
+  validateWebhookUrl,
+} = require("../src/services/webhookDelivery");
+
+describe("webhook SSRF protection", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    dns.lookup.mockClear();
+    dns.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+    });
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  it.each([
+    ["10.0.0.4", "private IPv4"],
+    ["172.20.0.4", "private IPv4"],
+    ["192.168.1.10", "private IPv4"],
+    ["127.0.0.1", "loopback IPv4"],
+    ["169.254.169.254", "link-local IPv4"],
+    ["::1", "loopback IPv6"],
+    ["fc00::1", "private IPv6"],
+    ["::ffff:127.0.0.1", "mapped loopback IPv4"],
+  ])("blocks %s (%s)", (address) => {
+    expect(isBlockedAddress(address)).toBeTruthy();
+  });
+
+  it("rejects a hostname resolving to a private address", async () => {
+    dns.lookup.mockResolvedValue([{ address: "192.168.1.12", family: 4 }]);
+
+    await expect(validateWebhookUrl("https://internal.example/hook")).rejects.toThrow(
+      "blocked private address"
+    );
+  });
+
+  it("revalidates redirects and refuses a private redirect target", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 307,
+      headers: { get: () => "https://internal.example/hook" },
+    });
+    dns.lookup
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValueOnce([{ address: "10.0.0.5", family: 4 }]);
+
+    await deliverWebhook(
+      { id: "wh-1", secret: "secret", url: "https://public.example/hook" },
+      { event: "payment_received" }
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(dns.lookup).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not make a request for an HTTP or non-default-port URL", async () => {
+    await deliverWebhook(
+      { id: "wh-2", secret: "secret", url: "http://127.0.0.1:8080/hook" },
+      { event: "payment_received" }
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/webhookDelivery.js
+++ b/backend/src/services/webhookDelivery.js
@@ -8,6 +8,47 @@
 
 const logger = require("../utils/logger");
 const { generateWebhookSignature } = require("../utils/webhookSignature");
+const dns = require("node:dns").promises;
+
+const BLOCKED_IPV4 = [
+  [/^0\./, "unspecified"],
+  [/^10\./, "private"],
+  [/^127\./, "loopback"],
+  [/^169\.254\./, "link-local"],
+  [/^192\.0\.0\./, "special-use"],
+  [/^192\.168\./, "private"],
+  [/^198\.18\./, "benchmark"],
+  [/^198\.19\./, "benchmark"],
+  [/^224\./, "multicast"],
+  [/^255\./, "broadcast"],
+];
+
+function isBlockedAddress(address) {
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::1" || normalized === "::" || normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe8") || normalized.startsWith("fe9") || normalized.startsWith("fea") || normalized.startsWith("feb")) {
+    return "non-public IPv6";
+  }
+  if (normalized.startsWith("::ffff:")) return isBlockedAddress(normalized.slice(7));
+  for (const [pattern, reason] of BLOCKED_IPV4) if (pattern.test(normalized)) return reason;
+  const octets = normalized.split(".").map(Number);
+  if (octets.length === 4 && octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127) return "carrier-grade NAT";
+  if (octets.length === 4 && octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) return "private";
+  return null;
+}
+
+async function validateWebhookUrl(rawUrl) {
+  let parsed;
+  try { parsed = new URL(rawUrl); } catch { throw new Error("Webhook URL is invalid"); }
+  if (parsed.protocol !== "https:") throw new Error("Webhook URL must use HTTPS");
+  if (parsed.username || parsed.password || parsed.port && parsed.port !== "443") throw new Error("Webhook URL has disallowed authority components");
+  const records = await dns.lookup(parsed.hostname, { all: true, verbatim: true });
+  if (!records.length) throw new Error("Webhook hostname has no address");
+  for (const record of records) {
+    const reason = isBlockedAddress(record.address);
+    if (reason) throw new Error(`Webhook hostname resolves to a blocked ${reason} address`);
+  }
+  return parsed;
+}
 
 /**
  * @typedef {Object} Webhook
@@ -44,21 +85,32 @@ async function deliverWebhook(webhook, payload) {
   const sig = generateWebhookSignature(body, webhook.secret);
 
   try {
-    const res = await fetch(webhook.url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Stellar-Signature": `sha256=${sig}`,
-        "X-Webhook-ID": webhook.id,
-      },
-      body,
-    });
+    let url = webhook.url;
+    for (let redirects = 0; redirects <= 3; redirects += 1) {
+      const parsed = await validateWebhookUrl(url);
+      const res = await fetch(parsed, {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Stellar-Signature": `sha256=${sig}`,
+          "X-Webhook-ID": webhook.id,
+        },
+        body,
+      });
+      if (res.status >= 300 && res.status < 400 && res.headers.get("location")) {
+        if (redirects === 3) throw new Error("Webhook redirect limit exceeded");
+        url = new URL(res.headers.get("location"), parsed).href;
+        continue;
+      }
 
-    if (!res.ok) {
-      logger.error(
-        { webhookId: webhook.id, url: webhook.url, status: res.status },
-        `[webhook] delivery failed for ${webhook.id}: HTTP ${res.status}`
-      );
+      if (!res.ok) {
+        logger.error(
+          { webhookId: webhook.id, url, status: res.status },
+          `[webhook] delivery failed for ${webhook.id}: HTTP ${res.status}`
+        );
+      }
+      break;
     }
   } catch (err) {
     logger.error(
@@ -69,4 +121,4 @@ async function deliverWebhook(webhook, payload) {
   }
 }
 
-module.exports = { deliverWebhook };
+module.exports = { deliverWebhook, isBlockedAddress, validateWebhookUrl };


### PR DESCRIPTION
Protect webhook delivery against SSRF by requiring HTTPS, resolving every destination before delivery, rejecting loopback/private/link-local/metadata-capable IPv4 and IPv6 ranges, disabling automatic redirects, and revalidating each redirect target. Added focused regression coverage for blocked IPv4/IPv6 addresses, private DNS results, private redirect targets, and non-HTTPS URLs. Verification: npm test -- --runInBand __tests__/webhookDelivery.ssrf.test.js (11 passed).\n\nCloses #769