### PR TITLE
fix(tipsService): make tip recording idempotent by tx hash and operation index

### DIFF
--- a/backend/__tests__/tipsController.test.js
+++ b/backend/__tests__/tipsController.test.js
@@ -61,6 +61,7 @@ describe("tipsController", () => {
         asset: "XLM",
         memo: "Great work!",
         txHash: "abc123hash",
+        operationIndex: 0,
       });
 
       expect(res.status).toHaveBeenCalledWith(201);
@@ -108,6 +109,7 @@ describe("tipsController", () => {
         asset: "XLM",
         memo: "",
         txHash: "",
+        operationIndex: 0,
       });
     });
 
@@ -125,6 +127,78 @@ describe("tipsController", () => {
       await tipsController.recordTip(req, res, next);
 
       expect(next).toHaveBeenCalledWith(validationError);
+    });
+  });
+
+  describe("Idempotent tip recording", () => {
+    it("returns 200 with the existing record when tipsService reports a duplicate", async () => {
+      req.body = {
+        senderPublicKey: "GABC123456789012345678901234567890123456789012345678",
+        creatorPublicKey: "GDEF456789012345678901234567890123456789012345678901",
+        amount: "10.5",
+        txHash: "abc123hash",
+        operationIndex: 0,
+      };
+
+      const existingTip = {
+        id: 1,
+        senderPublicKey: req.body.senderPublicKey,
+        creatorPublicKey: req.body.creatorPublicKey,
+        amount: req.body.amount,
+        txHash: req.body.txHash,
+        operationIndex: 0,
+        isDuplicate: true,
+        timestamp: new Date().toISOString(),
+      };
+
+      tipsService.validateTipInput.mockImplementation(() => {});
+      tipsService.recordTip.mockReturnValue(existingTip);
+
+      await tipsController.recordTip(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: existingTip,
+        message: "Tip already recorded",
+      });
+    });
+
+    it("passes operationIndex through to tipsService.recordTip", async () => {
+      req.body = {
+        senderPublicKey: "GABC123456789012345678901234567890123456789012345678",
+        creatorPublicKey: "GDEF456789012345678901234567890123456789012345678901",
+        amount: "10.5",
+        txHash: "abc123hash",
+        operationIndex: 2,
+      };
+
+      tipsService.validateTipInput.mockImplementation(() => {});
+      tipsService.recordTip.mockReturnValue({ id: 1, isDuplicate: false });
+
+      await tipsController.recordTip(req, res, next);
+
+      expect(tipsService.recordTip).toHaveBeenCalledWith(
+        expect.objectContaining({ operationIndex: 2 })
+      );
+    });
+
+    it("defaults operationIndex to 0 when omitted", async () => {
+      req.body = {
+        senderPublicKey: "GABC123456789012345678901234567890123456789012345678",
+        creatorPublicKey: "GDEF456789012345678901234567890123456789012345678901",
+        amount: "10.5",
+        txHash: "abc123hash",
+      };
+
+      tipsService.validateTipInput.mockImplementation(() => {});
+      tipsService.recordTip.mockReturnValue({ id: 1, isDuplicate: false });
+
+      await tipsController.recordTip(req, res, next);
+
+      expect(tipsService.recordTip).toHaveBeenCalledWith(
+        expect.objectContaining({ operationIndex: 0 })
+      );
     });
   });
 

--- a/backend/__tests__/tipsService.test.js
+++ b/backend/__tests__/tipsService.test.js
@@ -19,6 +19,7 @@ describe("tipsService", () => {
   beforeEach(() => {
     // Clear in-memory storage before each test
     tipsService.tipsByCreator?.clear?.();
+    tipsService.tipsByTxHash?.clear?.();
     // Reset tip ID counter
     tipsService.tipIdCounter = 1;
   });
@@ -61,6 +62,146 @@ describe("tipsService", () => {
       });
 
       expect(tip.asset).toBe("XLM");
+    });
+  });
+
+  describe("recordTip idempotency (txHash + operationIndex)", () => {
+    it("returns the existing record when the same txHash and operationIndex are replayed", () => {
+      const first = tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-replay",
+        operationIndex: 0,
+      });
+
+      const replay = tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-replay",
+        operationIndex: 0,
+      });
+
+      expect(first.isDuplicate).toBe(false);
+      expect(replay.isDuplicate).toBe(true);
+      expect(replay.id).toBe(first.id);
+
+      const stored = tipsService.getTipsReceived(KEY_B);
+      expect(stored.total).toBe(1);
+    });
+
+    it("does not treat mismatched sender/amount as new when txHash+operationIndex replay", () => {
+      const first = tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-replay-2",
+        operationIndex: 0,
+      });
+
+      // A client replaying the same on-chain operation with slightly
+      // different metadata should still resolve to the original record.
+      const replay = tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "999.0",
+        txHash: "tx-replay-2",
+        operationIndex: 0,
+      });
+
+      expect(replay.id).toBe(first.id);
+      expect(replay.amount).toBe("10.0");
+      expect(tipsService.getTipsReceived(KEY_B).total).toBe(1);
+    });
+
+    it("treats different operationIndex values on the same txHash as distinct tips", () => {
+      tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-multi-op",
+        operationIndex: 0,
+      });
+      tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "5.0",
+        txHash: "tx-multi-op",
+        operationIndex: 1,
+      });
+
+      expect(tipsService.getTipsReceived(KEY_B).total).toBe(2);
+    });
+
+    it("treats the same operationIndex on different txHash values as distinct tips", () => {
+      tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-a",
+        operationIndex: 0,
+      });
+      tipsService.recordTip({
+        senderPublicKey: KEY_A,
+        creatorPublicKey: KEY_B,
+        amount: "10.0",
+        txHash: "tx-b",
+        operationIndex: 0,
+      });
+
+      expect(tipsService.getTipsReceived(KEY_B).total).toBe(2);
+    });
+
+    it("does not deduplicate tips recorded without a txHash", () => {
+      tipsService.recordTip({ senderPublicKey: KEY_A, creatorPublicKey: KEY_B, amount: "10.0" });
+      tipsService.recordTip({ senderPublicKey: KEY_A, creatorPublicKey: KEY_B, amount: "10.0" });
+
+      expect(tipsService.getTipsReceived(KEY_B).total).toBe(2);
+    });
+
+    it("rejects a negative operationIndex", () => {
+      expect(() =>
+        tipsService.recordTip({
+          senderPublicKey: KEY_A,
+          creatorPublicKey: KEY_B,
+          amount: "10.0",
+          txHash: "tx-bad-index",
+          operationIndex: -1,
+        })
+      ).toThrow("operationIndex must be a non-negative integer");
+    });
+
+    it("rejects a non-integer operationIndex", () => {
+      expect(() =>
+        tipsService.recordTip({
+          senderPublicKey: KEY_A,
+          creatorPublicKey: KEY_B,
+          amount: "10.0",
+          txHash: "tx-bad-index-2",
+          operationIndex: 1.5,
+        })
+      ).toThrow("operationIndex must be a non-negative integer");
+    });
+
+    it("prevents duplicate records under concurrent duplicate submissions", async () => {
+      const submit = () =>
+        Promise.resolve().then(() =>
+          tipsService.recordTip({
+            senderPublicKey: KEY_A,
+            creatorPublicKey: KEY_B,
+            amount: "10.0",
+            txHash: "tx-concurrent",
+            operationIndex: 0,
+          })
+        );
+
+      const results = await Promise.all([submit(), submit(), submit(), submit(), submit()]);
+
+      const uniqueIds = new Set(results.map((r) => r.id));
+      expect(uniqueIds.size).toBe(1);
+      expect(results.filter((r) => r.isDuplicate)).toHaveLength(4);
+      expect(tipsService.getTipsReceived(KEY_B).total).toBe(1);
     });
   });
 

--- a/backend/src/controllers/tipsController.js
+++ b/backend/src/controllers/tipsController.js
@@ -16,7 +16,9 @@ const tipsService = require("../services/tipsService");
  * @property {string} asset
  * @property {string} memo
  * @property {string} txHash
+ * @property {number} operationIndex
  * @property {string} timestamp
+ * @property {boolean} isDuplicate
  */
 
 /**
@@ -40,13 +42,15 @@ const tipsService = require("../services/tipsService");
  * @param {string} [req.body.asset] - Asset code, defaults to "XLM"
  * @param {string} [req.body.memo] - Optional message from sender
  * @param {string} [req.body.txHash] - On-chain transaction hash
+ * @param {number} [req.body.operationIndex] - Index of the payment operation within the transaction (default 0)
  * @param {object} res - Express response
  * @param {function} next - Express error-handling callback
- * @returns {Promise<void>} 201 JSON: `{ success: true, data: TipRecord, message: string }`
+ * @returns {Promise<void>} 201 JSON `{ success: true, data: TipRecord, message: string }` for a new
+ *   tip, or 200 with the pre-existing record when (txHash, operationIndex) was already recorded.
  */
 async function recordTip(req, res, next) {
   try {
-    const { senderPublicKey, creatorPublicKey, amount, asset, memo, txHash } = req.body;
+    const { senderPublicKey, creatorPublicKey, amount, asset, memo, txHash, operationIndex } = req.body;
 
     // Validate input
     tipsService.validateTipInput({ senderPublicKey, creatorPublicKey, amount });
@@ -58,7 +62,17 @@ async function recordTip(req, res, next) {
       asset: asset || "XLM",
       memo: memo || "",
       txHash: txHash || "",
+      operationIndex: operationIndex === undefined || operationIndex === null || operationIndex === "" ? 0 : operationIndex,
     });
+
+    if (tip.isDuplicate) {
+      res.status(200).json({
+        success: true,
+        data: tip,
+        message: "Tip already recorded",
+      });
+      return;
+    }
 
     res.status(201).json({
       success: true,

--- a/backend/src/services/tipsService.js
+++ b/backend/src/services/tipsService.js
@@ -10,10 +10,25 @@
 // Structure: Map<creatorPublicKey, TipRecord[]>
 const tipsByCreator = new Map();
 
+// Idempotency index: Map<"${txHash}:${operationIndex}", TipRecord>
+// Lets replayed client submissions of the same on-chain operation resolve to
+// the record that was already created instead of inserting a duplicate.
+const tipsByTxHash = new Map();
+
 // Tip record structure:
-// { id, senderPublicKey, creatorPublicKey, amount, asset, memo, timestamp, txHash }
+// { id, senderPublicKey, creatorPublicKey, amount, asset, memo, timestamp, txHash, operationIndex }
 
 let tipIdCounter = 1;
+
+/**
+ * Build the idempotency key for a Stellar transaction operation.
+ * @param {string} txHash
+ * @param {number} operationIndex
+ * @returns {string}
+ */
+function buildIdempotencyKey(txHash, operationIndex) {
+  return `${txHash}:${operationIndex}`;
+}
 
 // ── Stroop-safe arithmetic helpers ──────────────────────────────────────────
 // Stellar amounts have 7 decimal places (stroops). Using parseFloat introduces
@@ -55,19 +70,53 @@ function formatStroops(stroops) {
 
 /**
  * Record a tip sent to a creator.
+ *
+ * Idempotent when a txHash is supplied: the pair (txHash, operationIndex)
+ * uniquely identifies a Stellar operation, so a replayed submission of the
+ * same operation returns the record that was already created instead of
+ * inserting a duplicate. Callers without a txHash (e.g. legacy/off-chain
+ * records) are not deduplicated.
+ *
  * @param {string} senderPublicKey - The Stellar public key of the sender
  * @param {string} creatorPublicKey - The Stellar public key of the creator
  * @param {string} amount - The amount sent
  * @param {string} asset - The asset code (XLM, USDC, etc.)
  * @param {string} [memo] - Optional memo/message from sender
  * @param {string} [txHash] - The transaction hash
- * @returns {object} The created tip record
+ * @param {number} [operationIndex] - Index of the payment operation within the transaction
+ * @returns {object} The created tip record, or the existing record when this
+ *   (txHash, operationIndex) pair was already recorded (`isDuplicate: true`)
  */
-function recordTip({ senderPublicKey, creatorPublicKey, amount, asset = "XLM", memo = "", txHash = "" }) {
+function recordTip({
+  senderPublicKey,
+  creatorPublicKey,
+  amount,
+  asset = "XLM",
+  memo = "",
+  txHash = "",
+  operationIndex = 0,
+}) {
   if (!senderPublicKey || !creatorPublicKey || !amount) {
     const error = new Error("senderPublicKey, creatorPublicKey, and amount are required");
     error.status = 400;
     throw error;
+  }
+
+  const normalizedOperationIndex = Number(operationIndex);
+  if (!Number.isInteger(normalizedOperationIndex) || normalizedOperationIndex < 0) {
+    const error = new Error("operationIndex must be a non-negative integer");
+    error.status = 400;
+    throw error;
+  }
+
+  if (txHash) {
+    const idempotencyKey = buildIdempotencyKey(txHash, normalizedOperationIndex);
+    const existing = tipsByTxHash.get(idempotencyKey);
+    if (existing) {
+      // Replay of an already-recorded on-chain operation: return the
+      // original record rather than creating a duplicate.
+      return { ...existing, isDuplicate: true };
+    }
   }
 
   const tip = {
@@ -78,7 +127,9 @@ function recordTip({ senderPublicKey, creatorPublicKey, amount, asset = "XLM", m
     asset,
     memo,
     txHash,
+    operationIndex: normalizedOperationIndex,
     timestamp: new Date().toISOString(),
+    isDuplicate: false,
   };
 
   if (!tipsByCreator.has(creatorPublicKey)) {
@@ -86,6 +137,10 @@ function recordTip({ senderPublicKey, creatorPublicKey, amount, asset = "XLM", m
   }
 
   tipsByCreator.get(creatorPublicKey).unshift(tip); // Add to beginning (most recent first)
+
+  if (txHash) {
+    tipsByTxHash.set(buildIdempotencyKey(txHash, normalizedOperationIndex), tip);
+  }
 
   return tip;
 }
@@ -313,6 +368,7 @@ module.exports = {
   validateTipInput,
   getTopTippers,
   tipsByCreator,
+  tipsByTxHash,
   toStroops,
   formatStroops,
 };


### PR DESCRIPTION
Closes #758

## Summary

Repeated client submissions of the same on-chain tip transaction could previously create multiple `TipRecord`s in `tipsByCreator`, inflating stats, leaderboards, and sent/received history. This PR makes `recordTip` idempotent by keying on the Stellar `(txHash, operationIndex)` pair, so replaying the same submission returns the record that was already created instead of duplicating it.

## What changed

### Modified files
- `backend/src/services/tipsService.js`
  - Added a second in-memory index, `tipsByTxHash: Map<"txHash:operationIndex", TipRecord>`, alongside the existing `tipsByCreator` index.
  - Added `buildIdempotencyKey(txHash, operationIndex)` helper.
  - `recordTip` now accepts an `operationIndex` (default `0`), validates it's a non-negative integer, and — when a `txHash` is supplied — checks `tipsByTxHash` before inserting. On a hit it returns a copy of the existing record with `isDuplicate: true` instead of creating a new one. New records are stamped `isDuplicate: false` and indexed by their `(txHash, operationIndex)` key.
  - Tips recorded without a `txHash` (e.g. legacy/off-chain records) are not deduplicated, preserving existing behavior.
  - Exported `tipsByTxHash` (mirroring the existing `tipsByCreator` export) so tests can reset it between cases.
- `backend/src/controllers/tipsController.js`
  - `POST /api/v1/tips` (and legacy `/api/tips`) now forwards `operationIndex` from the request body (defaulting to `0`).
  - Responds `200` with `{ success: true, data: <existing record>, message: "Tip already recorded" }` when the service reports a duplicate, and keeps the existing `201 Tip recorded successfully` response for newly created tips.
  - Updated JSDoc for the `TipRecord` typedef and the `recordTip` handler to document `operationIndex` and `isDuplicate`.

### Test files
- `backend/__tests__/tipsService.test.js`
  - Clears the new `tipsByTxHash` map in `beforeEach`.
  - New `recordTip idempotency (txHash + operationIndex)` suite:
    - Replaying the same `(txHash, operationIndex)` returns the original record (`isDuplicate: true`, same `id`), and the creator's tip count stays at 1.
    - A replay with different sender/amount metadata still resolves to the original stored values (the stored record is authoritative, not the replay's payload).
    - Different `operationIndex` values on the same `txHash` are treated as distinct tips.
    - The same `operationIndex` on different `txHash` values are treated as distinct tips.
    - Tips recorded without a `txHash` are never deduplicated.
    - Negative or non-integer `operationIndex` values are rejected with a 400-style error.
    - **Concurrent duplicate submissions**: five simultaneous `recordTip` calls for the same `(txHash, operationIndex)` (fired via `Promise.all` over microtask-deferred calls) resolve to a single stored record — only one has `isDuplicate: false`, the other four report `isDuplicate: true`, and `getTipsReceived` reports a total of `1`.
  - Existing `beforeEach` reset of `tipsByCreator` covers the pre-existing suites; no other tests changed behavior.
- `backend/__tests__/tipsController.test.js`
  - Updated the two existing `recordTip` call-argument assertions to include the new `operationIndex: 0` default.
  - New `Idempotent tip recording` suite:
    - Returns `200` with the existing record and `"Tip already recorded"` message when `tipsService.recordTip` reports `isDuplicate: true`.
    - Passes a non-default `operationIndex` from the request body through to the service call.
    - Defaults `operationIndex` to `0` when the client omits it.

## Implementation notes

- `recordTip` remains a single synchronous function with no `await` between the duplicate check and the insert, so the check-and-set is atomic within Node's single-threaded event loop — no separate locking is needed to make concurrent requests safe.
- Idempotency is opt-in: only tips submitted with a non-empty `txHash` are deduplicated. This keeps the existing off-chain/manual tip-recording behavior unchanged.
- No network calls are involved in this change — the dedupe key is derived entirely from client-supplied `txHash`/`operationIndex`, so testnet vs. mainnet does not affect this logic. Verifying that the supplied `txHash` actually exists on the configured network (testnet or mainnet, via `stellarService`) is out of scope for this issue and can be tracked separately.

## How to test

```bash
cd backend
npm install
npx jest __tests__/tipsService.test.js __tests__/tipsController.test.js
npx jest __tests__/openapi-drift.test.js   # confirms no OpenAPI drift from the JSDoc changes
```

Manually:
```bash
npm run dev
curl -X POST http://localhost:4000/api/v1/tips \
  -H 'Content-Type: application/json' \
  -d '{"senderPublicKey":"G...","creatorPublicKey":"G...","amount":"10","txHash":"abc123","operationIndex":0}'
# → 201, isDuplicate:false

curl -X POST http://localhost:4000/api/v1/tips \
  -H 'Content-Type: application/json' \
  -d '{"senderPublicKey":"G...","creatorPublicKey":"G...","amount":"10","txHash":"abc123","operationIndex":0}'
# → 200, isDuplicate:true, same id as first response
```

## Validation

- `npx jest __tests__/tipsService.test.js __tests__/tipsController.test.js` → 57/57 passing.
- `npx jest` (full backend suite) → same 3 pre-existing failures as on `main` before this change (`scheduledTransactionService.test.js`, `accountController.test.js`), all unrelated to tips; everything else passes (282/285).
- `npx eslint src/**/*.js` fails to run on `main` as well (pre-existing invalid `import/order` rule config in `.eslintrc.json`, unrelated to this change) — not something introduced here.
- `npx jest __tests__/openapi-drift.test.js` → 8/8 passing, no drift from the updated JSDoc.