### PR TITLE
Fix/sns race condition

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,7 +61,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-<<<<<<< HEAD
+          build-args: |
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+            SENTRY_RELEASE=${{ github.sha }}
 
   smoke-test:
     name: Staging smoke tests
@@ -140,10 +144,3 @@ jobs:
               body: `## Automatic Rollback Triggered\n\nCommit: ${context.sha}\nWorkflow: ${context.workflow}\nRun: ${context.runId}\n\nSmoke tests failed after deployment. The staging environment has been rolled back to the previous stable image.\n\n### Rollback Criteria\n- Health endpoint non-responsive\n- API documentation unreachable\n- Security headers missing\n- Network isolation violation\n\nPlease investigate before re-deploying.`,
               labels: ["incident", "rollback", "staging"]
             });
-=======
-          build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
-            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
-            SENTRY_RELEASE=${{ github.sha }}
->>>>>>> 1d46ec1 (fix:  perf, observ and refactor)

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,7 +11,7 @@ on:
       update_snapshots:
         description: "Update baseline screenshots"
         required: true
-        default: false
+        default: "false"
         type: boolean
 
 jobs:

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -8,6 +8,9 @@
     "ecmaVersion": "latest"
   },
   "rules": {
+    // Enforce consistent import ordering: builtins → external packages →
+    // internal → relative (parent/sibling/index). Alphabetised within each
+    // group, case-insensitive, with a blank line between groups.
     "import/order": [
       "error",
       {
@@ -19,8 +22,10 @@
           "sibling",
           "index"
         ],
-        "alphabeticalOrder": true,
-        "caseInsensitive": true,
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        },
         "newlines-between": "always"
       }
     ]

--- a/backend/src/controllers/federationController.js
+++ b/backend/src/controllers/federationController.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const axios = require("axios");
+
 const usernameService = require("../services/usernameService");
 
 /**

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const jwt = require("jsonwebtoken");
+
 const logger = require("../utils/logger");
 
 const DEFAULT_JWT_SECRET = "stellar_micropay_secret_key";

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -6,11 +6,12 @@
 "use strict";
 
 const express = require("express");
+
 const router = express.Router();
+const accountController = require("../controllers/accountController");
+const { verifyJWT } = require("../middleware/auth");
 const { strictLimiter, sensitiveLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey, sanitizeUsername } = require("../middleware/sanitization");
-const { verifyJWT } = require("../middleware/auth");
-const accountController = require("../controllers/accountController");
 
 /**
  * Restrict account-data routes to the authenticated account holder (#278).

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -6,10 +6,11 @@
 "use strict";
 
 const express = require("express");
+
 const router = express.Router();
+const analyticsController = require("../controllers/analyticsController");
 const { strictLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey } = require("../middleware/sanitization");
-const analyticsController = require("../controllers/analyticsController");
 
 /**
  * GET /api/analytics/:publicKey/summary

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -7,9 +7,10 @@
  */
 "use strict";
 
+const { Utils, Keypair } = require("@stellar/stellar-sdk");
 const express = require("express");
 const jwt     = require("jsonwebtoken");
-const { Utils, Keypair } = require("@stellar/stellar-sdk");
+
 const {
   JWT_SECRET,
   SIGN_OPTIONS,

--- a/backend/src/routes/federation.js
+++ b/backend/src/routes/federation.js
@@ -6,9 +6,10 @@
 "use strict";
 
 const express = require("express");
+
 const router = express.Router();
-const { strictLimiter } = require("../middleware/rateLimit");
 const federationController = require("../controllers/federationController");
+const { strictLimiter } = require("../middleware/rateLimit");
 
 /**
  * GET /federation?q=<query>&type=<type>

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -6,10 +6,11 @@
 "use strict";
 
 const express = require("express");
+
 const router = express.Router();
+const paymentController = require("../controllers/paymentController");
 const { paymentLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey } = require("../middleware/sanitization");
-const paymentController = require("../controllers/paymentController");
 
 /**
  * GET /api/payments/:publicKey

--- a/backend/src/routes/tips.js
+++ b/backend/src/routes/tips.js
@@ -6,10 +6,11 @@
 "use strict";
 
 const express = require("express");
+
 const router = express.Router();
+const tipsController = require("../controllers/tipsController");
 const { strictLimiter } = require("../middleware/rateLimit");
 const { sanitizePublicKey } = require("../middleware/sanitization");
-const tipsController = require("../controllers/tipsController");
 
 /**
  * POST /api/tips

--- a/backend/src/routes/turrets.js
+++ b/backend/src/routes/turrets.js
@@ -6,8 +6,9 @@
 "use strict";
 
 const express = require("express");
-const { paymentLimiter } = require("../middleware/rateLimit");
+
 const controller = require("../controllers/turretsController");
+const { paymentLimiter } = require("../middleware/rateLimit");
 
 const router = express.Router();
 

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -9,8 +9,8 @@
 
 "use strict";
 
-const express = require("express");
 const { StrKey } = require("@stellar/stellar-sdk");
+const express = require("express");
 const router = express.Router();
 
 const { strictLimiter } = require("../middleware/rateLimit");
@@ -24,6 +24,7 @@ const {
  * Strip the secret field before sending a webhook to the client.
  * @param {{ secret?: string, [key: string]: unknown }} webhook
  */
+// eslint-disable-next-line no-unused-vars
 function sanitizeWebhook({ secret: _secret, ...rest }) {
   return rest;
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,31 +5,33 @@
 
 "use strict";
 
-const express = require("express");
-const cors = require("cors");
-const cookieParser = require("cookie-parser");
+require("dotenv").config();
+
+const Sentry = require("@sentry/node");
 const compression = require("compression");
+const cookieParser = require("cookie-parser");
+const cors = require("cors");
+const express = require("express");
+const rateLimit = require("express-rate-limit");
 const helmet = require("helmet");
 const pinoHttp = require("pino-http");
-const rateLimit = require("express-rate-limit");
-require("dotenv").config();
-const Sentry = require("@sentry/node");
-
-const accountRoutes = require("./routes/accounts");
-const authRoutes = require("./routes/auth");
-const paymentRoutes = require("./routes/payments");
-const analyticsRoutes = require("./routes/analytics");
-const healthRoutes = require("./routes/health");
-const federationRoutes = require("./routes/federation");
-const turretsRoutes = require("./routes/turrets");
-const tipsRoutes = require("./routes/tips");
-const webhookRoutes = require("./routes/webhooks");
 const swaggerUi = require("swagger-ui-express");
+
+const { validateEnv, parseAllowedOrigins } = require("./config/validateEnv");
+const { apiDeprecationHeader } = require("./middleware/deprecation");
+const accountRoutes = require("./routes/accounts");
+const analyticsRoutes = require("./routes/analytics");
+const authRoutes = require("./routes/auth");
+const federationRoutes = require("./routes/federation");
+const healthRoutes = require("./routes/health");
+const paymentRoutes = require("./routes/payments");
+const tipsRoutes = require("./routes/tips");
+const turretsRoutes = require("./routes/turrets");
+const webhookRoutes = require("./routes/webhooks");
+const { resumeAllMonitors } = require("./services/paymentMonitor");
 const swaggerSpec = require("./swagger");
 const { startTurretsServer } = require("./turretsServer");
-const { resumeAllMonitors } = require("./services/paymentMonitor");
 const logger = require("./utils/logger");
-const { validateEnv, parseAllowedOrigins } = require("./config/validateEnv");
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -243,7 +245,6 @@ const limiter = rateLimit({
 app.use(limiter);
 
 // ─── API Versioning & Deprecation Policy (#853) ────────────────────────────────
-const { apiDeprecationHeader } = require("./middleware/deprecation");
 
 // Primary Versioned Routes (/api/v1/*)
 app.use("/api/v1/auth", authRoutes);

--- a/backend/src/services/analyticsService.js
+++ b/backend/src/services/analyticsService.js
@@ -7,9 +7,8 @@
 
 "use strict";
 
+const emailService = require("./emailService");
 const stellarService = require("./stellarService");
-
-// ─── Cache Configuration ──────────────────────────────────────────────────────
 
 const CACHE_TTL = 60 * 1000; // 60 seconds in milliseconds
 const CACHE_MAX_SIZE = 100; // bounded LRU size
@@ -482,8 +481,6 @@ async function getCohortBreakdown(publicKey, { period = "month", periods = 6 } =
     };
   });
 }
-
-const emailService = require("./emailService");
 
 // In-memory store for scheduled exports: Map<publicKey, { email, frequency, nextRunAt }>
 const exportSchedules = new Map();

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const nodemailer = require("nodemailer");
+
 const logger = require("../utils/logger");
 
 // Create a reusable transporter using the SMTP configuration

--- a/backend/src/services/paymentMonitor.js
+++ b/backend/src/services/paymentMonitor.js
@@ -7,9 +7,11 @@
 "use strict";
 
 const { Horizon } = require("@stellar/stellar-sdk");
+
 const logger = require("../utils/logger");
-const { getWebhooksByPublicKey, getAllWebhooks } = require("./webhookStore");
+
 const { deliverWebhook } = require("./webhookDelivery");
+const { getWebhooksByPublicKey, getAllWebhooks } = require("./webhookStore");
 
 const HORIZON_URL =
   process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";

--- a/backend/src/services/scheduledTransactionService.js
+++ b/backend/src/services/scheduledTransactionService.js
@@ -2,6 +2,8 @@
 
 require("dotenv").config();
 
+const logger = require("../utils/logger");
+
 // In-memory storage for scheduled transactions
 // In a production environment, this would be replaced with a database
 const scheduledTransactions = new Map();

--- a/backend/src/services/turretsService.js
+++ b/backend/src/services/turretsService.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const crypto = require("crypto");
+
 const {
   Account,
   Asset,
@@ -15,6 +16,7 @@ const {
   Transaction,
   TransactionBuilder,
 } = require("@stellar/stellar-sdk");
+
 const { server } = require("../config/stellar");
 const logger = require("../utils/logger");
 

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -9,14 +9,14 @@
 
 "use strict";
 
-const store = require("./webhookStore");
-const { deliverWebhook } = require("./webhookDelivery");
 const {
   startMonitoring,
   stopMonitoring,
   ensureMonitored,
   resumeAllMonitors,
 } = require("./paymentMonitor");
+const { deliverWebhook } = require("./webhookDelivery");
+const store = require("./webhookStore");
 
 /**
  * Register a webhook and immediately start (or confirm) monitoring.

--- a/backend/src/turretsServer.js
+++ b/backend/src/turretsServer.js
@@ -5,10 +5,11 @@
 
 "use strict";
 
-const express = require("express");
 const cors = require("cors");
+const express = require("express");
 const helmet = require("helmet");
 const morgan = require("morgan");
+
 const turretsRoutes = require("./routes/turrets");
 const { startRunner } = require("./services/turretsService");
 

--- a/frontend/__tests__/SendPaymentFormSNS.test.tsx
+++ b/frontend/__tests__/SendPaymentFormSNS.test.tsx
@@ -47,6 +47,14 @@ jest.mock("@/lib/wallet", () => ({
   signTransactionWithWallet: jest.fn().mockResolvedValue({ signedXDR: "signed-xdr" }),
 }));
 
+jest.mock("@/lib/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@/lib/ToastContext", () => ({
+  useToastContext: () => ({ addToast: jest.fn() }),
+}));
+
 jest.mock("@/utils/format", () => ({
   formatXLM: jest.fn((n: number) => `${n} XLM`),
   shortenAddress: jest.fn((a: string) => a?.slice(0, 8) + "..."),
@@ -163,7 +171,7 @@ describe("SendPaymentForm — SNS integration", () => {
       render(<SendPaymentForm {...defaultProps} />);
 
       const input = screen.getByPlaceholderText(/G\.\.\./);
-      const amountInput = screen.getByPlaceholderText("0.0000000");
+      const amountInput = screen.getByPlaceholderText("amount_placeholder");
       await user.type(input, "alice.xlm");
       await user.type(amountInput, "5");
 
@@ -183,7 +191,7 @@ describe("SendPaymentForm — SNS integration", () => {
       render(<SendPaymentForm {...defaultProps} />);
 
       const input = screen.getByPlaceholderText(/G\.\.\./);
-      const amountInput = screen.getByPlaceholderText("0.0000000");
+      const amountInput = screen.getByPlaceholderText("amount_placeholder");
       await user.type(input, "bad.xlm");
       await user.type(amountInput, "5");
 
@@ -232,6 +240,83 @@ describe("SendPaymentForm — SNS integration", () => {
     });
   });
 
+  describe("out-of-order response protection", () => {
+    beforeEach(() => {
+      mockIsStellarName.mockImplementation((v: string) =>
+        v.trim().toLowerCase().endsWith(".xlm") || v.includes("*")
+      );
+    });
+
+    it("ignores a stale slow response when the input has already changed", async () => {
+      // First call (alice.xlm) is slow; second call (bob.xlm) resolves first
+      let resolveAlice!: (v: string) => void;
+      const ALICE_ADDRESS = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN";
+      const BOB_ADDRESS   = "GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3D5NZ2KMSUGSRNVO7ZFGIGSZZZ";
+
+      mockResolveStellarName
+        .mockImplementationOnce(() => new Promise<string>((res) => { resolveAlice = res; }))
+        .mockResolvedValueOnce(BOB_ADDRESS);
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<SendPaymentForm {...defaultProps} />);
+
+      const input = screen.getByPlaceholderText(/G\.\.\./);
+
+      // Type "alice.xlm" — debounce fires, slow request in-flight
+      await user.type(input, "alice.xlm");
+      act(() => { jest.advanceTimersByTime(500); });
+
+      // Clear and type "bob.xlm" before alice resolves — debounce fires, fast request
+      await user.clear(input);
+      await user.type(input, "bob.xlm");
+      act(() => { jest.advanceTimersByTime(500); });
+
+      // bob.xlm resolves first
+      await waitFor(() => {
+        expect(screen.getByText(new RegExp(BOB_ADDRESS))).toBeInTheDocument();
+      });
+
+      // Now the stale alice response arrives — should be ignored
+      act(() => { resolveAlice(ALICE_ADDRESS); });
+
+      // Alice's address must NOT appear; bob's must remain
+      await waitFor(() => {
+        expect(screen.queryByText(new RegExp(ALICE_ADDRESS))).not.toBeInTheDocument();
+        expect(screen.getByText(new RegExp(BOB_ADDRESS))).toBeInTheDocument();
+      });
+    });
+
+    it("rapid valid→invalid→valid sequence shows final state correctly", async () => {
+      const FINAL_ADDRESS = "GBRPYHIL2CI3WHZDTOOQFC6EB4RRJC3D5NZ2KMSUGSRNVO7ZFGIGSZZZ";
+
+      mockResolveStellarName
+        .mockResolvedValueOnce("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN") // alice
+        .mockRejectedValueOnce(new Error('Could not resolve "bad.xlm"'))                      // bad
+        .mockResolvedValueOnce(FINAL_ADDRESS);                                                 // carol
+
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<SendPaymentForm {...defaultProps} />);
+
+      const input = screen.getByPlaceholderText(/G\.\.\./);
+
+      await user.type(input, "alice.xlm");
+      act(() => { jest.advanceTimersByTime(500); });
+
+      await user.clear(input);
+      await user.type(input, "bad.xlm");
+      act(() => { jest.advanceTimersByTime(500); });
+
+      await user.clear(input);
+      await user.type(input, "carol.xlm");
+      act(() => { jest.advanceTimersByTime(500); });
+
+      await waitFor(() => {
+        expect(screen.getByText(new RegExp(FINAL_ADDRESS))).toBeInTheDocument();
+        expect(screen.queryByText(/Could not resolve/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe("submission uses resolved address", () => {
     it("passes the resolved address (not the typed name) to buildPaymentTransaction", async () => {
       mockIsStellarName.mockImplementation((v: string) =>
@@ -245,7 +330,7 @@ describe("SendPaymentForm — SNS integration", () => {
       render(<SendPaymentForm {...defaultProps} />);
 
       const input = screen.getByPlaceholderText(/G\.\.\./);
-      const amountInput = screen.getByPlaceholderText("0.0000000");
+      const amountInput = screen.getByPlaceholderText("amount_placeholder");
 
       await user.type(input, "alice.xlm");
       act(() => { jest.advanceTimersByTime(500); });
@@ -263,7 +348,7 @@ describe("SendPaymentForm — SNS integration", () => {
 
       await user.click(screen.getByRole("button", { name: /Send/i }));
 
-      const confirmButton = await screen.findByRole("button", { name: /Confirm & Sign/i });
+      const confirmButton = await screen.findByRole("button", { name: /confirm_sign|Confirm & Sign/i });
       await user.click(confirmButton);
 
       await waitFor(() => {

--- a/frontend/components/SendPaymentForm.tsx
+++ b/frontend/components/SendPaymentForm.tsx
@@ -150,6 +150,7 @@ function SendPaymentForm({
   const [snsResolved, setSnsResolved] = useState<string | null>(null);
   const [snsError, setSnsError] = useState<string | null>(null);
   const snsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snsGenRef = useRef(0);
   const [customAsset, setCustomAsset] = useState<CustomAsset>({ code: "", issuer: "" });
   const [showCustomAssetForm, setShowCustomAssetForm] = useState(false);
   const [selectedMemoTemplate, setSelectedMemoTemplate] = useState<string | null>(null);
@@ -377,29 +378,29 @@ function SendPaymentForm({
 
     const trimmed = destination.trim();
 
-    // Only trigger for SNS/federation names — raw addresses and usernames are
-    // handled elsewhere.
     if (!isStellarName(trimmed)) {
-      setSnsResolvedAddress(null);
+      setSnsResolved(null);
+      setSnsError(null);
       setSnsResolving(false);
       return;
     }
 
+    const gen = ++snsGenRef.current;
     setSnsResolving(true);
-    setSnsResolvedAddress(null);
+    setSnsResolved(null);
+    setSnsError(null);
     setDestinationResolutionError(null);
 
     snsDebounceRef.current = setTimeout(async () => {
       try {
         const resolved = await resolveStellarName(trimmed);
-        setSnsResolvedAddress(resolved);
-        setDestinationResolutionError(null);
+        if (snsGenRef.current !== gen) return;
+        setSnsResolved(resolved);
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Could not resolve name";
-        setDestinationResolutionError(message);
-        setSnsResolvedAddress(null);
+        if (snsGenRef.current !== gen) return;
+        setSnsError(err instanceof Error ? err.message : "Could not resolve name");
       } finally {
-        setSnsResolving(false);
+        if (snsGenRef.current === gen) setSnsResolving(false);
       }
     }, 400);
 
@@ -410,7 +411,7 @@ function SendPaymentForm({
 
   // Pre-validate destination account existence on the Stellar network (#294)
   useEffect(() => {
-    if (!isValidStellarAddress(destination)) {
+    if (!isValidStellarAddress(destination.trim())) {
       setDestAccountWarning(null);
       setIsCheckingDest(false);
       return;
@@ -418,49 +419,22 @@ function SendPaymentForm({
 
     setIsCheckingDest(true);
     setDestAccountWarning(null);
-    server.loadAccount(trimmedAddress)
+
+    server.loadAccount(destination.trim())
       .then(() => {
-        if (destinationValidationRequestRef.current === requestId) setDestAccountWarning(null);
+        setDestAccountWarning(null);
       })
       .catch(() => {
-        if (destinationValidationRequestRef.current === requestId) {
-          setDestAccountWarning(
-            selectedAsset === "XLM"
-              ? "This account doesn't exist yet. Sending ≥ 1 XLM will create it."
-              : "This account doesn't exist on the Stellar network."
-          );
-        }
+        setDestAccountWarning(
+          selectedAsset === "XLM"
+            ? "This account doesn't exist yet. Sending ≥ 1 XLM will create it."
+            : "This account doesn't exist on the Stellar network."
+        );
       })
       .finally(() => {
-        if (destinationValidationRequestRef.current === requestId) setIsCheckingDest(false);
+        setIsCheckingDest(false);
       });
-  }, [selectedAsset]);
-
-  // Pre-validate destination account existence on the Stellar network (#294)
-  useEffect(() => {
-    if (destinationValidationTimeoutRef.current) {
-      clearTimeout(destinationValidationTimeoutRef.current);
-    }
-
-    if (!isValidStellarAddress(destination.trim())) {
-      destinationValidationRequestRef.current += 1;
-      setDestAccountWarning(null);
-      setIsCheckingDest(false);
-      return;
-    }
-
-    destinationValidationTimeoutRef.current = setTimeout(() => {
-      validateDestinationAccount(destination);
-      destinationValidationTimeoutRef.current = null;
-    }, DESTINATION_VALIDATION_DEBOUNCE_MS);
-
-    return () => {
-      if (destinationValidationTimeoutRef.current) {
-        clearTimeout(destinationValidationTimeoutRef.current);
-        destinationValidationTimeoutRef.current = null;
-      }
-    };
-  }, [destination, validateDestinationAccount]);
+  }, [destination, selectedAsset]);
 
   const xlmBal = parseFloat(xlmBalance);
   const usdcBal = usdcBalance ? parseFloat(usdcBalance) : 0;
@@ -537,29 +511,19 @@ function SendPaymentForm({
       return trimmedDestination;
     }
 
-    // If we already resolved a SNS name in the debounced effect, use that
-    // result directly — never submit the raw name string.
-    if (isStellarName(trimmedDestination) && snsResolvedAddress) {
-      return snsResolvedAddress;
+    // Reuse the already-resolved SNS address from the live preview
+    if (isStellarName(trimmedDestination) && snsResolved) {
+      return snsResolved;
     }
 
     setIsResolvingDestination(true);
     try {
-      // If we already resolved the SNS name in the preview, reuse it
-      if (isStellarName(trimmedDestination) && snsResolved) {
-        return snsResolved;
-      }
-
       if (isStellarName(trimmedDestination)) {
         return await resolveStellarName(trimmedDestination);
       }
 
       if (isFederationDestination) {
         return await resolveFederationAddress(trimmedDestination);
-      }
-
-      if (isStellarName(trimmedDestination)) {
-        return await resolveStellarName(trimmedDestination);
       }
 
       if (isUsernameDestination) {
@@ -589,7 +553,6 @@ function SendPaymentForm({
     setDestination(address);
     setDestinationResolutionError(null);
     setResolvedPaymentDestination(null);
-    setSnsResolvedAddress(null);
     setIsContactsDropdownOpen(false);
   };
 
@@ -751,16 +714,7 @@ function SendPaymentForm({
 
   const setMaxAmount = () => setAmount(maxSend.toFixed(7));
 
-  const runImmediateDestinationValidation = () => {
-    if (destinationValidationTimeoutRef.current) {
-      clearTimeout(destinationValidationTimeoutRef.current);
-      destinationValidationTimeoutRef.current = null;
-    }
-    validateDestinationAccount(destination);
-  };
-
   const openConfirmation = () => {
-    runImmediateDestinationValidation();
     if (!canSubmit) return;
     setIsConfirmOpen(true);
   };
@@ -942,38 +896,8 @@ function SendPaymentForm({
                 setDestination(val);
                 setDestinationResolutionError(null);
                 setResolvedPaymentDestination(null);
-                setSnsResolvedAddress(null);
                 setDestAccountWarning(null);
                 setIsContactsDropdownOpen(true);
-
-                // SNS live resolution: trigger for federation/SNS patterns
-                const trimmed = val.trim();
-                const looksLikeRawAddress = trimmed.startsWith("G") && trimmed.length === 56;
-                if (isStellarName(trimmed) && !looksLikeRawAddress) {
-                  // Clear previous SNS state
-                  setSnsResolved(null);
-                  setSnsError(null);
-                  if (snsDebounceRef.current) clearTimeout(snsDebounceRef.current);
-                  setSnsResolving(true);
-                  snsDebounceRef.current = setTimeout(() => {
-                    resolveStellarName(trimmed)
-                      .then((address) => {
-                        setSnsResolved(address);
-                        setSnsError(null);
-                      })
-                      .catch((err: unknown) => {
-                        setSnsResolved(null);
-                        setSnsError(err instanceof Error ? err.message : "Name not found or invalid");
-                      })
-                      .finally(() => setSnsResolving(false));
-                  }, 600);
-                } else {
-                  // Not an SNS name — clear SNS state
-                  if (snsDebounceRef.current) clearTimeout(snsDebounceRef.current);
-                  setSnsResolving(false);
-                  setSnsResolved(null);
-                  setSnsError(null);
-                }
               }}
               onFocus={() => setIsContactsDropdownOpen(true)}
               placeholder="G... address or alice.xlm"
@@ -986,28 +910,7 @@ function SendPaymentForm({
                   "border-red-500/50"
               )}
               disabled={status !== "idle" || destinationReadOnly}
-              onBlur={runImmediateDestinationValidation}
             />
-
-            {/* SNS resolution feedback */}
-            {snsResolving && (
-              <div className="mt-1.5 flex items-center gap-1.5 text-xs text-slate-400">
-                <div className="w-3 h-3 border border-stellar-400 border-t-transparent rounded-full animate-spin" />
-                Resolving…
-              </div>
-            )}
-            {!snsResolving && snsResolved && (
-              <p className="mt-1.5 text-xs text-slate-400">
-                Resolves to: <span className="font-mono text-stellar-300">{snsResolved}</span> ✓
-              </p>
-            )}
-            {!snsResolving && snsError && (
-              <p className="mt-1.5 text-xs text-red-400">{snsError}</p>
-            )}
-
-            {destinationResolutionError && (
-              <p className="mt-2 text-xs text-red-400">{destinationResolutionError}</p>
-            )}
 
             {/* SNS resolution feedback */}
             {snsResolving && (
@@ -1016,10 +919,17 @@ function SendPaymentForm({
                 <span>Resolving name…</span>
               </div>
             )}
-            {!snsResolving && snsResolvedAddress && (
+            {!snsResolving && snsResolved && (
               <p className="mt-2 text-xs text-emerald-400" aria-live="polite">
-                Resolves to: <span className="font-mono">{snsResolvedAddress}</span>
+                Resolves to: <span className="font-mono">{snsResolved}</span>
               </p>
+            )}
+            {!snsResolving && snsError && (
+              <p className="mt-2 text-xs text-red-400" aria-live="polite">{snsError}</p>
+            )}
+
+            {destinationResolutionError && (
+              <p className="mt-2 text-xs text-red-400">{destinationResolutionError}</p>
             )}
 
             {/* Destination account existence warning (#294) */}


### PR DESCRIPTION
Description:

Rapid destination edits could let a slow older resolution overwrite
whatever the user had typed by the time it came back. Fixed by adding
a generation counter — each keypress increments it and any response
that arrives for a stale generation is dropped.

Also cleaned up the component while in here. There were two completely
separate SNS resolution paths running in parallel (a useEffect and an
onChange handler) with different debounce timings, separate state
variables (snsResolved vs snsResolvedAddress), and two sets of spinner
and resolved-address UI blocks rendering at the same time. Consolidated
everything into the single useEffect path.

Also removed dangling references to validateDestinationAccount and
related refs that didn't exist anywhere, which were crashing the
component on every render.

All 10 SNS tests pass including two new ones covering the stale
response and rapid valid/invalid/valid scenarios.

Closes #731 