### PR TITLE
fix: resolve workflow merge conflict and input type bug

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,7 +61,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-<<<<<<< HEAD
+          build-args: |
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+            SENTRY_RELEASE=${{ github.sha }}
 
   smoke-test:
     name: Staging smoke tests
@@ -140,10 +144,3 @@ jobs:
               body: `## Automatic Rollback Triggered\n\nCommit: ${context.sha}\nWorkflow: ${context.workflow}\nRun: ${context.runId}\n\nSmoke tests failed after deployment. The staging environment has been rolled back to the previous stable image.\n\n### Rollback Criteria\n- Health endpoint non-responsive\n- API documentation unreachable\n- Security headers missing\n- Network isolation violation\n\nPlease investigate before re-deploying.`,
               labels: ["incident", "rollback", "staging"]
             });
-=======
-          build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
-            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
-            SENTRY_RELEASE=${{ github.sha }}
->>>>>>> 1d46ec1 (fix:  perf, observ and refactor)

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,7 +11,7 @@ on:
       update_snapshots:
         description: "Update baseline screenshots"
         required: true
-        default: false
+        default: "false"
         type: boolean
 
 jobs:


### PR DESCRIPTION

Went through all 13 workflow files and found two issues.

deploy-staging.yml had unresolved git conflict markers left over from
commit 1d46ec1. This would break every push to develop since GitHub
Actions can't parse a YAML file with <<< >>> in it. Fixed by properly
merging both sides, also kept the Sentry build-args and the smoke-test /
rollback jobs.

visual-regression.yml had a bare boolean false as the default for the
update_snapshots dispatch input. GitHub expects a string there, so
changed it to "false".

Everything else looked fine.


Closes #719 