### PR TITLE
feat(monitor): resume payment streams from durable cursors

### DIFF
--- a/backend/__tests__/paymentMonitor.test.js
+++ b/backend/__tests__/paymentMonitor.test.js
@@ -1,0 +1,100 @@
+/**
+ * __tests__/paymentMonitor.test.js (#773)
+ * Verifies durable-cursor resume and replay de-duplication.
+ */
+
+"use strict";
+
+var streamOptions = null;
+var lastCursorArg = null;
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const stream = jest.fn((opts) => {
+    streamOptions = opts;
+    return jest.fn();
+  });
+  const cursor = jest.fn((arg) => {
+    lastCursorArg = arg;
+    return { stream };
+  });
+  const forAccount = jest.fn(() => ({ cursor }));
+  const payments = jest.fn(() => ({ forAccount }));
+  return { Horizon: { Server: jest.fn(() => ({ payments })) } };
+});
+
+jest.mock("../src/services/webhookStore", () => ({
+  getWebhooksByPublicKey: jest.fn().mockReturnValue([]),
+  getAllWebhooks: jest.fn().mockReturnValue([]),
+}));
+jest.mock("../src/services/webhookDelivery", () => ({
+  deliverWebhook: jest.fn(),
+}));
+jest.mock("../src/services/cursorStore", () => ({
+  get: jest.fn().mockReturnValue("now"),
+  set: jest.fn(),
+}));
+
+const { Horizon } = require("@stellar/stellar-sdk");
+const { startMonitoring } = require("../src/services/paymentMonitor");
+const { getWebhooksByPublicKey } = require("../src/services/webhookStore");
+const { deliverWebhook } = require("../src/services/webhookDelivery");
+const cursorStore = require("../src/services/cursorStore");
+
+const PUBLIC_KEY = "GA0000000000000000000000000000000000000000000000000000";
+
+function payment(over = {}) {
+  return {
+    type: "payment",
+    to: PUBLIC_KEY,
+    amount: "10.0000000",
+    asset_type: "native",
+    from: "GBFROM0000000000000000000000000000000000000000000000000000",
+    transaction_hash: "txhash",
+    ledger_attr: 123,
+    created_at: new Date().toISOString(),
+    paging_token: "003212345678",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  streamOptions = null;
+  lastCursorArg = null;
+  cursorStore.get.mockReturnValue("now");
+  getWebhooksByPublicKey.mockReturnValue([{ id: "w1", publicKey: PUBLIC_KEY }]);
+});
+
+describe("paymentMonitor durable cursor (#773)", () => {
+  it("resumes from a persisted cursor instead of always 'now'", () => {
+    cursorStore.get.mockReturnValue("003100000000");
+    startMonitoring(PUBLIC_KEY);
+    expect(lastCursorArg).toBe("003100000000");
+  });
+
+  it("falls back to 'now' when no cursor has been persisted", () => {
+    startMonitoring(PUBLIC_KEY);
+    expect(lastCursorArg).toBe("now");
+  });
+
+  it("advances the durable cursor after handling a payment", async () => {
+    startMonitoring(PUBLIC_KEY);
+    await streamOptions.onmessage(payment({ paging_token: "p1" }));
+    expect(cursorStore.set).toHaveBeenCalledWith(PUBLIC_KEY, "p1");
+  });
+
+  it("skips a payment replayed at the last persisted cursor", async () => {
+    cursorStore.get.mockReturnValue("p1");
+    startMonitoring(PUBLIC_KEY);
+    await streamOptions.onmessage(payment({ paging_token: "p1" }));
+    expect(getWebhooksByPublicKey).not.toHaveBeenCalled();
+    expect(deliverWebhook).not.toHaveBeenCalled();
+  });
+
+  it("de-duplicates repeated paging tokens within one stream", async () => {
+    startMonitoring(PUBLIC_KEY);
+    await streamOptions.onmessage(payment({ paging_token: "p2" }));
+    await streamOptions.onmessage(payment({ paging_token: "p2" }));
+    expect(deliverWebhook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/cursorStore.js
+++ b/backend/src/services/cursorStore.js
@@ -1,0 +1,62 @@
+/**
+ * src/services/cursorStore.js
+ * Durable per-account cursor store for the payment monitor.
+ *
+ * Persists the last handled Horizon paging token per public key so streams can
+ * resume inclusively after process restarts or reconnects instead of always
+ * starting from "now" (which silently drops payments during downtime).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const logger = require("../utils/logger");
+
+const CURSOR_FILE =
+  process.env.PAYMENT_MONITOR_CURSOR_FILE ||
+  path.join(process.cwd(), "data", "payment-monitor-cursors.json");
+
+/** @type {Record<string, string> | null} */
+let cache = null;
+
+function load() {
+  if (cache) return cache;
+  try {
+    cache = JSON.parse(fs.readFileSync(CURSOR_FILE, "utf8"));
+    if (typeof cache !== "object" || cache === null) cache = {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+/**
+ * Return the last handled paging token for an account, or "now" if none.
+ * @param {string} publicKey
+ * @returns {string}
+ */
+function get(publicKey) {
+  return load()[publicKey] || "now";
+}
+
+/**
+ * Persist the latest handled paging token for an account.
+ * Never rewrites the file if the value is unchanged.
+ * @param {string} publicKey
+ * @param {string} pagingToken
+ */
+function set(publicKey, pagingToken) {
+  const store = load();
+  if (store[publicKey] === pagingToken) return;
+  store[publicKey] = pagingToken;
+  cache = store;
+  try {
+    fs.mkdirSync(path.dirname(CURSOR_FILE), { recursive: true });
+    fs.writeFileSync(CURSOR_FILE, JSON.stringify(store));
+  } catch (err) {
+    logger.warn({ err, publicKey }, "[cursorStore] failed to persist cursor");
+  }
+}
+
+module.exports = { get, set };

--- a/backend/src/services/paymentMonitor.js
+++ b/backend/src/services/paymentMonitor.js
@@ -10,6 +10,7 @@ const { Horizon } = require("@stellar/stellar-sdk");
 const logger = require("../utils/logger");
 const { getWebhooksByPublicKey, getAllWebhooks } = require("./webhookStore");
 const { deliverWebhook } = require("./webhookDelivery");
+const cursorStore = require("./cursorStore");
 
 const HORIZON_URL =
   process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -24,6 +25,13 @@ const horizonServer = new Horizon.Server(HORIZON_URL);
 const activeStreams = new Map();
 
 /**
+ * Recently-handled paging tokens per public key, used to de-duplicate rows
+ * replayed by an inclusive resume after a reconnect or restart.
+ * @type {Map<string, Set<string>>}
+ */
+const seenTokens = new Map();
+
+/**
  * Start monitoring a Stellar account for incoming payments.
  * If a stream is already active for this key, this is a no-op.
  *
@@ -36,14 +44,31 @@ function startMonitoring(publicKey) {
 
   logger.info({ publicKey }, "[monitor] starting SSE stream");
 
+  // Resume from the last persisted paging token so payments processed during
+  // downtime or a reconnect gap are not missed. Falls back to "now" only when
+  // no cursor has been persisted yet.
+  const resumeCursor = cursorStore.get(publicKey);
+
   const closeStream = horizonServer
     .payments()
     .forAccount(publicKey)
-    .cursor("now")
+    .cursor(resumeCursor)
     .stream({
       onmessage: async (record) => {
         // Only handle incoming simple payments to this account
         if (record.type !== "payment" || record.to !== publicKey) return;
+
+        // Deduplicate rows replayed by an inclusive resume.
+        let seen = seenTokens.get(publicKey) || new Set();
+        if (
+          seen.has(record.paging_token) ||
+          record.paging_token === cursorStore.get(publicKey)
+        ) {
+          return;
+        }
+        if (seen.size > 500) seen = new Set([record.paging_token]);
+        seen.add(record.paging_token);
+        seenTokens.set(publicKey, seen);
 
         const asset =
           record.asset_type === "native"
@@ -63,10 +88,14 @@ function startMonitoring(publicKey) {
         };
 
         const hooks = getWebhooksByPublicKey(publicKey);
-        if (hooks.length === 0) return;
+        if (hooks.length > 0) {
+          // Parallel delivery — one failed hook must not block others
+          await Promise.allSettled(hooks.map((hook) => deliverWebhook(hook, payload)));
+        }
 
-        // Parallel delivery — one failed hook must not block others
-        await Promise.allSettled(hooks.map((hook) => deliverWebhook(hook, payload)));
+        // Advance the durable cursor even when no webhook is registered, so a
+        // payment with no endpoint is not reprocessed on the next reconnect.
+        cursorStore.set(publicKey, record.paging_token);
       },
 
       onerror: (err) => {
@@ -76,6 +105,7 @@ function startMonitoring(publicKey) {
         );
         // Remove the dead stream so ensureMonitored can restart it next time
         activeStreams.delete(publicKey);
+        seenTokens.delete(publicKey);
       },
     });
 


### PR DESCRIPTION
Closes #773

## Summary
Makes Horizon payment streams resume from a persisted paging token instead of always starting at `now`, so payments processed while the process was down (or during a reconnect gap) are no longer missed.

## Changes
- `backend/src/services/cursorStore.js` (new)
  - Durable per-account cursor store backed by a JSON file (`data/payment-monitor-cursors.json`, overridable via `PAYMENT_MONITOR_CURSOR_FILE`).
- `backend/src/services/paymentMonitor.js`
  - Streams now start from the last persisted paging token (falling back to `now` only when none exists).
  - The durable cursor is advanced after each handled payment, including when no webhook is registered.
  - Replayed rows from an inclusive resume are de-duplicated by paging token, and the recently-seen set is bounded.
- `backend/__tests__/paymentMonitor.test.js` (new)
  - Covers resume-from-persisted-cursor, fallback to `now`, cursor advancement, and replay de-duplication.

## Validation
- Run `npm test` in `backend` to execute the new `paymentMonitor` test.
- I could not run the suite here (no network/deps), so please confirm in CI.