### PR TITLE
security(containers): run prod containers as non-root with read-only …

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -2,14 +2,27 @@ FROM node:20.19.5-alpine
 
 WORKDIR /app
 
-# Install dependencies
+ENV NODE_ENV=production
+
+# Install production dependencies
 COPY package*.json ./
 RUN npm install --production
 
 # Copy source code
 COPY . .
 
-# Expose port 4000
+# Drop root: run the API as the unprivileged `node` user.
+# The container rootfs is read-only at runtime (see docker-compose.prod.yml);
+# /tmp is mounted as tmpfs. The app performs no other filesystem writes.
+RUN chown -R node:node /app
+
+USER node
+
+# Port 4000 is unprivileged — no capabilities are re-added in docker-compose.prod.yml.
 EXPOSE 4000
+
+# Health probe (Node 20 global fetch) — writes nothing to disk.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 4000) + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 CMD ["node", "src/server.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,23 @@ version: "3.9"
 services:
   nginx:
     image: nginx:alpine
+    # Non-root ingress proxy: nginx alpine uid/gid. The official entrypoint
+    # rewrites /etc/nginx/conf.d, so it is bypassed and nginx launched directly.
+    user: "101:101"
+    entrypoint: ["/usr/sbin/nginx"]
+    command: ["-g", "daemon off;"]
+    read_only: true
+    tmpfs:
+      - /tmp:exec
+      - /var/cache/nginx:exec
+      - /var/run
+      - /var/log/nginx
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     ports:
       - "80:80"
       - "443:443"
@@ -27,8 +44,20 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.prod
+    read_only: true
+    tmpfs:
+      - /tmp:exec
+      - /var/cache/nginx:exec
+      - /var/run
+      - /var/log/nginx
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     volumes:
-      - frontend_static:/usr/share/nginx/html
+      - frontend_static:/usr/share/nginx/html:ro
     environment:
       - NEXT_PUBLIC_STELLAR_NETWORK=mainnet
       - NEXT_PUBLIC_HORIZON_URL=https://horizon.stellar.org
@@ -47,6 +76,13 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile.prod
+    read_only: true
+    tmpfs:
+      - /tmp:exec
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - PORT=4000
       - NODE_ENV=production

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -7,17 +7,30 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 
-# Copy source code and build
+# Copy source code and build (static export -> /app/out)
 COPY . .
 RUN npm run build
 
 # Stage 2: Serve stage
 FROM nginx:alpine
 
-# Copy built static files from build stage
-COPY --from=builder /app/out /usr/share/nginx/html
+# Copy built static files from the build stage, owned by the non-root nginx user
+COPY --chown=nginx:nginx --from=builder /app/out /usr/share/nginx/html
 
-# Expose port 80
+# Drop root: serve as the unprivileged `nginx` user.
+# The container rootfs is read-only at runtime (see docker-compose.prod.yml);
+# writable paths are mounted as tmpfs (/tmp, /var/cache/nginx, /var/run, /var/log/nginx).
+USER nginx
+
+# The official entrypoint rewrites /etc/nginx/conf.d, which is read-only when the
+# rootfs is mounted read-only — launch nginx directly instead.
+ENTRYPOINT ["nginx", "-g", "daemon off;"]
+CMD []
+
+# Port 80 requires NET_BIND_SERVICE, which is re-added in docker-compose.prod.yml
+# after dropping all capabilities.
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+# Health probe (busybox wget) — writes nothing to disk.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
## Description
Resolves #846 by hardening production container configurations across `frontend/Dockerfile.prod`, `backend/Dockerfile.prod`, and `docker-compose.prod.yml`.

## Changes Made
- **Non-Root Execution:** Configured dedicated unprivileged user execution (`USER node`) in both frontend and backend production Dockerfiles with proper file ownership.
- **Read-Only Root Filesystem:** Set `read_only: true` in `docker-compose.prod.yml` and explicitly mounted necessary writable temporary paths via `tmpfs`.
- **Capability Reduction:** Added `cap_drop: [ "ALL" ]` and `security_opt: [ "no-new-privileges:true" ]` to restrict container escalation paths.
- **Healthchecks:** Integrated container health checks for early failure detection.

## Validation & Verification
- [x] Verified images build cleanly:
  ```bash
  docker compose -f docker-compose.prod.yml build