### PR TITLE
 test: Isolate tipsService state between Jest tests

### DIFF
--- a/backend/__tests__/tipsService.test.js
+++ b/backend/__tests__/tipsService.test.js
@@ -17,10 +17,8 @@ const KEY_E = "G" + "E".repeat(55); // 56 chars
 
 describe("tipsService", () => {
   beforeEach(() => {
-    // Clear in-memory storage before each test
-    tipsService.tipsByCreator?.clear?.();
-    // Reset tip ID counter
-    tipsService.tipIdCounter = 1;
+    // Clear in-memory storage and counter before each test
+    tipsService._resetState();
   });
 
   describe("recordTip", () => {

--- a/backend/src/services/tipsService.js
+++ b/backend/src/services/tipsService.js
@@ -242,6 +242,14 @@ function getTopTippers(creatorPublicKey, limit = 5) {
   return result;
 }
 
+/**
+ * Resets the in-memory storage (for testing).
+ */
+function _resetState() {
+  tipsByCreator.clear();
+  tipIdCounter = 1;
+}
+
 module.exports = {
   recordTip,
   getTipsReceived,
@@ -250,4 +258,5 @@ module.exports = {
   validateTipInput,
   getTopTippers,
   tipsByCreator,
+  _resetState,
 };


### PR DESCRIPTION
Closes #725 

Fixes the issue where module-level tips map and id counter leak records between tests, producing order-dependent totals.

### Changes Made:
- Added a `_resetState` function to `tipsService.js` that clears the internal `tipsByCreator` map and resets the `tipIdCounter`.
- Updated the `beforeEach` block in `tipsService.test.js` to call this new reset hook, ensuring complete state isolation for randomized test execution without leakage.