### PR TITLE
[codex] split Stellar helpers into domain modules

### DIFF
--- a/frontend/__tests__/stellar-modules.test.ts
+++ b/frontend/__tests__/stellar-modules.test.ts
@@ -1,0 +1,40 @@
+import {
+  STELLAR_BASE_FEE_STROOPS as legacyBaseFee,
+  TransactionCategory as LegacyTransactionCategory,
+  USDC as legacyUsdc,
+  calculateMinimumBalance as legacyMinimumBalance,
+  truncateMemoText as legacyTruncateMemoText,
+  type PaymentHistoryResponse as LegacyPaymentHistoryResponse,
+} from "@/lib/stellar";
+import {
+  STELLAR_BASE_FEE_STROOPS,
+  calculateMinimumBalance,
+  truncateMemoText,
+} from "@/lib/stellar/protocol";
+import { USDC } from "@/lib/stellar/assets";
+import {
+  TransactionCategory,
+  type PaymentHistoryResponse,
+} from "@/lib/stellar/types";
+
+describe("Stellar domain module compatibility", () => {
+  it("keeps legacy runtime exports bound to the extracted modules", () => {
+    expect(legacyBaseFee).toBe(STELLAR_BASE_FEE_STROOPS);
+    expect(legacyMinimumBalance).toBe(calculateMinimumBalance);
+    expect(legacyTruncateMemoText).toBe(truncateMemoText);
+    expect(LegacyTransactionCategory).toBe(TransactionCategory);
+    expect(legacyUsdc).toBe(USDC);
+  });
+
+  it("keeps extracted pure helpers behaviorally compatible", () => {
+    expect(calculateMinimumBalance(3)).toBe(2.5);
+    expect(truncateMemoText("😀".repeat(8))).toBe("😀".repeat(7));
+  });
+
+  it("keeps shared payment contracts assignable through either entry point", () => {
+    const response: PaymentHistoryResponse = { records: [], hasMore: false };
+    const legacyResponse: LegacyPaymentHistoryResponse = response;
+
+    expect(legacyResponse).toEqual(response);
+  });
+});

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -41,6 +41,30 @@ import {
 } from "./stellarConfig";
 
 import { apiFetch } from "./api";
+import {
+  STELLAR_BASE_FEE_STROOPS,
+  STELLAR_STROOPS_PER_XLM,
+  STELLAR_TRANSACTION_TIMEOUT_SECONDS,
+  calculateMinimumBalance,
+  truncateMemoText,
+} from "./stellar/protocol";
+import { USDC, USDC_ISSUER } from "./stellar/assets";
+import {
+  TransactionCategory,
+  type AccountReserveInfo,
+  type FetchAllPaymentsProgress,
+  type FundingPollOptions,
+  type PaymentHistoryResponse,
+  type PaymentRecord,
+  type PaymentStreamHandler,
+  type PaymentStreamUnsubscribe,
+  type Trustline,
+  type WalletBalance,
+} from "./stellar/types";
+
+export * from "./stellar/protocol";
+export * from "./stellar/assets";
+export * from "./stellar/types";
 
 export {
   server,
@@ -55,92 +79,8 @@ export {
   NETWORK_PASSPHRASE,
 };
 
-/** One XLM is divided into 10,000,000 stroops, Stellar's smallest unit. */
-export const STELLAR_STROOPS_PER_XLM = 10_000_000;
-
-/** Stellar's protocol minimum operation fee is 100 stroops. */
-export const STELLAR_BASE_FEE_STROOPS = 100;
-
-/** Default network fee in XLM, derived from the base fee in stroops. */
-export const STELLAR_BASE_FEE_XLM =
-  STELLAR_BASE_FEE_STROOPS / STELLAR_STROOPS_PER_XLM;
-
-/** Transactions built for wallet signing expire after 60 seconds. */
-export const STELLAR_TRANSACTION_TIMEOUT_SECONDS = 60;
-
-/** Stellar MEMO_TEXT values are capped at 28 UTF-8 bytes by the protocol. */
-export const STELLAR_MEMO_TEXT_MAX_BYTES = 28;
-
-/** A base Stellar account must keep two reserve units before subentries. */
-export const STELLAR_BASE_ACCOUNT_RESERVE_COUNT = 2;
-
-/**
- * Stellar base reserve in XLM.
- *
- * Each account holds (2 + subentry_count) base reserves of 0.5 XLM. Trustlines,
- * offers, signers, and data entries each count as one subentry.
- *
- * @see https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/accounts#base-reserves
- */
-export const STELLAR_BASE_RESERVE_XLM = 0.5;
-
-/** Minimum XLM balance for an account with no subentries. */
-export const STELLAR_MINIMUM_ACCOUNT_BALANCE_XLM =
-  STELLAR_BASE_ACCOUNT_RESERVE_COUNT * STELLAR_BASE_RESERVE_XLM;
-
 const STELLAR_BASE_FEE_STROOPS_STRING = String(STELLAR_BASE_FEE_STROOPS);
 const ELEVATED_FEE_MAX_STROOPS = STELLAR_BASE_FEE_STROOPS * 10;
-
-/** Truncate a memo string so its UTF-8 encoding fits within the Stellar MEMO_TEXT byte limit. */
-export function truncateMemoText(memo: string): string {
-  const encoder = new TextEncoder();
-  if (encoder.encode(memo).length <= STELLAR_MEMO_TEXT_MAX_BYTES) {
-    return memo;
-  }
-
-  let truncated = "";
-  for (const char of memo) {
-    const next = truncated + char;
-    if (encoder.encode(next).length > STELLAR_MEMO_TEXT_MAX_BYTES) {
-      break;
-    }
-    truncated = next;
-  }
-
-  return truncated;
-}
-
-/**
- * USDC issuer (Circle) for the active network.
- *
- * If you intend to use USDC features on testnet, set `NEXT_PUBLIC_USDC_ISSUER`.
- */
-export const USDC_ISSUER =
-  process.env.NEXT_PUBLIC_USDC_ISSUER ||
-  // Default to mainnet Circle issuer. (App can still run without USDC usage.)
-  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
-
-/** USDC asset helper. */
-export const USDC = new Asset("USDC", USDC_ISSUER);
-
-/** Known assets for trustline management. */
-export const KNOWN_ASSETS = {
-  testnet: [
-    { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
-    { code: "AQUA", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA7" }, // Example issuer
-    { code: "yXLM", issuer: "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55" }, // Example issuer
-  ],
-  mainnet: [
-    { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
-    { code: "AQUA", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA7" }, // Example issuer
-    { code: "yXLM", issuer: "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55" }, // Example issuer
-  ],
-};
-
-/** Get known assets for the current network. */
-export function getKnownAssets() {
-  return KNOWN_ASSETS[NETWORK];
-}
 
 /** Soroban RPC server URL. Defaults to testnet. */
 export function getSorobanRpcUrl(): string {
@@ -180,83 +120,6 @@ export const sorobanServer = new Proxy({} as rpc.Server, {
 /** The deployed Soroban contract ID for recording tips. */
 export const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID || "";
 
-// ─── Types ─────────────────────────────────────────────────────────────────
-
-/**
- * Enum for transaction categories.
- */
-export enum TransactionCategory {
-  Payment = "Payment",
-  Transfer = "Transfer",
-  Merge = "Merge",
-  // Add more as needed
-}
-
-/**
- * Represents a single asset balance on a Stellar account.
-*/
-export interface WalletBalance {
-  /** Full asset identifier, e.g. `"native"` or `"USDC:GA5ZSEJY..."` */
-  asset: string;
-  /** Human-readable balance string, e.g. `"100.0000000"` */
-  balance: string;
-  /** Short asset code shown in the UI, e.g. `"XLM"` or `"USDC"` */
-  assetCode: string;
-}
-
-/**
- * Represents a trustline for a non-native asset.
- */
-export interface Trustline {
-  /** Asset code, e.g. "USDC" */
-  assetCode: string;
-  /** Asset issuer public key */
-  issuer: string;
-  /** Current balance */
-  balance: string;
-  /** Trust limit */
-  limit: string;
-}
-/**
- * Represents a single transaction operation in a user's transaction history.
-*/
-export interface PaymentRecord {
-  /** Unique operation ID assigned by Horizon. */
-  id: string;
-  /** Whether this payment was sent or received by the queried account. */
-  type: "sent" | "received" | "merge";
-  /** Whether this payment was sent or received by the queried account. */
-  amount: string;
-  /** Asset code, e.g. `"XLM"` */
-  asset: string;
-  /** Sender's Stellar public key. */
-  from: string;
-  /** Recipient's Stellar public key. */
-  to: string;
-  /** Optional memo text attached to the transaction. */
-  memo?: string;
-  /** ISO 8601 timestamp of when the operation was created. */
-  createdAt: string;
-  /** Hash of the parent transaction. */
-  transactionHash: string;
-  /** Horizon paging token used for cursor-based pagination. */
-  pagingToken?: string;
-  /** Category of the transaction. */
-  category?: TransactionCategory;
-}
-
-/**
- * Response shape returned by {@link getPaymentHistory}.
-*/
-export interface PaymentHistoryResponse {
-  /** Array of payment records for the requested page. */
-  records: PaymentRecord[];
-  /** Whether more records are available on the next page. */
-  hasMore: boolean;
-  /** Cursor string to pass into the next {@link getPaymentHistory} call. */
-  nextCursor?: string;
-}
-
 // DEX Types
 export interface OrderbookEntry {
   price: string;
@@ -279,22 +142,6 @@ export interface NetworkStats {
   p99Fee: number;
 }
 
-export interface FetchAllPaymentsProgress {
-  fetchedRecords: number;
-  fetchedPages: number;
-  done: boolean;
-}
-
-/**
- * Handle function invoked for each streamed payment operation.
- */
-export type PaymentStreamHandler = (payment: PaymentRecord) => void;
-
-/**
- * Function returned by {@link streamPayments} to stop the underlying EventSource.
- */
-export type PaymentStreamUnsubscribe = () => void;
-
 // ─── Account helpers ────────────────────────────────────────────────────────
 
 /** Sentinel error message used to detect unfunded accounts in the UI. */
@@ -303,12 +150,6 @@ export const ACCOUNT_NOT_FOUND_ERROR = "ACCOUNT_NOT_FOUND";
 /** Friendbot endpoint for Stellar testnet funding. */
 export const FRIENDBOT_URL =
   process.env.NEXT_PUBLIC_FRIENDBOT_URL || "https://friendbot.stellar.org";
-
-/** Polling options for waiting until an account exists on Horizon. */
-export interface FundingPollOptions {
-  intervalMs?: number;
-  timeoutMs?: number;
-}
 
 /**
  * Fetch all trustlines (non-native asset balances) for a Stellar account.
@@ -457,30 +298,6 @@ export async function getXLMBalance(publicKey: string): Promise<string> {
   const balances = await getBalances(publicKey);
   const xlm = balances.find((b: WalletBalance) => b.assetCode === "XLM");
   return xlm ? xlm.balance : "0";
-}
-
-/**
- * Returns the minimum XLM balance required for an account with the given
- * subentry count.
- */
-export function calculateMinimumBalance(subentryCount: number): number {
-  const safeSubentryCount = Number.isFinite(subentryCount) && subentryCount >= 0
-    ? subentryCount
-    : 0;
-  return (
-    STELLAR_BASE_ACCOUNT_RESERVE_COUNT + safeSubentryCount
-  ) * STELLAR_BASE_RESERVE_XLM;
-}
-
-export interface AccountReserveInfo {
-  /** Total XLM held by the account (native balance). */
-  xlmBalance: number;
-  /** Number of subentries on the account (trustlines + offers + signers + data). */
-  subentryCount: number;
-  /** Minimum balance the account must keep to remain submittable. */
-  minimumBalance: number;
-  /** XLM available to spend without breaching the reserve. */
-  spendableBalance: number;
 }
 
 /**

--- a/frontend/lib/stellar/README.md
+++ b/frontend/lib/stellar/README.md
@@ -1,0 +1,12 @@
+# Stellar domain modules
+
+`lib/stellar.ts` remains the compatibility entry point. New code may import the
+smaller modules directly:
+
+- `stellar/protocol` contains network-independent protocol constants and pure helpers.
+- `stellar/types` contains stable shared account and payment contracts.
+- `stellar/assets` contains configured asset definitions.
+
+Domain modules must not import `lib/stellar.ts`; dependencies flow from the legacy
+barrel into these modules. This rule prevents circular imports while functionality
+is migrated incrementally. Existing imports from `@/lib/stellar` remain supported.

--- a/frontend/lib/stellar/assets.ts
+++ b/frontend/lib/stellar/assets.ts
@@ -1,0 +1,30 @@
+import { Asset } from "@stellar/stellar-sdk";
+import { NETWORK } from "../stellarConfig";
+
+export interface KnownAsset {
+  code: string;
+  issuer: string;
+}
+
+export const USDC_ISSUER =
+  process.env.NEXT_PUBLIC_USDC_ISSUER ||
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+export const USDC = new Asset("USDC", USDC_ISSUER);
+
+export const KNOWN_ASSETS: Record<"testnet" | "mainnet", KnownAsset[]> = {
+  testnet: [
+    { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+    { code: "AQUA", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA7" },
+    { code: "yXLM", issuer: "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55" },
+  ],
+  mainnet: [
+    { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+    { code: "AQUA", issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA7" },
+    { code: "yXLM", issuer: "GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55" },
+  ],
+};
+
+export function getKnownAssets(): KnownAsset[] {
+  return KNOWN_ASSETS[NETWORK];
+}

--- a/frontend/lib/stellar/protocol.ts
+++ b/frontend/lib/stellar/protocol.ts
@@ -1,0 +1,33 @@
+/** Stellar protocol limits and pure helpers with no network dependencies. */
+
+export const STELLAR_STROOPS_PER_XLM = 10_000_000;
+export const STELLAR_BASE_FEE_STROOPS = 100;
+export const STELLAR_BASE_FEE_XLM =
+  STELLAR_BASE_FEE_STROOPS / STELLAR_STROOPS_PER_XLM;
+export const STELLAR_TRANSACTION_TIMEOUT_SECONDS = 60;
+export const STELLAR_MEMO_TEXT_MAX_BYTES = 28;
+export const STELLAR_BASE_ACCOUNT_RESERVE_COUNT = 2;
+export const STELLAR_BASE_RESERVE_XLM = 0.5;
+export const STELLAR_MINIMUM_ACCOUNT_BALANCE_XLM =
+  STELLAR_BASE_ACCOUNT_RESERVE_COUNT * STELLAR_BASE_RESERVE_XLM;
+
+export function truncateMemoText(memo: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(memo).length <= STELLAR_MEMO_TEXT_MAX_BYTES) return memo;
+
+  let truncated = "";
+  for (const char of memo) {
+    const next = truncated + char;
+    if (encoder.encode(next).length > STELLAR_MEMO_TEXT_MAX_BYTES) break;
+    truncated = next;
+  }
+  return truncated;
+}
+
+export function calculateMinimumBalance(subentryCount: number): number {
+  const safeSubentryCount =
+    Number.isFinite(subentryCount) && subentryCount >= 0 ? subentryCount : 0;
+  return (
+    STELLAR_BASE_ACCOUNT_RESERVE_COUNT + safeSubentryCount
+  ) * STELLAR_BASE_RESERVE_XLM;
+}

--- a/frontend/lib/stellar/types.ts
+++ b/frontend/lib/stellar/types.ts
@@ -1,0 +1,61 @@
+/** Stable contracts shared by Stellar domain helpers and UI consumers. */
+
+export enum TransactionCategory {
+  Payment = "Payment",
+  Transfer = "Transfer",
+  Merge = "Merge",
+}
+
+export interface WalletBalance {
+  asset: string;
+  balance: string;
+  assetCode: string;
+}
+
+export interface Trustline {
+  assetCode: string;
+  issuer: string;
+  balance: string;
+  limit: string;
+}
+
+export interface PaymentRecord {
+  id: string;
+  type: "sent" | "received" | "merge";
+  amount: string;
+  asset: string;
+  from: string;
+  to: string;
+  memo?: string;
+  createdAt: string;
+  transactionHash: string;
+  pagingToken?: string;
+  category?: TransactionCategory;
+}
+
+export interface PaymentHistoryResponse {
+  records: PaymentRecord[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+export interface FetchAllPaymentsProgress {
+  fetchedRecords: number;
+  fetchedPages: number;
+  done: boolean;
+}
+
+export type PaymentStreamHandler = (payment: PaymentRecord) => void;
+export type PaymentStreamUnsubscribe = () => void;
+
+export interface FundingPollOptions {
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface AccountReserveInfo {
+  xlmBalance: number;
+  subentryCount: number;
+  minimumBalance: number;
+  spendableBalance: number;
+}


### PR DESCRIPTION
## Summary

Begins the incremental decomposition of the 2,000-line Stellar helper by extracting three stable domains while preserving `frontend/lib/stellar.ts` as the public compatibility entry point.

Closes #843.

## Problem and user impact

Account, payment, asset, protocol, DEX, federation, streaming, and Soroban behavior currently share one module. That coupling makes changes harder to review, increases merge-conflict risk, and gives frontend consumers no narrow contract to import.

The public barrel is already widely used, so removing or renaming its exports during the migration would break existing pages, tests, and downstream code.

## Root cause

Protocol primitives, configured assets, and cross-domain TypeScript contracts were declared alongside network operations. There was no documented dependency direction for extracting domains safely, so new behavior continued accumulating in the same file.

## Changes

- added `stellar/protocol.ts` for network-independent protocol constants, memo truncation, and reserve calculation
- added `stellar/assets.ts` for USDC and known-asset configuration
- added `stellar/types.ts` for stable account and payment interfaces and transaction categories
- changed `stellar.ts` to consume and re-export those modules, preserving all existing import paths and runtime identities
- documented direct module imports and the one-way dependency rule that prevents domain modules from importing the legacy barrel
- added compatibility coverage for runtime re-exports, pure-helper behavior, enum identity, asset identity, and type assignability

This is intentionally an incremental seam: network-heavy account, transaction, DEX, federation, streaming, escrow, and Soroban behavior remains in the compatibility module for later focused migrations.

## Network behavior

No Horizon, Soroban, testnet, or mainnet behavior changed. `stellar/assets.ts` continues reading the same normalized `NETWORK` value from `stellarConfig`, and protocol helpers remain network-independent.

## Validation

- `git diff --check` passed
- verified extracted domain modules do not import `frontend/lib/stellar.ts`, preventing circular barrel dependencies
- focused test added at `frontend/__tests__/stellar-modules.test.ts`
- focused Jest execution was not run because dependencies are not installed in the isolated worktree
- full CI, build, lint, typecheck, and dependency installation were intentionally not run because upstream `main` has known baseline CI failures
