### PR TITLE
Enforce frontend security headers for static export

### DIFF
--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -1,0 +1,32 @@
+# Frontend security headers
+
+The frontend is a Next.js static export. Next.js `headers()` configuration is
+not emitted into static files, so production headers must be added by the HTTP
+server that returns those files.
+
+Both supported production paths enforce the same policy:
+
+- `nginx/nginx.conf` covers the Compose edge proxy.
+- `frontend/nginx.conf` is copied into the standalone frontend image by
+  `frontend/Dockerfile.prod`.
+
+After deploying, verify the actual public response rather than only inspecting
+configuration:
+
+```bash
+cd frontend
+npm run check:security-headers -- https://your-deployment.example
+```
+
+The command follows redirects, rejects unsuccessful responses, and fails when
+required headers or critical CSP directives are missing. Run it against the
+final HTTPS URL so CDN, load-balancer, and proxy behavior is included.
+
+`next dev` is intentionally different: it does not use Nginx and does not add
+the production policy because Next development tooling requires behavior that
+the production CSP restricts. Local production verification should build the
+Docker image, publish a port, then run the same checker against that URL.
+
+The header policy is network-neutral: testnet and mainnet selection changes
+Stellar endpoints but not browser security headers. Review CSP `connect-src`
+when narrowing allowed Horizon or API origins.

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -16,6 +16,7 @@ FROM nginx:alpine
 
 # Copy built static files from build stage
 COPY --from=builder /app/out /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 80
 EXPOSE 80

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,51 +5,11 @@ if (process.env.npm_lifecycle_event !== "lint") {
   validateEnv();
 }
 
-const isProduction = process.env.NODE_ENV === "production";
-
-function buildContentSecurityPolicy() {
-  const scriptSrc = ["'self'"];
-  if (!isProduction) {
-    // Next.js dev tooling relies on eval-based sourcemaps/HMR.
-    scriptSrc.push("'unsafe-eval'");
-  }
-
-  const directives = [
-    "default-src 'self'",
-    `script-src ${scriptSrc.join(" ")}`,
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' data: https://fonts.gstatic.com",
-    "img-src 'self' data: blob:",
-    "connect-src 'self' http: https: ws: wss:",
-    "worker-src 'self' blob:",
-    "manifest-src 'self'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "object-src 'none'",
-    "frame-ancestors 'self'",
-  ];
-
-  return directives.join("; ");
-}
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   // Required for the production Docker image (copies only what's needed)
   output: "export",
-  async headers() {
-    return [
-      {
-        source: "/:path*",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: buildContentSecurityPolicy(),
-          },
-        ],
-      },
-    ];
-  },
   // Allow Stellar SDK in browser
   webpack: (config) => {
     config.resolve.fallback = {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' http: https: ws: wss:; worker-src 'self' blob:; manifest-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'self';" always;
+
+    location / {
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'OK';
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "jest --runInBand",
+    "test:security-headers": "node --test scripts/security-headers.test.mjs",
+    "check:security-headers": "node scripts/check-security-headers.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",

--- a/frontend/scripts/check-security-headers.mjs
+++ b/frontend/scripts/check-security-headers.mjs
@@ -1,0 +1,31 @@
+import { validateSecurityHeaders } from './security-headers.mjs';
+
+const target = process.argv[2] || process.env.SECURITY_HEADERS_URL;
+if (!target) {
+  console.error('Usage: npm run check:security-headers -- https://example.com');
+  process.exit(2);
+}
+
+let url;
+try {
+  url = new URL(target);
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('unsupported protocol');
+} catch {
+  console.error(`Invalid deployment URL: ${target}`);
+  process.exit(2);
+}
+
+try {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok) throw new Error(`response status ${response.status}`);
+  const failures = validateSecurityHeaders(response.headers);
+  if (failures.length) {
+    console.error(`Security header check failed for ${response.url}:\n- ${failures.join('\n- ')}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`Security headers verified at ${response.url}`);
+  }
+} catch (error) {
+  console.error(`Could not verify ${url}: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/frontend/scripts/security-headers.mjs
+++ b/frontend/scripts/security-headers.mjs
@@ -1,0 +1,23 @@
+export const REQUIRED_SECURITY_HEADERS = {
+  'content-security-policy': ["default-src 'self'", "object-src 'none'", "frame-ancestors 'self'"],
+  'x-content-type-options': ['nosniff'],
+  'x-frame-options': ['SAMEORIGIN'],
+  'referrer-policy': ['strict-origin-when-cross-origin'],
+  'permissions-policy': ['camera=()', 'microphone=()', 'geolocation=()'],
+  'cross-origin-opener-policy': ['same-origin'],
+};
+
+export function validateSecurityHeaders(headers) {
+  const failures = [];
+  for (const [name, expectedParts] of Object.entries(REQUIRED_SECURITY_HEADERS)) {
+    const value = headers.get(name);
+    if (!value) {
+      failures.push(`${name}: missing`);
+      continue;
+    }
+    for (const expected of expectedParts) {
+      if (!value.includes(expected)) failures.push(`${name}: missing ${expected}`);
+    }
+  }
+  return failures;
+}

--- a/frontend/scripts/security-headers.test.mjs
+++ b/frontend/scripts/security-headers.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateSecurityHeaders } from './security-headers.mjs';
+
+const valid = {
+  'content-security-policy': "default-src 'self'; object-src 'none'; frame-ancestors 'self'",
+  'x-content-type-options': 'nosniff',
+  'x-frame-options': 'SAMEORIGIN',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'permissions-policy': 'camera=(), microphone=(), geolocation=(), payment=()',
+  'cross-origin-opener-policy': 'same-origin',
+};
+
+test('accepts a complete deployed header policy', () => {
+  assert.deepEqual(validateSecurityHeaders(new Headers(valid)), []);
+});
+
+test('reports missing headers', () => {
+  assert.deepEqual(validateSecurityHeaders(new Headers()), Object.keys(valid).map((name) => `${name}: missing`));
+});
+
+test('reports incomplete CSP and permissions policies', () => {
+  const headers = new Headers(valid);
+  headers.set('content-security-policy', "default-src 'self'");
+  headers.set('permissions-policy', 'camera=()');
+  const failures = validateSecurityHeaders(headers);
+  assert.ok(failures.includes("content-security-policy: missing object-src 'none'"));
+  assert.ok(failures.includes('permissions-policy: missing microphone=()'));
+});

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,9 +17,11 @@ http {
 
     # Security Headers
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' http: https: ws: wss:; worker-src 'self' blob:; manifest-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'self';" always;
 
     server {


### PR DESCRIPTION
## Summary

Moves frontend browser security headers out of ineffective Next.js static-export configuration and into the Nginx servers that actually return production responses. It also adds an integration checker for verifying the final deployed response after proxies, CDNs, and redirects.

## Issue

Closes #818

## Root cause and user impact

The frontend uses `output: "export"`, which produces static files and cannot attach runtime headers through Next.js `headers()`. Although the Compose edge proxy had a partial policy, the standalone frontend image used Nginx's default configuration and could serve the export without CSP or related protections.

## Changes

- Remove the ineffective Next.js `headers()` hook while retaining static export.
- Apply consistent CSP, framing, MIME-sniffing, referrer, permissions, opener, and HSTS policies at the Compose edge proxy.
- Add a dedicated Nginx configuration to the standalone production frontend image.
- Add a dependency-free deployed-response checker that follows redirects and fails on HTTP errors, missing headers, or incomplete critical directives.
- Add focused primary, missing-header, and incomplete-policy tests.
- Document local-development differences, both production hosting paths, deployment verification, and network-neutral behavior.

## Validation

- `node --test frontend/scripts/security-headers.test.mjs` — 3 tests passed.
- `git diff --check` — passed.
- A live deployment URL was not available, so the integration checker itself was tested but not run against production.
- Full CI/build/lint was intentionally not run because upstream `main` has known unrelated baseline failures.

## Deployment notes

After deployment, run `npm run check:security-headers -- https://deployment.example` from `frontend`. The check must target the final public HTTPS URL so every serving layer is included.
