### PR TITLE
fix: harden contract schemas and chart accessibility

### DIFF
--- a/contracts/stellar-micropay-contract/README.md
+++ b/contracts/stellar-micropay-contract/README.md
@@ -113,7 +113,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `admin: Address` - account stored as the contract administrator.
 - **Return value**: none.
 - **Authorization requirements**: none in the current implementation; the first successful caller sets the admin.
-- **Events emitted**: `(init)` with the admin address as event data.
+- **Events emitted**: `(init)` with `(1, admin)` as event data.
 - **Error conditions**:
   - Panics with `Contract already initialized` if an admin is already stored.
 
@@ -138,7 +138,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `amount: i128` - amount to transfer and record.
 - **Return value**: none.
 - **Authorization requirements**: `from.require_auth()`.
-- **Events emitted**: `(tip, from, to)` with `amount` as event data.
+- **Events emitted**: `(tip, from, to)` with `(1, amount)` as event data.
 - **Error conditions**:
   - Panics with `Tip amount must be positive` when `amount <= 0`.
   - Propagates token contract transfer failures, including insufficient balance, missing trustline, or token authorization failures.
@@ -181,18 +181,19 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
 - **Error conditions**:
   - Panics with `Tip record not found` if no record exists for `(recipient, index)`.
 
-### `mint_receipt(env: Env, from: Address, to: Address, amount: i128, memo: Symbol) -> u32`
+### `mint_receipt(env: Env, from: Address, to: Address, amount: i128, memo: String) -> Result<u32, ContractError>`
 
 - **Parameters**:
   - `from: Address` - payer address that owns the receipt record.
   - `to: Address` - payment recipient address.
   - `amount: i128` - amount represented by the receipt.
-  - `memo: Symbol` - short receipt memo stored on-chain.
+  - `memo: String` - UTF-8 receipt memo, capped at 256 bytes.
 - **Return value**: zero-based receipt index for `from`.
 - **Authorization requirements**: `from.require_auth()`.
-- **Events emitted**: `(receipt, from)` with the receipt index as event data.
+- **Events emitted**: `(receipt, from)` with `(1, receipt_index)` as event data.
 - **Error conditions**:
   - Panics with `Receipt amount must be positive` when `amount <= 0`.
+  - Returns `ReceiptMemoTooLong` when the UTF-8 encoding exceeds 256 bytes.
 
 ### `get_receipt_count(env: Env, payer: Address) -> u32`
 
@@ -214,18 +215,35 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
 - **Error conditions**:
   - Panics with `Receipt not found` if no receipt exists for `(payer, index)`.
 
-### `create_escrow(env: Env, from: Address, to: Address, amount: i128, release_ledger: u32) -> ()`
+### `get_legacy_receipt(env: Env, payer: Address, index: u32) -> LegacyReceiptMetadata`
+
+Reads a receipt written through storage schema v3, preserving its original
+`Symbol` memo. New UTF-8 receipts are read through `get_receipt` instead.
+
+### `create_escrow(env: Env, token_address: Address, from: Address, to: Address, amount: i128, release_ledger: u32) -> u32`
 
 - **Parameters**:
-  - `from: Address` - intended escrow funder.
-  - `to: Address` - intended escrow beneficiary.
-  - `amount: i128` - intended escrow amount.
-  - `release_ledger: u32` - intended release ledger.
-- **Return value**: none.
-- **Authorization requirements**: none in the current stub.
-- **Events emitted**: none.
+  - `token_address: Address` - token contract whose funds are locked.
+  - `from: Address` - escrow funder.
+  - `to: Address` - escrow beneficiary.
+  - `amount: i128` - amount locked by the escrow.
+  - `release_ledger: u32` - first ledger at which the beneficiary may claim.
+- **Return value**: zero-based escrow id.
+- **Authorization requirements**: `from.require_auth()`.
+- **Events emitted**: `(escrow_create, escrow_id)` with `(1, from, to, amount, release_ledger)` as event data.
 - **Error conditions**:
-  - Always panics with `Escrow payments coming in v2.1 — see ROADMAP.md`.
+  - Panics when the amount is not positive or the release ledger is not in the future.
+
+### Escrow release boundary
+
+The boundary is inclusive for claims and exclusive for cancellations:
+
+- `claim_escrow` returns `EscrowClaimTooEarly` through `release_ledger - 1` and is valid at `release_ledger` and later.
+- `cancel_escrow` is valid through `release_ledger - 1` and returns `EscrowCancelTooLate` at `release_ledger` and later.
+
+Therefore claim and cancel are never both valid in the same ledger. These
+semantics are identical on testnet and mainnet because they use the current
+ledger sequence, not wall-clock time.
 
 ### `batch_send(env: Env, token_address: Address, from: Address, recipients: Vec<Address>, amounts: Vec<i128>) -> ()`
 
@@ -253,7 +271,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `deposit: i128` - amount locked in the contract up front.
 - **Return value**: zero-based stream id.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_open, stream_id)` with `(payer, recipients, weights, rate_per_ledger, deposit)`.
+- **Events emitted**: `(stream_open, stream_id)` with `(1, payer, recipients, weights, rate_per_ledger, deposit)`.
 - **Error conditions**:
   - Panics with `recipients and weights must have equal length` when the two lists differ in length.
   - Panics with `at least one recipient is required` when `recipients` is empty.
@@ -272,7 +290,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `recipient: Address` - one of the stream's recipients.
 - **Return value**: amount transferred to `recipient` — their weighted share of accrual minus what they have already claimed; `0` when nothing new has accrued for them since their last claim.
 - **Authorization requirements**: `recipient.require_auth()`.
-- **Events emitted**: `(stream_claim, stream_id)` with `(recipient, amount)`.
+- **Events emitted**: `(stream_claim, stream_id)` with `(1, recipient, amount)`.
 - **Error conditions**:
   - Panics with `stream not found` for an unknown id.
   - Panics with `unauthorized` when the caller is not one of the stream's recipients.
@@ -286,7 +304,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `amount: i128` - additional deposit.
 - **Return value**: none.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_topup, stream_id)` with `(payer, amount, deposited)`.
+- **Events emitted**: `(stream_topup, stream_id)` with `(1, payer, amount, deposited)`.
 - **Error conditions**: `stream not found`, `unauthorized`, `stream is closed`, or `amount must be positive`.
 
 ### `pause_stream(env: Env, stream_id: u32, payer: Address) -> ()`
@@ -296,7 +314,7 @@ All amounts are `i128` stroop-denominated values unless a caller explicitly pass
   - `payer: Address` - the stream's payer.
 - **Return value**: none.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_pause, stream_id)` with `(payer, paused_at_ledger)`.
+- **Events emitted**: `(stream_pause, stream_id)` with `(1, payer, paused_at_ledger)`.
 - **Error conditions**: `stream not found`, `unauthorized`, `stream is closed`, or `stream already paused`.
 
 While paused, the claimable amount stops growing. Already-accrued funds stay
@@ -310,7 +328,7 @@ balance.
   - `payer: Address` - the stream's payer.
 - **Return value**: none.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_resume, stream_id)` with `(payer, pause_length)`.
+- **Events emitted**: `(stream_resume, stream_id)` with `(1, payer, pause_length)`.
 - **Error conditions**: `stream not found`, `unauthorized`, `stream is closed`, or `stream is not paused`.
 
 Accrual resumes from the point it stopped: the pause length is added to
@@ -324,7 +342,7 @@ never back-paid.
   - `payer: Address` - the stream's payer.
 - **Return value**: none.
 - **Authorization requirements**: `payer.require_auth()`.
-- **Events emitted**: `(stream_close, stream_id)` with `(owed, refund)`, where `owed` is the combined amount paid out to all recipients during this call and `refund` is what goes back to the payer (#558).
+- **Events emitted**: `(stream_close, stream_id)` with `(1, owed, refund)`, where `owed` is the combined amount paid out to all recipients during this call and `refund` is what goes back to the payer (#558).
 - **Error conditions**: `stream not found`, `unauthorized`, or `stream is closed`.
 
 Settles everything accrued to each recipient by weight (#559) and refunds the
@@ -357,7 +375,7 @@ unstreamed remainder to the payer in the same call.
   - `admin: Address` - the stored contract administrator.
 - **Return value**: the schema version migrated to.
 - **Authorization requirements**: `admin.require_auth()`.
-- **Events emitted**: `(migrate)` with `(from_version, to_version)`.
+- **Events emitted**: `(migrate)` with `(1, from_version, to_version)`.
 - **Error conditions**:
   - Panics with `Contract not initialized` if `initialize` has not run.
   - Panics with `Unauthorized` when the caller is not the stored admin.
@@ -383,9 +401,23 @@ deployments; `migrate` advances it after an upgrade.
 | `1` | Adds `Stream`, `DataKey::Stream`, `DataKey::StreamCount` and `DataKey::SchemaVersion`. |
 | `2` | `Stream.recipient: Address` and `Stream.claimed: i128` replaced by `Stream.recipients: Vec<StreamRecipient>`, splitting payout across weighted recipients (#559). |
 | `3` | Adds `EscrowSenderCount`, `EscrowSenderIndex`, `EscrowRecipientCount`, and `EscrowRecipientIndex` for account-oriented escrow discovery (#796). |
+| `4` | Adds `ReceiptRecordV2` with a bounded UTF-8 `String` memo. Existing `ReceiptRecord` entries remain readable through `get_legacy_receipt`; new receipts append at the existing per-payer count and are stored under the v2 key (#797). |
 
 `get_schema_version()` returns `0` for any instance that has never been
 stamped, which is how a pre-versioning deployment is detected.
+
+#### v3 to v4 receipt migration
+
+Receipt owners are not globally enumerable, so v4 deliberately avoids an
+unbounded eager rewrite. After the admin upgrades the WASM and calls
+`migrate`, existing `(payer, index)` entries stay under `ReceiptRecord` and
+remain available through `get_legacy_receipt`. New receipts continue from the
+same `ReceiptCount` but are written under the appended `ReceiptRecordV2` key
+and read through `get_receipt`. Clients choose the getter based on the receipt
+creation era (or try v2, then legacy) and preserve legacy `Symbol` values
+exactly. A future archival migration may copy records off-chain and re-mint
+them only with each payer's authorization; this contract never silently
+converts or truncates a legacy memo.
 
 ### What counts as a breaking storage change
 

--- a/contracts/stellar-micropay-contract/src/benchmarks.rs
+++ b/contracts/stellar-micropay-contract/src/benchmarks.rs
@@ -15,7 +15,7 @@ extern crate std;
 #[cfg(test)]
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    token, vec, Address, Env, Symbol,
+    token, vec, Address, Env,
 };
 
 #[cfg(test)]
@@ -194,7 +194,7 @@ fn benchmark_mint_receipt() {
 
     let payer = Address::generate(&env);
     let payee = Address::generate(&env);
-    let memo = Symbol::new(&env, "Rent");
+    let memo = soroban_sdk::String::from_str(&env, "Rent");
 
     env.budget().reset_default();
     let _id = client.mint_receipt(&payer, &payee, &1_000, &memo);

--- a/contracts/stellar-micropay-contract/src/lib.rs
+++ b/contracts/stellar-micropay-contract/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, String, Symbol,
 };
 
 #[contracterror]
@@ -10,6 +10,9 @@ pub enum ContractError {
     AlreadyInitialized = 1,
     SchemaAlreadyCurrent = 2,
     SchemaDowngrade = 3,
+    EscrowClaimTooEarly = 4,
+    EscrowCancelTooLate = 5,
+    ReceiptMemoTooLong = 6,
 }
 
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 100_000;
@@ -20,7 +23,15 @@ const PERSISTENT_BUMP_AMOUNT: u32 = 500_000;
 /// Bump this whenever a stored struct (`Stream`, `Escrow`, …) or a `DataKey`
 /// variant changes shape, and add the corresponding step to the migration
 /// table in the contract README (#562).
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
+
+/// Version of every event data payload emitted by this contract. Event names
+/// and indexed topics stay stable; only the non-indexed data tuple is
+/// versioned so indexers can select the correct decoder (#798).
+pub const EVENT_SCHEMA_VERSION: u32 = 1;
+
+/// Maximum UTF-8 byte length accepted for a receipt memo (#797).
+pub const MAX_RECEIPT_MEMO_BYTES: u32 = 256;
 
 /// Smallest deposit `open_stream` accepts, in stroops (0.001 XLM against the
 /// native SAC).
@@ -55,6 +66,19 @@ pub struct ReceiptMetadata {
     pub to: Address,
     pub amount: i128,
     pub timestamp: u64,
+    pub memo: String,
+    pub ledger: u32,
+}
+
+/// Receipt layout used through storage schema v3. It remains readable via
+/// `get_legacy_receipt` while new records are written under `ReceiptRecordV2`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LegacyReceiptMetadata {
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+    pub timestamp: u64,
     pub memo: Symbol,
     pub ledger: u32,
 }
@@ -80,6 +104,9 @@ pub enum DataKey {
     EscrowRecipientCount(Address),
     /// Maps `(recipient, index)` → global escrow id (#796).
     EscrowRecipientIndex(Address, u32),
+    /// UTF-8 receipt layout introduced in storage schema v4 (#797). Appended
+    /// to preserve the encoded discriminants of every existing key variant.
+    ReceiptRecordV2(Address, u32),
 }
 
 #[contracttype]
@@ -354,7 +381,10 @@ impl MicroPayContract {
 
         // Emit an init event so off-chain indexers can detect an initialised
         // contract without polling get_admin() (#258).
-        env.events().publish((Symbol::new(&env, "init"),), admin);
+        env.events().publish(
+            (Symbol::new(&env, "init"),),
+            (EVENT_SCHEMA_VERSION, admin),
+        );
         Ok(())
     }
 
@@ -429,8 +459,10 @@ impl MicroPayContract {
 
         // Clone `from` into the event tuple so the owned binding is not moved
         // out before the borrow checker is done with it (#202).
-        env.events()
-            .publish((Symbol::new(&env, "tip"), from.clone(), to.clone()), amount);
+        env.events().publish(
+            (Symbol::new(&env, "tip"), from.clone(), to.clone()),
+            (EVENT_SCHEMA_VERSION, amount),
+        );
 
         // Interactions: external token transfer after all state is persisted.
         let token = token::Client::new(&env, &token_address);
@@ -493,10 +525,19 @@ impl MicroPayContract {
         val
     }
 
-    pub fn mint_receipt(env: Env, from: Address, to: Address, amount: i128, memo: Symbol) -> u32 {
+    pub fn mint_receipt(
+        env: Env,
+        from: Address,
+        to: Address,
+        amount: i128,
+        memo: String,
+    ) -> Result<u32, ContractError> {
         from.require_auth();
         if amount <= 0 {
             panic!("Receipt amount must be positive");
+        }
+        if memo.len() > MAX_RECEIPT_MEMO_BYTES {
+            return Err(ContractError::ReceiptMemoTooLong);
         }
         let count: u32 = env
             .storage()
@@ -515,9 +556,9 @@ impl MicroPayContract {
 
         env.storage()
             .persistent()
-            .set(&DataKey::ReceiptRecord(from.clone(), count), &receipt);
+            .set(&DataKey::ReceiptRecordV2(from.clone(), count), &receipt);
         env.storage().persistent().extend_ttl(
-            &DataKey::ReceiptRecord(from.clone(), count),
+            &DataKey::ReceiptRecordV2(from.clone(), count),
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
@@ -531,9 +572,11 @@ impl MicroPayContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        env.events()
-            .publish((Symbol::new(&env, "receipt"), from), count);
-        count
+        env.events().publish(
+            (Symbol::new(&env, "receipt"), from),
+            (EVENT_SCHEMA_VERSION, count),
+        );
+        Ok(count)
     }
 
     pub fn get_receipt_count(env: Env, payer: Address) -> u32 {
@@ -550,12 +593,30 @@ impl MicroPayContract {
     }
 
     pub fn get_receipt(env: Env, payer: Address, index: u32) -> ReceiptMetadata {
-        let key = DataKey::ReceiptRecord(payer, index);
+        let key = DataKey::ReceiptRecordV2(payer, index);
         let val: ReceiptMetadata = env
             .storage()
             .persistent()
             .get(&key)
             .expect("Receipt not found");
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        val
+    }
+
+    /// Read a receipt created before storage schema v4. Legacy Symbol memos
+    /// cannot represent arbitrary UTF-8 and are intentionally kept in their
+    /// original type rather than converted lossy on-chain (#797).
+    pub fn get_legacy_receipt(env: Env, payer: Address, index: u32) -> LegacyReceiptMetadata {
+        let key = DataKey::ReceiptRecord(payer, index);
+        let val: LegacyReceiptMetadata = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("Legacy receipt not found");
         env.storage().persistent().extend_ttl(
             &key,
             PERSISTENT_LIFETIME_THRESHOLD,
@@ -601,18 +662,21 @@ impl MicroPayContract {
 
         index_escrow_accounts(&env, &from, &to, next_id);
 
-        env.events()
-            .publish((Symbol::new(&env, "escrow_create"), next_id), (from, to, amount, release_ledger));
+        env.events().publish(
+            (Symbol::new(&env, "escrow_create"), next_id),
+            (EVENT_SCHEMA_VERSION, from, to, amount, release_ledger),
+        );
         next_id
     }
 
-    pub fn claim_escrow(env: Env, id: u32) {
+    /// Claim is valid inclusively from `release_ledger` onward (#793).
+    pub fn claim_escrow(env: Env, id: u32) -> Result<(), ContractError> {
         let mut escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(id)).expect("escrow not found");
         if escrow.status != EscrowStatus::Pending {
             panic!("escrow is not pending");
         }
         if env.ledger().sequence() < escrow.release_ledger {
-            panic!("release_ledger not reached");
+            return Err(ContractError::EscrowClaimTooEarly);
         }
         // Only the recipient can claim.
         escrow.to.require_auth();
@@ -623,21 +687,26 @@ impl MicroPayContract {
         env.storage().persistent().extend_ttl(&DataKey::Escrow(id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         let to_clone = escrow.to.clone();
-        env.events()
-            .publish((Symbol::new(&env, "escrow_claim"), id), (escrow.to, escrow.amount));
+        env.events().publish(
+            (Symbol::new(&env, "escrow_claim"), id),
+            (EVENT_SCHEMA_VERSION, escrow.to, escrow.amount),
+        );
 
         // Interactions: external token transfer after state is persisted.
         let token = token::Client::new(&env, &escrow.token);
         token.transfer(&env.current_contract_address(), &to_clone, &escrow.amount);
+        Ok(())
     }
 
-    pub fn cancel_escrow(env: Env, id: u32) {
+    /// Cancel is valid only before `release_ledger`; at the boundary claim is
+    /// the sole valid settlement operation (#793).
+    pub fn cancel_escrow(env: Env, id: u32) -> Result<(), ContractError> {
         let mut escrow: Escrow = env.storage().persistent().get(&DataKey::Escrow(id)).expect("escrow not found");
         if escrow.status != EscrowStatus::Pending {
             panic!("escrow is not pending");
         }
         if env.ledger().sequence() >= escrow.release_ledger {
-            panic!("release_ledger already reached — cancellation is no longer allowed");
+            return Err(ContractError::EscrowCancelTooLate);
         }
         // Only the creator can cancel.
         escrow.from.require_auth();
@@ -648,12 +717,15 @@ impl MicroPayContract {
         env.storage().persistent().extend_ttl(&DataKey::Escrow(id), PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         let from_clone = escrow.from.clone();
-        env.events()
-            .publish((Symbol::new(&env, "escrow_cancel"), id), (escrow.from, escrow.amount));
+        env.events().publish(
+            (Symbol::new(&env, "escrow_cancel"), id),
+            (EVENT_SCHEMA_VERSION, escrow.from, escrow.amount),
+        );
 
         // Interactions: external token transfer after state is persisted.
         let token = token::Client::new(&env, &escrow.token);
         token.transfer(&env.current_contract_address(), &from_clone, &escrow.amount);
+        Ok(())
     }
 
     pub fn get_escrow(env: Env, id: u32) -> Escrow {
@@ -874,7 +946,14 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_open"), stream_id),
-            (payer, recipients, weights, rate_per_ledger, deposit),
+            (
+                EVENT_SCHEMA_VERSION,
+                payer,
+                recipients,
+                weights,
+                rate_per_ledger,
+                deposit,
+            ),
         );
         stream_id
     }
@@ -905,8 +984,10 @@ impl MicroPayContract {
         let token = token::Client::new(&env, &stream.token);
         token.transfer(&env.current_contract_address(), &recipient, &amount);
 
-        env.events()
-            .publish((Symbol::new(&env, "stream_claim"), stream_id), (recipient, amount));
+        env.events().publish(
+            (Symbol::new(&env, "stream_claim"), stream_id),
+            (EVENT_SCHEMA_VERSION, recipient, amount),
+        );
         amount
     }
 
@@ -932,7 +1013,7 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_topup"), stream_id),
-            (payer, amount, stream.deposited),
+            (EVENT_SCHEMA_VERSION, payer, amount, stream.deposited),
         );
     }
 
@@ -957,7 +1038,7 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_pause"), stream_id),
-            (payer, stream.paused_at_ledger),
+            (EVENT_SCHEMA_VERSION, payer, stream.paused_at_ledger),
         );
     }
 
@@ -984,7 +1065,7 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "stream_resume"), stream_id),
-            (payer, pause_length),
+            (EVENT_SCHEMA_VERSION, payer, pause_length),
         );
     }
 
@@ -1031,8 +1112,10 @@ impl MicroPayContract {
             token.transfer(&contract_address, &payer, &refund);
         }
 
-        env.events()
-            .publish((Symbol::new(&env, "stream_close"), stream_id), (owed, refund));
+        env.events().publish(
+            (Symbol::new(&env, "stream_close"), stream_id),
+            (EVENT_SCHEMA_VERSION, owed, refund),
+        );
     }
 
     pub fn get_stream(env: Env, stream_id: u32) -> Stream {
@@ -1132,7 +1215,7 @@ impl MicroPayContract {
 
         env.events().publish(
             (Symbol::new(&env, "migrate"),),
-            (from_version, SCHEMA_VERSION),
+            (EVENT_SCHEMA_VERSION, from_version, SCHEMA_VERSION),
         );
         Ok(SCHEMA_VERSION)
     }
@@ -1188,7 +1271,7 @@ mod tests {
                 (
                     contract_id.clone(),
                     (Symbol::new(&env, "init"),).into_val(&env),
-                    admin.into_val(&env),
+                    (EVENT_SCHEMA_VERSION, admin).into_val(&env),
                 ),
             ]
         );
@@ -1227,7 +1310,7 @@ mod tests {
 
         env.mock_all_auths();
 
-        let memo = Symbol::new(&env, "Rent");
+        let memo = String::from_str(&env, "Rent");
         let receipt_id = client.mint_receipt(&payer, &payee, &1000, &memo);
         assert_eq!(receipt_id, 0);
 
@@ -1255,12 +1338,58 @@ mod tests {
 
         env.mock_all_auths();
 
-        let id1 = client.mint_receipt(&payer, &payee1, &500, &Symbol::new(&env, "Coffee"));
-        let id2 = client.mint_receipt(&payer, &payee2, &1500, &Symbol::new(&env, "Invoice"));
+        let id1 = client.mint_receipt(&payer, &payee1, &500, &String::from_str(&env, "Coffee"));
+        let id2 = client.mint_receipt(&payer, &payee2, &1500, &String::from_str(&env, "Invoice"));
 
         assert_eq!(id1, 0);
         assert_eq!(id2, 1);
         assert_eq!(client.get_receipt_count(&payer), 2);
+    }
+
+    #[test]
+    fn test_receipt_memo_accepts_unicode_and_exact_byte_cap() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        let payer = Address::generate(&env);
+        let payee = Address::generate(&env);
+        env.mock_all_auths();
+
+        let unicode = String::from_str(&env, "Café ☕ — 谢谢");
+        let unicode_id = client.mint_receipt(&payer, &payee, &100, &unicode);
+        assert_eq!(client.get_receipt(&payer, &unicode_id).memo, unicode);
+
+        let max_bytes = [b'x'; MAX_RECEIPT_MEMO_BYTES as usize];
+        let max_memo = String::from_bytes(&env, &max_bytes);
+        let max_id = client.mint_receipt(&payer, &payee, &100, &max_memo);
+        assert_eq!(client.get_receipt(&payer, &max_id).memo.len(), MAX_RECEIPT_MEMO_BYTES);
+    }
+
+    #[test]
+    fn test_receipt_memo_rejects_more_than_byte_cap() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, MicroPayContract);
+        let client = MicroPayContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        let payer = Address::generate(&env);
+        let payee = Address::generate(&env);
+        env.mock_all_auths();
+
+        let too_many_bytes = [b'x'; MAX_RECEIPT_MEMO_BYTES as usize + 1];
+        let result = client.try_mint_receipt(
+            &payer,
+            &payee,
+            &100,
+            &String::from_bytes(&env, &too_many_bytes),
+        );
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::ReceiptMemoTooLong
+        );
+        assert_eq!(client.get_receipt_count(&payer), 0);
     }
 
     #[test]
@@ -1450,8 +1579,8 @@ mod tests {
         let release_ledger = env.ledger().sequence() + 10;
         let id = client.create_escrow(&token_id, &from, &to, &amount, &release_ledger);
 
-        // Fast-forward past release.
-        advance_ledger(&env, release_ledger + 1);
+        // Claim is valid at the inclusive release boundary.
+        advance_ledger(&env, release_ledger);
         client.claim_escrow(&id);
 
         assert_eq!(token.balance(&to), amount);
@@ -1482,7 +1611,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "release_ledger not reached")]
     fn test_claim_escrow_rejected_before_release_ledger() {
         let env = Env::default();
         let contract_id = env.register_contract(None, MicroPayContract);
@@ -1496,7 +1624,12 @@ mod tests {
         let token_id = create_token(&env, &admin, &from, 100);
         let release = env.ledger().sequence() + 50;
         let id = client.create_escrow(&token_id, &from, &to, &100, &release);
-        client.claim_escrow(&id);
+        advance_ledger(&env, release - 1);
+        let result = client.try_claim_escrow(&id);
+        assert_eq!(
+            result.unwrap_err().unwrap(),
+            ContractError::EscrowClaimTooEarly
+        );
     }
 
     #[test]
@@ -1548,7 +1681,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "release_ledger already reached")]
     fn test_cancel_escrow_rejected_after_release_ledger() {
         let env = Env::default();
         let contract_id = env.register_contract(None, MicroPayContract);
@@ -1562,8 +1694,19 @@ mod tests {
         let token_id = create_token(&env, &admin, &from, 100);
         let release = env.ledger().sequence() + 5;
         let id = client.create_escrow(&token_id, &from, &to, &100, &release);
+        advance_ledger(&env, release);
+        let at_release = client.try_cancel_escrow(&id);
+        assert_eq!(
+            at_release.unwrap_err().unwrap(),
+            ContractError::EscrowCancelTooLate
+        );
+
         advance_ledger(&env, release + 1);
-        client.cancel_escrow(&id);
+        let after_release = client.try_cancel_escrow(&id);
+        assert_eq!(
+            after_release.unwrap_err().unwrap(),
+            ContractError::EscrowCancelTooLate
+        );
     }
 
     #[test]
@@ -1870,7 +2013,14 @@ mod tests {
         let recipient2 = Address::generate(&env);
         let token = token::Client::new(&env, &token_id);
 
-        let id = open_single_stream(&env, &client, &token_id, &payer, &recipient, RATE, DEPOSIT);
+        let id = client.open_stream(
+            &token_id,
+            &payer,
+            &soroban_sdk::vec![&env, recipient1.clone(), recipient2.clone()],
+            &soroban_sdk::vec![&env, 1u32, 1u32],
+            &RATE,
+            &DEPOSIT,
+        );
 
         // Accrue some balance, then partially claim it.
         advance_by(&env, 10);
@@ -1885,10 +2035,11 @@ mod tests {
 
         let after_topup = client.get_stream(&id);
         assert_eq!(after_topup.deposited, DEPOSIT * 2);
-        assert_eq!(claimed_of(&after_topup), RATE * 10);
+        assert_eq!(total_claimed(&after_topup.recipients), RATE * 10);
         // The top-up must not change what's claimable right now — the
         // extended runway only shows up as ledgers advance.
-        assert_eq!(client.get_claimable(&id, &recipient), 0);
+        assert_eq!(client.get_claimable(&id, &recipient1), 0);
+        assert_eq!(client.get_claimable(&id, &recipient2), 0);
 
         advance_by(&env, 5);
         let second_claim1 = client.claim_stream(&id, &recipient1);
@@ -1897,14 +2048,17 @@ mod tests {
         assert_eq!(second_claim2, (RATE * 5) / 2);
 
         let final_stream = client.get_stream(&id);
-        assert_eq!(claimed_of(&final_stream), RATE * 15);
-        assert_eq!(token.balance(&recipient), claimed_of(&final_stream));
+        assert_eq!(total_claimed(&final_stream.recipients), RATE * 15);
+        assert_eq!(
+            token.balance(&recipient1) + token.balance(&recipient2),
+            total_claimed(&final_stream.recipients)
+        );
 
         // Reconciliation: claimed + whatever remains locked in the contract
         // for this stream equals the total ever deposited, exactly.
         let remaining_in_contract = token.balance(&contract_id);
         assert_eq!(
-            claimed_of(&final_stream) + remaining_in_contract,
+            total_claimed(&final_stream.recipients) + remaining_in_contract,
             after_topup.deposited
         );
     }
@@ -1959,7 +2113,7 @@ mod tests {
                 (
                     contract_id,
                     (Symbol::new(&env, "stream_close"), id).into_val(&env),
-                    (streamed, refund).into_val(&env),
+                    (EVENT_SCHEMA_VERSION, streamed, refund).into_val(&env),
                 ),
             ]
         );

--- a/contracts/stellar-micropay-contract/src/migration_tests.rs
+++ b/contracts/stellar-micropay-contract/src/migration_tests.rs
@@ -8,13 +8,17 @@
 //! contract API so we can write the old layout), call `migrate`, and then
 //! verify every retained record through the public getters.
 
+extern crate std;
+
 use soroban_sdk::{
-    contracttype,
-    testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, Symbol,
+    testutils::{Address as _, Events as _},
+    vec, Address, Env, IntoVal, String, Symbol,
 };
 
-use crate::{DataKey, Escrow, EscrowStatus, MicroPayContract, ReceiptMetadata, TipRecord, SCHEMA_VERSION};
+use crate::{
+    DataKey, Escrow, EscrowStatus, LegacyReceiptMetadata, MicroPayContract,
+    MicroPayContractClient, TipRecord, SCHEMA_VERSION,
+};
 
 // ── v1 snapshot fixture builder ──────────────────────────────────────────────
 
@@ -88,12 +92,12 @@ fn build_v1_snapshot(env: &Env, contract_id: &Address) -> (Address, Address, Add
         );
 
         // ── Receipts (1 record for payer) ───────────────────────────────
-        let receipt = ReceiptMetadata {
+        let receipt = LegacyReceiptMetadata {
             from: payer.clone(),
             to: tip_recipient.clone(),
             amount: 3_000,
             timestamp: 1_700_000_000,
-            memo: Symbol::new(env, "invoice-42"),
+            memo: Symbol::new(env, "invoice_42"),
             ledger: 200,
         };
         env.storage().persistent().set(
@@ -160,9 +164,9 @@ fn build_v1_snapshot(env: &Env, contract_id: &Address) -> (Address, Address, Add
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-/// Build a v1 snapshot, migrate to v2, and validate every retained record.
+/// Build a v1 snapshot, migrate to the current schema, and validate every retained record.
 #[test]
-fn test_migrate_v1_to_v2_preserves_all_records() {
+fn test_migrate_v1_to_current_preserves_all_records() {
     let env = Env::default();
     let contract_id = env.register_contract(None, MicroPayContract);
     let client = MicroPayContractClient::new(&env, &contract_id);
@@ -187,11 +191,11 @@ fn test_migrate_v1_to_v2_preserves_all_records() {
 
     // Receipts
     assert_eq!(client.get_receipt_count(&payer), 1);
-    let r0 = client.get_receipt(&payer, &0);
+    let r0 = client.get_legacy_receipt(&payer, &0);
     assert_eq!(r0.from, payer);
     assert_eq!(r0.to, tip_recipient);
     assert_eq!(r0.amount, 3_000);
-    assert_eq!(r0.memo, Symbol::new(&env, "invoice-42"));
+    assert_eq!(r0.memo, Symbol::new(&env, "invoice_42"));
     assert_eq!(r0.ledger, 200);
 
     // Escrow
@@ -224,9 +228,9 @@ fn test_migrate_v1_to_v2_preserves_all_records() {
 
     // Receipts survived
     assert_eq!(client.get_receipt_count(&payer), 1);
-    let r0 = client.get_receipt(&payer, &0);
+    let r0 = client.get_legacy_receipt(&payer, &0);
     assert_eq!(r0.amount, 3_000);
-    assert_eq!(r0.memo, Symbol::new(&env, "invoice-42"));
+    assert_eq!(r0.memo, Symbol::new(&env, "invoice_42"));
 
     // Escrow survived
     assert_eq!(client.get_escrow_count(), 1);
@@ -250,24 +254,17 @@ fn test_migrate_v1_emits_correct_event() {
     env.mock_all_auths();
     client.migrate(&admin);
 
-    let events = env.events().all();
-    let migrate_events: Vec<_> = events
-        .iter()
-        .filter(|e| {
-            e.in_contract_class_id(&contract_id)
-                && match &e.topics[0] {
-                    soroban_sdk::Val::Symbol(s) => *s == Symbol::new(&env, "migrate"),
-                    _ => false,
-                }
-        })
-        .collect();
-
-    assert_eq!(migrate_events.len(), 1);
-    // The event data is (from_version: u32, to_version: u32)
-    // Verify via the raw event data
-    let event = &migrate_events[0];
-    // Event data is a tuple; we check the topics carried the "migrate" symbol
-    assert!(event.in_contract_class_id(&contract_id));
+    assert_eq!(
+        env.events().all().filter_by_contract(&contract_id),
+        vec![
+            &env,
+            (
+                contract_id,
+                (Symbol::new(&env, "migrate"),).into_val(&env),
+                (crate::EVENT_SCHEMA_VERSION, 1u32, SCHEMA_VERSION).into_val(&env),
+            ),
+        ]
+    );
 }
 
 /// Post-migration, new operations work correctly on the migrated state.
@@ -284,8 +281,8 @@ fn test_new_operations_after_v1_migration() {
     client.migrate(&admin);
 
     // Send a new tip after migration
-    let token_client = soroban_sdk::token::Client::new(&env, &token);
-    token_client.mint(&payer, &100_000);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&payer, &100_000);
     client.send_tip(&token, &payer, &tip_recipient, &8_000);
 
     // Verify the new tip was appended correctly
@@ -294,6 +291,17 @@ fn test_new_operations_after_v1_migration() {
     let tip2 = client.get_tip_record(&tip_recipient, &2);
     assert_eq!(tip2.amount, 8_000);
     assert_eq!(tip2.from, payer);
+
+    // A v4 UTF-8 receipt can be appended without rewriting or hiding the
+    // legacy Symbol receipt at index 0.
+    let memo = String::from_str(&env, "Lunch 🍜");
+    let receipt_id = client.mint_receipt(&payer, &tip_recipient, &4_000, &memo);
+    assert_eq!(receipt_id, 1);
+    assert_eq!(client.get_receipt(&payer, &1).memo, memo);
+    assert_eq!(
+        client.get_legacy_receipt(&payer, &0).memo,
+        Symbol::new(&env, "invoice_42")
+    );
 }
 
 /// Migrating an already-current instance panics.

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,6 +54,56 @@ curl -X GET http://localhost:4000/api/v1/accounts/resolve/alice
 
 ---
 
+## Soroban event schema versioning
+
+Contract events use event-data schema version `1`. The first item in every
+non-indexed event data tuple is `schema_version: u32`; event names and indexed
+topics remain stable across payload revisions. Indexers should select a decoder
+from this field and reject or quarantine versions they do not understand.
+
+| Event | Indexed topics | Version 1 event data |
+|-------|----------------|----------------------|
+| `init` | `(init)` | `(1, admin)` |
+| `tip` | `(tip, from, to)` | `(1, amount)` |
+| `receipt` | `(receipt, from)` | `(1, receipt_index)` |
+| `escrow_create` | `(escrow_create, escrow_id)` | `(1, from, to, amount, release_ledger)` |
+| `escrow_claim` | `(escrow_claim, escrow_id)` | `(1, to, amount)` |
+| `escrow_cancel` | `(escrow_cancel, escrow_id)` | `(1, from, amount)` |
+| `stream_open` | `(stream_open, stream_id)` | `(1, payer, recipients, weights, rate_per_ledger, deposit)` |
+| `stream_claim` | `(stream_claim, stream_id)` | `(1, recipient, amount)` |
+| `stream_topup` | `(stream_topup, stream_id)` | `(1, payer, amount, total_deposited)` |
+| `stream_pause` | `(stream_pause, stream_id)` | `(1, payer, paused_at_ledger)` |
+| `stream_resume` | `(stream_resume, stream_id)` | `(1, payer, pause_length)` |
+| `stream_close` | `(stream_close, stream_id)` | `(1, paid_to_recipients, payer_refund)` |
+| `migrate` | `(migrate)` | `(1, from_storage_version, to_storage_version)` |
+
+### JavaScript decoding example
+
+```ts
+import { scValToNative } from "@stellar/stellar-sdk";
+
+function decodeMicroPayEvent(event) {
+  const topics = event.topic.map(scValToNative);
+  const [schemaVersion, ...payload] = scValToNative(event.value);
+
+  if (schemaVersion !== 1) {
+    throw new Error(`Unsupported MicroPay event schema: ${schemaVersion}`);
+  }
+
+  return { name: topics[0], indexedTopics: topics.slice(1), payload };
+}
+```
+
+For example, `escrow_claim` decodes to indexed topics `[escrow_id]` and
+payload `[to, amount]`; `stream_close` decodes to indexed topics `[stream_id]`
+and payload `[paid_to_recipients, payer_refund]`.
+
+The layout is network-independent. Testnet and mainnet emit the same schema;
+indexers must configure the correct network passphrase, RPC endpoint, and
+deployed contract ID for each network and must not merge their cursors.
+
+---
+
 ## Response conventions
 
 Most JSON endpoints use one of these shapes:

--- a/frontend/__tests__/dashboard-volume-charts-a11y.test.tsx
+++ b/frontend/__tests__/dashboard-volume-charts-a11y.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  BalanceSparkline,
+  MonthlySpendingChart,
+  ThirtyDayVolumeChart,
+} from "@/components/dashboard";
+
+describe("dashboard volume chart accessibility", () => {
+  it("summarizes a sparkline, hides its drawing nodes, and discloses values", () => {
+    const { container } = render(<BalanceSparkline data={[2, -1, 5]} />);
+
+    expect(
+      screen.getByText(/upward trend: \+3\.0000 XLM across 3 recent payments/i)
+    ).toBeInTheDocument();
+    expect(container.querySelector("path")).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelector("polyline")).toHaveAttribute("aria-hidden", "true");
+
+    fireEvent.click(screen.getByText("View balance trend data"));
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("columnheader", { name: "Payment" })).toBeInTheDocument();
+    expect(within(table).getByText("-1.0000 XLM")).toBeInTheDocument();
+  });
+
+  it("summarizes monthly spending and discloses a data table", () => {
+    const { container } = render(
+      <MonthlySpendingChart
+        loading={false}
+        onBarClick={jest.fn()}
+        data={[
+          { month: "Jul", label: "July 2026", sent: 2, received: 4 },
+          { month: "Aug", label: "August 2026", sent: 5.5, received: 1 },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByText("7.50 XLM sent across 2 months. Highest spending was 5.50 XLM in August 2026.")
+    ).toBeInTheDocument();
+    expect(container.querySelector("[aria-hidden='true']")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View monthly spending data"));
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("rowheader", { name: "July 2026" })).toBeInTheDocument();
+    expect(within(table).getByText("5.50 XLM")).toBeInTheDocument();
+  });
+
+  it("summarizes 30-day volume and discloses sent and received values", () => {
+    render(
+      <ThirtyDayVolumeChart
+        loading={false}
+        data={[
+          { day: "Aug 29", sent: 3, received: 1 },
+          { day: "Aug 30", sent: 2, received: 8 },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByText("5.00 XLM sent and 9.00 XLM received. Net flow was in 4.00 XLM.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("View 30-day volume data"));
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("columnheader", { name: "Received" })).toBeInTheDocument();
+    expect(within(table).getByRole("rowheader", { name: "Aug 30" })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/dashboard/BalanceSparkline.tsx
+++ b/frontend/components/dashboard/BalanceSparkline.tsx
@@ -18,6 +18,7 @@ export function BalanceSparkline({ data }: { data: number[] }) {
   const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
 
   const trend = data[data.length - 1] >= data[0];
+  const change = data[data.length - 1] - data[0];
   const color = trend ? "#22c55e" : "#ef4444";
   const fillColor = trend ? "rgba(34,197,94,0.12)" : "rgba(239,68,68,0.12)";
 
@@ -27,7 +28,7 @@ export function BalanceSparkline({ data }: { data: number[] }) {
     ` L ${points[points.length - 1].x},${H - PAD} Z`;
 
   return (
-    <div className="relative inline-block" aria-label="Balance sparkline chart">
+    <div className="relative inline-block">
       <svg
         width={W}
         height={H}
@@ -35,7 +36,7 @@ export function BalanceSparkline({ data }: { data: number[] }) {
         role="img"
         aria-label={`Balance trend: ${trend ? "upward" : "downward"}`}
       >
-        <path d={fillPath} fill={fillColor} />
+        <path d={fillPath} fill={fillColor} aria-hidden="true" />
         <polyline
           points={polyline}
           fill="none"
@@ -43,9 +44,10 @@ export function BalanceSparkline({ data }: { data: number[] }) {
           strokeWidth="1.5"
           strokeLinejoin="round"
           strokeLinecap="round"
+          aria-hidden="true"
         />
         {points.map((p, i) => (
-          <g key={i} className="group">
+          <g key={i} className="group" aria-hidden="true">
             <circle
               cx={p.x}
               cy={p.y}
@@ -79,8 +81,30 @@ export function BalanceSparkline({ data }: { data: number[] }) {
         ))}
       </svg>
       <p className="text-xs mt-0.5" style={{ color, fontSize: "10px" }}>
-        {trend ? "▲ Upward trend" : "▼ Downward trend"}
+        {trend ? "▲ Upward trend" : "▼ Downward trend"}: {change >= 0 ? "+" : ""}
+        {change.toFixed(4)} XLM across {data.length} recent payments
       </p>
+      <details className="mt-1 text-[10px] text-slate-300">
+        <summary className="cursor-pointer text-stellar-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-400">
+          View balance trend data
+        </summary>
+        <table className="mt-2 min-w-[160px] text-left">
+          <thead>
+            <tr>
+              <th scope="col" className="pe-3">Payment</th>
+              <th scope="col">Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((value, index) => (
+              <tr key={index}>
+                <th scope="row" className="pe-3 font-normal">{index + 1}</th>
+                <td>{value >= 0 ? "+" : ""}{value.toFixed(4)} XLM</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
     </div>
   );
 }

--- a/frontend/components/dashboard/VolumeCharts.tsx
+++ b/frontend/components/dashboard/VolumeCharts.tsx
@@ -9,12 +9,77 @@ import {
   Tooltip,
 } from "recharts";
 
+export interface MonthlyVolumePoint {
+  month: string;
+  label?: string;
+  sent: number;
+  received: number;
+}
+
+export interface DailyVolumePoint {
+  day: string;
+  sent: number;
+  received: number;
+}
+
+function formatXlm(value: number) {
+  return `${value.toFixed(2)} XLM`;
+}
+
+function DataDisclosure({
+  label,
+  headings,
+  rows,
+}: {
+  label: string;
+  headings: string[];
+  rows: Array<Array<string>>;
+}) {
+  return (
+    <details className="mt-4 text-sm text-slate-300">
+      <summary className="w-fit cursor-pointer rounded text-stellar-400 hover:text-stellar-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-400">
+        {label}
+      </summary>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr>
+              {headings.map((heading) => (
+                <th key={heading} scope="col" className="border-b border-white/10 px-3 py-2 font-medium text-slate-200">
+                  {heading}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={`${row[0]}-${rowIndex}`}>
+                {row.map((cell, cellIndex) =>
+                  cellIndex === 0 ? (
+                    <th key={cellIndex} scope="row" className="border-b border-white/5 px-3 py-2 font-normal">
+                      {cell}
+                    </th>
+                  ) : (
+                    <td key={cellIndex} className="border-b border-white/5 px-3 py-2">
+                      {cell}
+                    </td>
+                  )
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
 export function MonthlySpendingChart({
   data,
   loading,
   onBarClick,
 }: {
-  data: any[];
+  data: MonthlyVolumePoint[];
   loading: boolean;
   onBarClick: (data: any) => void;
 }) {
@@ -24,12 +89,22 @@ export function MonthlySpendingChart({
     );
   }
 
+  const totalSent = data.reduce((total, point) => total + point.sent, 0);
+  const peak = data.reduce<MonthlyVolumePoint | null>(
+    (highest, point) => (!highest || point.sent > highest.sent ? point : highest),
+    null
+  );
+  const summary = data.length === 0
+    ? "No monthly spending recorded for this period."
+    : `${formatXlm(totalSent)} sent across ${data.length} months. Highest spending was ${formatXlm(peak?.sent ?? 0)} in ${peak?.label ?? peak?.month}.`;
+
   return (
     <div className="card mb-6 overflow-hidden">
       <h2 className="font-display text-lg font-semibold text-white mb-6">
         Monthly Spending (XLM)
       </h2>
-      <div className="h-[250px] w-full">
+      <p className="mb-4 text-sm text-slate-300">{summary}</p>
+      <div className="h-[250px] w-full" aria-hidden="true">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={data}
@@ -65,19 +140,35 @@ export function MonthlySpendingChart({
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <DataDisclosure
+        label="View monthly spending data"
+        headings={["Month", "Sent", "Received"]}
+        rows={data.map((point) => [
+          point.label ?? point.month,
+          formatXlm(point.sent),
+          formatXlm(point.received),
+        ])}
+      />
     </div>
   );
 }
 
-export function ThirtyDayVolumeChart({ data, loading }: { data: any[]; loading: boolean }) {
+export function ThirtyDayVolumeChart({ data, loading }: { data: DailyVolumePoint[]; loading: boolean }) {
   if (loading && data.length === 0) {
     return <div className="card mb-6 h-[280px] animate-pulse bg-white/[0.03] border-white/10" />;
   }
-  const visibleData = data.filter((_: any, i: number) => i % 5 === 0 || i === data.length - 1);
+  const visibleData = data.filter((_, i: number) => i % 5 === 0 || i === data.length - 1);
+  const totalSent = data.reduce((total, point) => total + point.sent, 0);
+  const totalReceived = data.reduce((total, point) => total + point.received, 0);
+  const net = totalReceived - totalSent;
+  const summary = data.length === 0
+    ? "No payment volume recorded in the last 30 days."
+    : `${formatXlm(totalSent)} sent and ${formatXlm(totalReceived)} received. Net flow was ${net >= 0 ? "in" : "out"} ${formatXlm(Math.abs(net))}.`;
   return (
     <div className="card mb-6 overflow-hidden">
       <h2 className="font-display text-lg font-semibold text-white mb-6">30-Day Volume (XLM)</h2>
-      <div className="h-[220px] w-full">
+      <p className="mb-4 text-sm text-slate-300">{summary}</p>
+      <div className="h-[220px] w-full" aria-hidden="true">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" stroke="#334155" vertical={false} />
@@ -104,6 +195,15 @@ export function ThirtyDayVolumeChart({ data, loading }: { data: any[]; loading: 
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <DataDisclosure
+        label="View 30-day volume data"
+        headings={["Day", "Sent", "Received"]}
+        rows={data.map((point) => [
+          point.day,
+          formatXlm(point.sent),
+          formatXlm(point.received),
+        ])}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Hardens the contract upgrade/indexing surface and makes dashboard charts accessible without relying on visual interpretation.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Smart contract change

## Related issues

Closes #793
Closes #797
Closes #798
Closes #827

## Changes

- Defines the escrow boundary explicitly: cancellation is valid only before `release_ledger`, while claiming is valid at and after it, with dedicated typed errors.
- Replaces new receipt `Symbol` memos with UTF-8 `String` values capped at 256 bytes; storage schema v4 appends a new key and preserves legacy receipts through `get_legacy_receipt`.
- Adds event-data schema version 1 to every emitted event while preserving event names and indexed topics; documents all layouts and a JavaScript decoder.
- Adds concise chart summaries, keyboard-operable data disclosures/tables, and hides decorative chart drawing nodes from assistive technology.
- Repairs current-SDK test fixtures/helpers needed to exercise the migration and stream regression suites.

## Testing

- [x] `cargo test -p stellar-micropay-contract` — 78 passed
- [x] `cargo test -p stellar-micropay-contract migration_tests` — 5 passed
- [x] `cargo build -p stellar-micropay-contract --target wasm32v1-none --release`
- [x] `npm test -- --runInBand __tests__/dashboard-volume-charts-a11y.test.tsx` — 3 passed
- [x] Isolated TypeScript compile for `BalanceSparkline.tsx` and `VolumeCharts.tsx`
- [ ] `npm run type-check` — blocked by existing `main` errors outside this change, including missing `useTranslation`, realtime dashboard callbacks, and unrelated SendPaymentForm/e2e types
- [ ] `npm run lint` — blocked by the existing invalid `import/order` ESLint configuration

Contract behavior and event layouts are network-independent. The docs explicitly call out identical testnet/mainnet ledger semantics and separate network passphrase, RPC, contract ID, and cursor configuration. No live network deployment was performed.

## Screenshots

Not included; the UI change adds text/table alternatives to existing visuals without changing the chart design.

## Checklist

- [x] Added/updated unit tests
- [x] Updated contract and API documentation
- [x] Rebased on latest `main`
- [x] `git diff --check` passes
