### PR TITLE
[codex] Prevent SSRF in federation forwarding

### DIFF
--- a/backend/__tests__/federationSsrf.test.js
+++ b/backend/__tests__/federationSsrf.test.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const dns = require("node:dns");
+
+const axios = require("axios");
+
+const {
+  UnsafeNetworkTargetError,
+  buildDiscoveryUrl,
+  isPublicAddress,
+  parseSecureUrl,
+  secureGet,
+} = require("../src/services/secureHttpClient");
+
+jest.mock("axios");
+
+describe("federation SSRF protection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    "10.0.0.1",
+    "127.0.0.1",
+    "169.254.169.254",
+    "172.31.255.255",
+    "192.168.1.1",
+    "::1",
+    "fe80::1",
+    "fd00:ec2::254",
+    "::ffff:127.0.0.1",
+  ])("blocks non-public address %s", address => {
+    expect(isPublicAddress(address)).toBe(false);
+  });
+
+  test.each([
+    "https://127.0.0.1/federation",
+    "https://%31%32%37.0.0.1/federation",
+    "https://2130706433/federation",
+    "https://0177.0.0.1/federation",
+    "https://0x7f000001/federation",
+    "https://[::1]/federation",
+    "https://[::ffff:127.0.0.1]/federation",
+    "https://metadata.google.internal/federation",
+  ])("rejects literal and encoded internal host %s", target => {
+    expect(() => parseSecureUrl(target)).toThrow(UnsafeNetworkTargetError);
+  });
+
+  it("requires HTTPS and rejects URL credentials", () => {
+    expect(() => parseSecureUrl("http://example.com/federation")).toThrow(
+      UnsafeNetworkTargetError
+    );
+    expect(() => parseSecureUrl("https://example.com@127.0.0.1/federation")).toThrow(
+      UnsafeNetworkTargetError
+    );
+  });
+
+  test.each(["example.com:8443", "example.com/path", "example.com?next=127.0.0.1"])(
+    "rejects non-domain discovery input %s",
+    domain => {
+      expect(() => buildDiscoveryUrl(domain)).toThrow(UnsafeNetworkTargetError);
+    }
+  );
+
+  it("rejects a hostname when any DNS answer is private", async () => {
+    jest.spyOn(dns.promises, "lookup").mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "169.254.169.254", family: 4 },
+    ]);
+
+    await expect(secureGet("https://example.com/federation")).rejects.toThrow(
+      UnsafeNetworkTargetError
+    );
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it("pins the connection to the address that passed validation", async () => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    axios.get.mockResolvedValue({ status: 200, headers: {}, data: { account_id: "G..." } });
+
+    await secureGet("https://example.com/federation");
+
+    const requestOptions = axios.get.mock.calls[0][1];
+    const callback = jest.fn();
+    requestOptions.httpsAgent.options.lookup("example.com", {}, callback);
+    expect(callback).toHaveBeenCalledWith(null, "93.184.216.34", 4);
+    expect(requestOptions.maxRedirects).toBe(0);
+    expect(requestOptions.proxy).toBe(false);
+  });
+
+  it("resolves and revalidates DNS again for every redirect", async () => {
+    const lookup = jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValueOnce([{ address: "127.0.0.1", family: 4 }]);
+    axios.get.mockResolvedValueOnce({
+      status: 302,
+      headers: { location: "/moved" },
+      data: "",
+    });
+
+    await expect(secureGet("https://example.com/federation")).rejects.toThrow(
+      UnsafeNetworkTargetError
+    );
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects redirects to encoded internal IP addresses before connecting", async () => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    axios.get.mockResolvedValueOnce({
+      status: 302,
+      headers: { location: "https://0x7f000001/latest/meta-data" },
+      data: "",
+    });
+
+    await expect(secureGet("https://example.com/federation")).rejects.toThrow(
+      UnsafeNetworkTargetError
+    );
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/controllers/federationController.js
+++ b/backend/src/controllers/federationController.js
@@ -5,7 +5,11 @@
 
 "use strict";
 
-const axios = require("axios");
+const {
+  buildDiscoveryUrl,
+  parseSecureUrl,
+  secureGet,
+} = require("../services/secureHttpClient");
 const usernameService = require("../services/usernameService");
 
 /**
@@ -146,8 +150,8 @@ async function forwardFederation(query, type) {
   const domain = parts[1];
 
   // Fetch stellar.toml from the domain
-  const tomlUrl = `https://${domain}/.well-known/stellar.toml`;
-  const tomlResponse = await axios.get(tomlUrl, { timeout: 5000 });
+  const tomlUrl = buildDiscoveryUrl(domain);
+  const tomlResponse = await secureGet(tomlUrl, { timeout: 5000, responseType: "text" });
   const tomlContent = tomlResponse.data;
 
   // Parse TOML to find FEDERATION_SERVER
@@ -157,8 +161,10 @@ async function forwardFederation(query, type) {
   }
 
   // Make request to external federation server
-  const federationUrl = `${federationServer}?q=${encodeURIComponent(query)}&type=${type}`;
-  const response = await axios.get(federationUrl, { timeout: 5000 });
+  const federationUrl = parseSecureUrl(federationServer);
+  federationUrl.searchParams.set("q", query);
+  federationUrl.searchParams.set("type", type);
+  const response = await secureGet(federationUrl, { timeout: 5000 });
 
   return response.data;
 }

--- a/backend/src/services/secureHttpClient.js
+++ b/backend/src/services/secureHttpClient.js
@@ -1,0 +1,207 @@
+"use strict";
+
+const dns = require("node:dns");
+const https = require("node:https");
+const net = require("node:net");
+
+const axios = require("axios");
+
+const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+class UnsafeNetworkTargetError extends Error {
+  constructor(message = "External federation target is not allowed") {
+    super(message);
+    this.name = "UnsafeNetworkTargetError";
+    this.status = 400;
+  }
+}
+
+function ipv4ToNumber(address) {
+  return address
+    .split(".")
+    .reduce((value, octet) => (value << 8n) | BigInt(Number(octet)), 0n);
+}
+
+function isInIpv4Cidr(address, base, prefix) {
+  const bits = 32n;
+  const shift = bits - BigInt(prefix);
+  return (ipv4ToNumber(address) >> shift) === (ipv4ToNumber(base) >> shift);
+}
+
+function expandIpv6(address) {
+  let value = address.toLowerCase();
+  const ipv4Match = value.match(/(\d+\.\d+\.\d+\.\d+)$/);
+  if (ipv4Match) {
+    const ipv4 = ipv4ToNumber(ipv4Match[1]);
+    value = `${value.slice(0, ipv4Match.index)}${(ipv4 >> 16n).toString(16)}:${(
+      ipv4 & 0xffffn
+    ).toString(16)}`;
+  }
+
+  const sides = value.split("::");
+  const left = sides[0] ? sides[0].split(":") : [];
+  const right = sides[1] ? sides[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  return [...left, ...Array(Math.max(0, missing)).fill("0"), ...right].map(part =>
+    Number.parseInt(part || "0", 16)
+  );
+}
+
+function ipv6ToBigInt(address) {
+  return expandIpv6(address).reduce((value, part) => (value << 16n) | BigInt(part), 0n);
+}
+
+function isPublicIpv4(address) {
+  const blockedCidrs = [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.0.0.0", 24],
+    ["192.0.2.0", 24],
+    ["192.88.99.0", 24],
+    ["192.168.0.0", 16],
+    ["198.18.0.0", 15],
+    ["198.51.100.0", 24],
+    ["203.0.113.0", 24],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4],
+  ];
+
+  return !blockedCidrs.some(([base, prefix]) => isInIpv4Cidr(address, base, prefix));
+}
+
+function isPublicIpv6(address) {
+  const value = ipv6ToBigInt(address);
+  const globalUnicastPrefix = value >> 125n;
+
+  // Only globally routable 2000::/3 addresses are valid federation targets.
+  if (globalUnicastPrefix !== 1n) return false;
+
+  // Documentation addresses must never become federation destinations.
+  const documentationBase = ipv6ToBigInt("2001:db8::");
+  return value >> 96n !== documentationBase >> 96n;
+}
+
+function isPublicAddress(address) {
+  const normalized = String(address).replace(/^\[|\]$/g, "").split("%")[0];
+  const family = net.isIP(normalized);
+  if (family === 4) return isPublicIpv4(normalized);
+  if (family === 6) return isPublicIpv6(normalized);
+  return false;
+}
+
+function parseSecureUrl(input) {
+  let url;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new UnsafeNetworkTargetError("External federation target is invalid");
+  }
+
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new UnsafeNetworkTargetError("External federation targets must use HTTPS");
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (
+    !hostname ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".home.arpa")
+  ) {
+    throw new UnsafeNetworkTargetError();
+  }
+
+  // WHATWG URL parsing canonicalizes decimal, octal, hexadecimal and percent-
+  // encoded IP hosts, so alternate spellings cannot bypass this check.
+  if (net.isIP(hostname) && !isPublicAddress(hostname)) {
+    throw new UnsafeNetworkTargetError();
+  }
+
+  return url;
+}
+
+function buildDiscoveryUrl(domain) {
+  const rawDomain = String(domain).trim();
+  const origin = parseSecureUrl(`https://${rawDomain}/`);
+  if (origin.port || origin.pathname !== "/" || origin.search || origin.hash) {
+    throw new UnsafeNetworkTargetError("Federation address domain is invalid");
+  }
+
+  return new URL("/.well-known/stellar.toml", origin);
+}
+
+async function resolvePublicAddresses(hostname) {
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new UnsafeNetworkTargetError("External federation target could not be resolved");
+  }
+
+  if (!addresses.length || addresses.some(result => !isPublicAddress(result.address))) {
+    throw new UnsafeNetworkTargetError();
+  }
+
+  return addresses;
+}
+
+async function requestOnce(url, options) {
+  // Resolve immediately before this hop and pin the socket lookup to the vetted
+  // address. This removes the validation/connect race used by DNS rebinding.
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const addresses = await resolvePublicAddresses(hostname);
+  const selected = addresses[0];
+  const agent = new https.Agent({
+    lookup: (_hostname, _options, callback) => {
+      callback(null, selected.address, selected.family);
+    },
+  });
+
+  try {
+    return await axios.get(url.toString(), {
+      ...options,
+      httpAgent: undefined,
+      httpsAgent: agent,
+      maxRedirects: 0,
+      proxy: false,
+      validateStatus: status =>
+        (status >= 200 && status < 300) || REDIRECT_STATUSES.has(status),
+    });
+  } finally {
+    agent.destroy();
+  }
+}
+
+async function secureGet(input, options = {}) {
+  let url = parseSecureUrl(input);
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+    const response = await requestOnce(url, options);
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+    if (redirectCount === MAX_REDIRECTS || !response.headers.location) {
+      throw new UnsafeNetworkTargetError("External federation redirect was invalid");
+    }
+
+    url = parseSecureUrl(new URL(response.headers.location, url).toString());
+  }
+
+  throw new UnsafeNetworkTargetError("Too many external federation redirects");
+}
+
+module.exports = {
+  MAX_REDIRECTS,
+  UnsafeNetworkTargetError,
+  buildDiscoveryUrl,
+  isPublicAddress,
+  parseSecureUrl,
+  resolvePublicAddresses,
+  secureGet,
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -250,6 +250,13 @@ FEDERATION_SERVER="http://localhost:4000/federation"
 
 SEP-0002 federation resolver. Subject to **read-only** rate limit.
 
+External `type=name` lookups use the public network only. Both the discovery
+document and advertised federation endpoint must use HTTPS. Every DNS answer is
+checked for private, loopback, link-local, reserved, and metadata addresses,
+and the same validation is repeated and socket-pinned for every redirect. This
+behavior is independent of Stellar testnet/mainnet selection because federation
+discovery is a DNS/HTTPS protocol rather than a Horizon network operation.
+
 **Query parameters**
 
 | Name | Type | Required | Description |


### PR DESCRIPTION
## Summary

Federation forwarding previously sent two server-side HTTP requests to locations ultimately derived from a user-provided federation domain: the domain's `stellar.toml` and the `FEDERATION_SERVER` advertised by that document. Those requests relied on Axios redirect handling and did not validate DNS results, allowing a crafted lookup to target loopback, private, link-local, metadata, or other non-public services.

This PR introduces a narrowly scoped secure HTTPS client for external federation traffic and uses it for both discovery and forwarding.

## Root cause and user impact

The application constructed the discovery URL directly and then followed the remote document's federation URL without enforcing a public-network boundary. URL-string checks alone would not be sufficient because alternate IPv4 encodings, IPv6 forms, redirects, mixed DNS answers, and DNS rebinding can change the actual socket destination.

An attacker able to invoke external federation resolution could therefore make the backend probe services that are not intended to be reachable from the public API, including cloud metadata endpoints.

## Changes

- Require HTTPS for both `stellar.toml` discovery and advertised federation endpoints.
- Reject URL credentials, malformed discovery domains, non-standard discovery ports, and internal hostname suffixes.
- Canonicalize URLs before checking literal hosts so percent-encoded, decimal, octal, hexadecimal, IPv4-mapped IPv6, and other alternate IP spellings cannot bypass validation.
- Resolve every hostname immediately before each outbound request and reject the entire answer set if any result is private, loopback, link-local, reserved, documentation-only, multicast, or otherwise non-public.
- Disable proxy routing and automatic redirects for these requests.
- Pin each HTTPS agent's socket lookup to the address that was validated, removing the DNS validation/connect race used by rebinding attacks.
- Follow redirects explicitly with a bounded redirect count, reparsing and re-resolving every hop, including same-host redirects.
- Build federation query parameters with `URLSearchParams` instead of string concatenation.
- Document that external federation is public HTTPS-only and independent of Stellar testnet/mainnet selection.

## Tests and validation

Added focused Jest coverage for:

- private, loopback, link-local, metadata, IPv6, and IPv4-mapped addresses;
- percent-encoded, decimal, octal, and hexadecimal host encodings;
- HTTPS and credential enforcement;
- mixed public/private DNS answers;
- socket address pinning;
- DNS rebinding across redirects; and
- redirects to encoded internal destinations.

Validation performed:

- `node --check backend/src/services/secureHttpClient.js`
- `node --check backend/src/controllers/federationController.js`
- `node --check backend/__tests__/federationSsrf.test.js`
- focused dependency-free SSRF address/encoded-host assertions
- `git diff --check`

The dependency-backed Jest suite, build, lint, and full CI were intentionally not run because this fork's main branch has known baseline CI failures and this isolated worktree has no installed dependencies.

Closes #820
