### PR TITLE
Feature/locale lang dir accessibility

### DIFF
--- a/frontend/__tests__/I18nContext.test.tsx
+++ b/frontend/__tests__/I18nContext.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * __tests__/I18nContext.test.tsx
+ * Tests for I18nProvider locale state, persistence, and <html lang/dir> sync.
+ */
+
+import React from "react";
+
+import { render, screen, act, waitFor } from "@testing-library/react";
+
+import { I18nProvider, useI18n } from "../contexts/I18nContext";
+import * as i18n from "../lib/i18n";
+
+// Override only isRTL so the dir=rtl code path can be exercised (no supported
+// locale is natively RTL). All other helpers stay real.
+jest.mock("../lib/i18n", () => {
+  const actual = { ...jest.requireActual("../lib/i18n") };
+  return {
+    ...actual,
+    isRTL: jest.fn((locale: string) => locale === "es"),
+  };
+});
+
+const mockedIsRTL = i18n.isRTL as jest.Mock;
+
+function Probe() {
+  const { locale, setLocale } = useI18n();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <button onClick={() => setLocale("es")}>to es</button>
+      <button onClick={() => setLocale("en")}>to en</button>
+      <button onClick={() => setLocale("fr" as never)}>to unsupported</button>
+    </div>
+  );
+}
+
+describe("I18nProvider", () => {
+  beforeEach(() => {
+    mockedIsRTL.mockImplementation((locale: string) => locale === "es");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("lang");
+    document.documentElement.removeAttribute("dir");
+    jest.clearAllMocks();
+  });
+
+  it("stamps the default locale onto <html> after mount", async () => {
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+    expect(document.documentElement.lang).toBe("en");
+    expect(document.documentElement.dir).toBe("ltr");
+  });
+
+  it("restores the stored locale on mount and syncs <html>", async () => {
+    localStorage.setItem("stellar-micropay:locale", "es");
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("es"));
+    expect(document.documentElement.lang).toBe("es");
+    expect(document.documentElement.dir).toBe("rtl");
+  });
+
+  it("updates localStorage and <html lang/dir> on locale change", async () => {
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+
+    act(() => {
+      screen.getByText("to es").click();
+    });
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("es"));
+    expect(localStorage.getItem("stellar-micropay:locale")).toBe("es");
+    expect(document.documentElement.lang).toBe("es");
+    expect(document.documentElement.dir).toBe("rtl");
+
+    act(() => {
+      screen.getByText("to en").click();
+    });
+    await waitFor(() => expect(document.documentElement.dir).toBe("ltr"));
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("rejects unsupported locales without mutating state, storage, or <html>", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId("locale")).toHaveTextContent("en"));
+
+    act(() => {
+      screen.getByText("to unsupported").click();
+    });
+
+    expect(screen.getByTestId("locale")).toHaveTextContent("en");
+    expect(localStorage.getItem("stellar-micropay:locale")).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("Unsupported locale: fr");
+    warnSpy.mockRestore();
+  });
+});

--- a/frontend/__tests__/Navbar.test.tsx
+++ b/frontend/__tests__/Navbar.test.tsx
@@ -1,5 +1,167 @@
-import Navbar from '.../components/Navbar';
+/**
+ * __tests__/Navbar.test.tsx
+ * Language selector accessibility: native labels, localized aria-label, selection.
+ */
 
-test 'Navbar exists', () => {
-  expect(Navbar).toBeDefined();
+import React from "react";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    pathname: "/",
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    query: {},
+  }),
+}));
+
+jest.mock("next/link", () => {
+  const Link = ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+jest.mock("@/lib/stellar", () => ({
+  getNetworkConfig: jest.fn(() => ({
+    network: "testnet",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+  })),
+  fetchNetworkFeeStats: jest.fn(() =>
+    Promise.resolve({ baseFeeXlm: 0.00001, feeLevel: "normal" })
+  ),
+  shortenAddress: jest.fn(() => "GA...ABCD"),
+}));
+
+jest.mock("@/lib/wallet", () => ({
+  connectWallet: jest.fn(),
+  performSEP0010Auth: jest.fn(() => Promise.resolve({ error: null })),
+}));
+
+jest.mock("@/lib/useWallet", () => ({
+  useWallet: () => ({
+    publicKey: null,
+    connectWallet: jest.fn(),
+    disconnectWallet: jest.fn(),
+    xlmBalance: "0.0000000",
+    usdcBalance: null,
+  }),
+}));
+
+jest.mock("@/pages/_app", () => ({
+  useTheme: () => ({ theme: "dark", toggleTheme: jest.fn() }),
+}));
+
+const mockUseI18n = jest.fn();
+
+jest.mock("@/contexts/I18nContext", () => ({
+  useI18n: () => mockUseI18n(),
+}));
+
+const mockSetLocale = jest.fn();
+
+function buildT(callValue: string, selectLanguage: string) {
+  const t = jest.fn(() => callValue) as unknown as {
+    (): string;
+    nav: Record<string, string>;
+    common: Record<string, string>;
+    dashboard: Record<string, string>;
+  };
+  t.nav = {
+    home: callValue,
+    dashboard: callValue,
+    trade: callValue,
+    transactions: callValue,
+    network: callValue,
+    settings: callValue,
+    connectWallet: callValue,
+    disconnect: callValue,
+    disconnectConfirm: callValue,
+    confirm: callValue,
+    cancel: callValue,
+  };
+  t.common = {
+    loading: callValue,
+    error: callValue,
+    success: callValue,
+    copy: callValue,
+    copied: callValue,
+    selectLanguage,
+  };
+  t.dashboard = {
+    title: callValue,
+    balance: callValue,
+    available: callValue,
+    reserved: callValue,
+    send: callValue,
+    receive: callValue,
+    recentActivity: callValue,
+    paymentStats: callValue,
+    totalSent: callValue,
+    totalReceived: callValue,
+    transactionCount: callValue,
+  };
+  return t;
+}
+
+mockUseI18n.mockReturnValue({
+  locale: "en",
+  setLocale: mockSetLocale,
+  t: buildT("Home", "Select language"),
+  isRTL: false,
+  supportedLocales: ["en", "es"],
+});
+
+import Navbar from "@/components/Navbar";
+
+describe("Navbar language selector", () => {
+  beforeEach(() => {
+    mockSetLocale.mockClear();
+    mockUseI18n.mockClear();
+    mockUseI18n.mockReturnValue({
+      locale: "en",
+      setLocale: mockSetLocale,
+      t: buildT("Home", "Select language"),
+      isRTL: false,
+      supportedLocales: ["en", "es"],
+    });
+  });
+
+  it("lists languages by their native names", () => {
+    render(<Navbar />);
+
+    const select = screen.getByRole("combobox", { name: "Select language" });
+    const options = within(select).getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["English", "Español"]);
+    expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual(["en", "es"]);
+  });
+
+  it("calls setLocale with the selected locale", async () => {
+    const user = userEvent.setup();
+    render(<Navbar />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Select language" }),
+      "es"
+    );
+
+    expect(mockSetLocale).toHaveBeenCalledWith("es");
+  });
+
+  it("localizes the accessible label from current translations", () => {
+    mockUseI18n.mockReturnValue({
+      locale: "es",
+      setLocale: mockSetLocale,
+      t: buildT("Inicio", "Seleccionar idioma"),
+      isRTL: false,
+      supportedLocales: ["en", "es"],
+    });
+
+    render(<Navbar />);
+    expect(screen.getByRole("combobox", { name: "Seleccionar idioma" })).toBeInTheDocument();
+  });
 });

--- a/frontend/__tests__/i18n.test.ts
+++ b/frontend/__tests__/i18n.test.ts
@@ -1,0 +1,74 @@
+/**
+ * __tests__/i18n.test.ts
+ * Unit tests for i18n helpers: native display names, RTL detection, persistence.
+ */
+
+import {
+  DEFAULT_LOCALE,
+  RTL_LOCALES,
+  SUPPORTED_LOCALES,
+  getLocaleDisplayName,
+  getTranslations,
+  getStoredLocale,
+  isRTL,
+  setStoredLocale,
+} from "../lib/i18n";
+
+const ORIGINAL_WINDOW = globalThis.window;
+
+describe("i18n helpers", () => {
+  afterEach(() => {
+    localStorage.clear();
+    globalThis.window = ORIGINAL_WINDOW;
+  });
+
+  describe("getLocaleDisplayName", () => {
+    it("returns native language names, not translated equivalents", () => {
+      expect(getLocaleDisplayName("en")).toBe("English");
+      expect(getLocaleDisplayName("es")).toBe("Español");
+    });
+  });
+
+  describe("RTL support", () => {
+    it("treats all supported locales as LTR", () => {
+      for (const locale of SUPPORTED_LOCALES) {
+        expect(isRTL(locale)).toBe(false);
+      }
+    });
+
+    it("lists known RTL scripts in the canonical RTL_LOCALES list", () => {
+      expect(RTL_LOCALES).toContain("ar");
+      expect(RTL_LOCALES).toContain("he");
+    });
+
+    it("returns false for unknown locales", () => {
+      expect(isRTL("fr" as never)).toBe(false);
+    });
+  });
+
+  describe("locale persistence", () => {
+    it("round-trips a persisted locale through localStorage", () => {
+      setStoredLocale("es");
+      expect(getStoredLocale()).toBe("es");
+    });
+
+    it("falls back to the default when nothing is stored or the value is invalid", () => {
+      expect(getStoredLocale()).toBe(DEFAULT_LOCALE);
+      localStorage.setItem("stellar-micropay:locale", "fr");
+      expect(getStoredLocale()).toBe(DEFAULT_LOCALE);
+    });
+
+    it("falls back when window is undefined (SSR path)", () => {
+      globalThis.window = undefined as unknown as Window & typeof globalThis;
+      expect(getStoredLocale()).toBe(DEFAULT_LOCALE);
+      expect(() => setStoredLocale("es")).not.toThrow();
+    });
+  });
+
+  describe("getTranslations", () => {
+    it("returns locale-appropriate selectLanguage copy", () => {
+      expect(getTranslations("en").common.selectLanguage).toBe("Select language");
+      expect(getTranslations("es").common.selectLanguage).toBe("Seleccionar idioma");
+    });
+  });
+});

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -3,24 +3,28 @@
  * Top navigation bar with theme toggle, network status, and wallet controls.
  */
 
+import { useEffect, useState } from "react";
+
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+
 import clsx from "clsx";
+
+import { NavStarIcon, MoonIcon, SunIcon } from "@/components/icons";
+import { useI18n } from "@/contexts/I18nContext";
+import { getLocaleDisplayName, type Locale } from "@/lib/i18n";
 import {
   shortenAddress,
   getNetworkConfig,
   fetchNetworkFeeStats,
   type FeeLevel,
 } from "@/lib/stellar";
+import { useWallet } from "@/lib/useWallet";
 import {
   connectWallet as requestWalletConnection,
   performSEP0010Auth,
 } from "@/lib/wallet";
-import { useWallet } from "@/lib/useWallet";
 import { useTheme } from "@/pages/_app";
-import { useI18n } from "@/contexts/I18nContext";
-import { NavStarIcon, MoonIcon, SunIcon } from "@/components/icons";
 
 
 export default function Navbar() {
@@ -214,13 +218,13 @@ export default function Navbar() {
           <div className="relative">
             <select
               value={locale}
-              onChange={(e) => setLocale(e.target.value as any)}
+              onChange={(e) => setLocale(e.target.value as Locale)}
               className="h-9 rounded-lg border border-slate-300/30 bg-white/90 px-3 py-1 text-sm font-medium text-slate-700 shadow-sm transition-all duration-200 hover:bg-slate-100 dark:border-slate-700/50 dark:bg-cosmos-800/80 dark:text-slate-100 dark:hover:bg-cosmos-700/90"
-              aria-label="Select language"
+              aria-label={t.common.selectLanguage}
             >
               {supportedLocales.map((loc) => (
                 <option key={loc} value={loc}>
-                  {loc.toUpperCase()}
+                  {getLocaleDisplayName(loc)}
                 </option>
               ))}
             </select>

--- a/frontend/contexts/I18nContext.tsx
+++ b/frontend/contexts/I18nContext.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
 import {
   Locale,
   DEFAULT_LOCALE,
@@ -82,18 +83,13 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       console.warn(`Unsupported locale: ${newLocale}`);
       return;
     }
-    
+
     setLocaleState(newLocale);
     setStoredLocale(newLocale);
-    
-    // Update document direction for RTP support
-    if (typeof document !== 'undefined') {
-      document.documentElement.dir = isRTL(newLocale) ? 'rtl' : 'ltr';
-      document.documentElement.lang = newLocale;
-    }
   };
 
-  // Set initial document direction
+  // Keep <html lang>/<html dir> in sync with the active locale after hydration.
+  // Pre-hydration values are applied by public/locale-init.js to avoid a flash.
   useEffect(() => {
     if (isClient && typeof document !== 'undefined') {
       document.documentElement.dir = isRTL(locale) ? 'rtl' : 'ltr';

--- a/frontend/e2e/locale.spec.ts
+++ b/frontend/e2e/locale.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+// Mock Freighter so no browser extension is needed
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as any).freighter = {
+      isConnected: async () => ({ isConnected: false }),
+      getAddress: async () => ({ address: '' }),
+      getPublicKey: async () => ({ publicKey: '' }),
+      signTransaction: async () => ({ signedTxXdr: '' }),
+      requestAccess: async () => ({}),
+      isAllowed: async () => ({ isAllowed: false }),
+    };
+  });
+});
+
+const htmlLang = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => document.documentElement.lang);
+const htmlDir = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => document.documentElement.dir);
+
+test('lang/dir match the stored locale before and after a reload', async ({ page }) => {
+  // Preset a stored locale before any page script runs (pre-hydration path).
+  await page.addInitScript(() => {
+    localStorage.setItem('stellar-micropay:locale', 'es');
+  });
+
+  await page.goto('/');
+
+  await expect.poll(() => htmlLang(page)).toBe('es');
+  await expect.poll(() => htmlDir(page)).toBe('ltr');
+
+  // No flash/mismatch across a full reload: init script re-applies before hydration.
+  await page.reload();
+  await expect.poll(() => htmlLang(page)).toBe('es');
+  await expect.poll(() => htmlDir(page)).toBe('ltr');
+});
+
+test('switching locale in the navbar updates lang/dir and persists', async ({ page }) => {
+  await page.goto('/');
+
+  const select = page.getByRole('combobox', { name: 'Select language' });
+  await select.selectOption('es');
+
+  await expect.poll(() => htmlLang(page)).toBe('es');
+  await expect.poll(() => htmlDir(page)).toBe('ltr');
+
+  await page.reload();
+  await expect.poll(() => htmlLang(page)).toBe('es');
+});
+
+test('language selector shows native language names', async ({ page }) => {
+  await page.goto('/');
+
+  const select = page.getByRole('combobox', { name: 'Select language' });
+  await expect(select.locator('option')).toHaveCount(2);
+  await expect(select.locator('option')).toHaveText(['English', 'Español']);
+});

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -9,6 +9,13 @@ export type Locale = 'en' | 'es';
 export const DEFAULT_LOCALE: Locale = 'en';
 export const SUPPORTED_LOCALES: Locale[] = ['en', 'es'];
 
+/**
+ * Locales that should render right-to-left.
+ * All currently supported locales (en, es) are LTR, but future RTL locales
+ * must be added to this list (alongside the Locale union and translations).
+ */
+export const RTL_LOCALES: readonly string[] = ['ar', 'he', 'fa', 'ur'];
+
 const LOCALE_STORAGE_KEY = 'stellar-micropay:locale';
 
 // Translation type definitions
@@ -32,6 +39,7 @@ export interface Translations {
     success: string;
     copy: string;
     copied: string;
+    selectLanguage: string;
   };
   dashboard: {
     title: string;
@@ -69,6 +77,7 @@ const en: Translations = {
     success: 'Success',
     copy: 'Copy',
     copied: 'Copied!',
+    selectLanguage: 'Select language',
   },
   dashboard: {
     title: 'Dashboard',
@@ -106,6 +115,7 @@ const es: Translations = {
     success: 'Éxito',
     copy: 'Copiar',
     copied: '¡Copiado!',
+    selectLanguage: 'Seleccionar idioma',
   },
   dashboard: {
     title: 'Panel',
@@ -174,12 +184,11 @@ export function getLocaleDisplayName(locale: Locale): string {
 }
 
 /**
- * Check if locale is RTL right-to-left)
- * Currently all supported locales are LTR, but this prepares for future RTL support
+ * Check if locale is RTL (right-to-left)
+ * The canonical RTL locale list is RTL_LOCALES; new RTL locales must be added there.
  */
 export function isRTL(locale: Locale): boolean {
-  const rtlLocales: Locale[] = [];
-  return rtlLocales.includes(locale);
+  return RTL_LOCALES.includes(locale);
 }
 
 // Re-export the canonical translation hook from the I18n context

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -12,6 +12,10 @@ export default function Document() {
         {/* Prevent theme flash on page load (#217) without requiring inline script CSP allowances. */}
         <script src="/theme-init.js" />
 
+        {/* Prevent stored-locale lang/dir flash on page load; the active locale is
+            read back in I18nContext after hydration to keep the document in sync. */}
+        <script src="/locale-init.js" />
+
         {/* PWA Manifest */}
         <link rel="manifest" href="/manifest.json" />
 

--- a/frontend/public/locale-init.js
+++ b/frontend/public/locale-init.js
@@ -1,0 +1,15 @@
+(function () {
+  try {
+    // Keep in sync with RTL_LOCALES in lib/i18n.ts.
+    var rtlLocales = ["ar", "he", "fa", "ur"];
+
+    var saved = localStorage.getItem("stellar-micropay:locale");
+    var locale = saved === "es" || saved === "en" ? saved : "en";
+
+    // Apply lang/dir before React hydrates so stored locales don't flash.
+    document.documentElement.lang = locale;
+    document.documentElement.dir = rtlLocales.indexOf(locale) !== -1 ? "rtl" : "ltr";
+  } catch (e) {
+    // Ignore storage failures and leave the build-time defaults in place.
+  }
+})();


### PR DESCRIPTION
## Summary

Fixes the locale accessibility gap: changing the language now keeps the document `<html lang>` and `<html dir>` attributes in sync (before *and* after hydration), and the language selector presents each language's native name with a localized, accessible label. This closes the Flash-of-Unstyled-Language / lang-dir-mismatch on page load when a stored locale isn't the default.

Closes #836

## Type of change

- [x] New feature (accessibility improvement)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Smart contract change

## Related context

- `tailwind.config.ts` RTL/LTR audit note for Issue #642
- `theme-init.js` pre-hydration theme script (#217) — the pattern this change mirrors

## Changes

**`frontend/lib/i18n.ts`**
- Added a canonical `RTL_LOCALES` list (`ar`, `he`, `fa`, `ur`); `isRTL()` now derives from it instead of an inline placeholder. Future RTL locales get added in one place.
- Added `Translations.common.selectLanguage` (EN: "Select language", ES: "Seleccionar idioma").
- `getLocaleDisplayName()` remains the single source of native language names (`English`, `Español`).

**`frontend/public/locale-init.js`** (new)
- Mirrors `theme-init.js`: applies `<html lang/dir>` from `localStorage` **synchronously before React hydrates**, eliminating the wrong-`lang`/missing-`dir` flash for users with a stored non-default locale. (External file, not inline, to stay within the `script-src 'self'` CSP.)

**`frontend/pages/_document.tsx`**
- Loads `locale-init.js` next to `theme-init.js`. `lang="en"` remains the static-export build-time default (app is `output: "export"` — no runtime server), and the init script + context converge on the user's stored locale client-side.

**`frontend/contexts/I18nContext.tsx`**
- Consolidated `documentElement.lang/dir` handling into a single post-hydration effect (removed the duplicate mutation inside `setLocale`). Pre-hydration values come from `locale-init.js`; the effect keeps them in sync afterward.

**`frontend/components/Navbar.tsx`**
- Language selector options now render native names via `getLocaleDisplayName()` instead of uppercased codes (`EN`/`ES` → `English`/`Español`).
- `onChange` is typed as `Locale` (dropped `as any`).
- The selector's `aria-label` is localized through `t.common.selectLanguage`.

**`frontend/.eslintrc.json`**
- Repaired the broken `import/order` config: removed the invalid `alphabeticalOrder`/`caseInsensitive` options (not in `eslint-plugin-import@2.32` schema) in favor of `alphabetize`. Lint could not run at all (repo-wide) before this fix.

## Testing

- [x] Added/updated unit tests:
  - `frontend/__tests__/i18n.test.ts` — native display names, RTL list, persistence round-trip (incl. SSR path), `selectLanguage` copy
  - `frontend/__tests__/I18nContext.test.tsx` — `<html lang/dir>` stamped on mount, restores stored locale, updates on locale change, rejects unsupported locales
  - `frontend/__tests__/Navbar.test.tsx` — native option labels, selection calls `setLocale`, localized accessible label
  - **15/15 new tests passing**
- [ ] Tested locally on Testnet — **blocked** (see Notes)
- [ ] Manually tested UI flow — pending; e2e spec added:
  - `frontend/e2e/locale.spec.ts` — presets a stored locale pre-navigation, asserts `documentElement.lang/dir` immediately and again after a full reload (no flash/mismatch), and verifies native names + persistence after switching in the selector

### Validation results

| Check | Result |
| --- | --- |
| `npm test` (new suites) | 15/15 passing |
| ESLint (touched files) | 0 errors (3 pre-existing warnings) |
| `tsc --noEmit` | No new errors introduced; repo has pre-existing type errors |
| `next build` | Blocked by pre-existing failures, not this change |

## Screenshots

None required — no visual/layout change; this only affects the document attributes and selector labels.

## Notes for reviewers

- `npm run type-check` and `npm run build` are **already red on `main`** (pre-existing: callable-`t()` type errors in `Navbar`/`SendPaymentForm`/`dashboard`, missing helpers in `lib/stellar.ts`, a broken `__tests__/resolveStellarName.test.ts` import, e2e fixture types). This PR adds **zero** new type errors; the 16 `Navbar` `t(...)` errors are line-shifted only.
- The full jest suite has pre-existing failures and was not green at baseline on the dev machine (Node 22 vs pinned `20.19.5`).
- The repo's `t` API is half-migrated (used as both a function and an object); this PR deliberately used the typed object form (`t.common.selectLanguage`) to avoid compounding the broken callable form. Recommend tracking the `t()` migration as a follow-up issue.
- The `testnet/mainnet` validation note on this issue is boilerplate — network behavior is untouched; it only affects Navbar tests, which mock `getNetworkConfig` to testnet per existing convention.

## Checklist

- [x] My code follows the project style (lint-clean on touched files)
- [ ] I've updated docs if needed (no docs affected)
- [x] No console errors or warnings (selector no longer logs `as any`; `locale-init.js` is wrapped in try/catch)
- [x] I've rebased on latest `main` (branched from synced `main` = `d9728f1`)

