### PR TITLE
feat(backend): add Horizon circuit breaker with observable fallback s…

### DIFF
--- a/backend/__tests__/healthHorizonBreaker.test.js
+++ b/backend/__tests__/healthHorizonBreaker.test.js
@@ -1,0 +1,49 @@
+/**
+ * __tests__/healthHorizonBreaker.test.js (#840)
+ */
+
+"use strict";
+
+const request = require("supertest");
+
+jest.mock("../src/middleware/auth", () => ({
+  verifyJWT: (req, res, next) => next(),
+}));
+
+const app = require("../src/server");
+const { getBreaker, resetAllBreakers } = require("../src/services/horizonCircuitBreaker");
+
+describe("GET /health horizon circuit visibility (#840)", () => {
+  beforeEach(() => {
+    resetAllBreakers();
+  });
+
+  afterAll(() => {
+    resetAllBreakers();
+  });
+
+  it("returns ok with closed circuit by default", async () => {
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+    expect(res.body.horizon.network).toBe("testnet");
+    expect(res.body.horizon.openOrigins).toEqual([]);
+    expect(res.body.horizon.halfOpenOrigins).toEqual([]);
+  });
+
+  it("reports degraded status and open origins when the breaker is open", async () => {
+    const breaker = getBreaker("https://horizon-testnet.stellar.org", { failureThreshold: 1 });
+    breaker.recordFailure();
+
+    const res = await request(app).get("/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.horizon.openOrigins).toContain("https://horizon-testnet.stellar.org");
+    expect(res.body.horizon.circuits[0]).toMatchObject({
+      state: "open",
+      network: "testnet",
+    });
+  });
+});

--- a/backend/__tests__/horizonCircuitBreaker.test.js
+++ b/backend/__tests__/horizonCircuitBreaker.test.js
@@ -1,0 +1,124 @@
+/**
+ * __tests__/horizonCircuitBreaker.test.js (#840)
+ */
+
+"use strict";
+
+const {
+  STATES,
+  HorizonCircuitOpenError,
+  inferNetworkFromHorizonUrl,
+  getBreaker,
+  getAllBreakerStates,
+  resetAllBreakers,
+} = require("../src/services/horizonCircuitBreaker");
+
+const TESTNET_URL = "https://horizon-testnet.stellar.org";
+const MAINNET_URL = "https://horizon.stellar.org";
+
+describe("horizonCircuitBreaker (#840)", () => {
+  beforeEach(() => {
+    resetAllBreakers();
+    delete process.env.STELLAR_NETWORK;
+  });
+
+  afterAll(() => {
+    resetAllBreakers();
+  });
+
+  describe("inferNetworkFromHorizonUrl", () => {
+    it("detects testnet from Horizon URL", () => {
+      expect(inferNetworkFromHorizonUrl(TESTNET_URL)).toBe("testnet");
+    });
+
+    it("detects mainnet from Horizon URL", () => {
+      expect(inferNetworkFromHorizonUrl(MAINNET_URL)).toBe("mainnet");
+    });
+
+    it("prefers explicit STELLAR_NETWORK over URL heuristics", () => {
+      process.env.STELLAR_NETWORK = "mainnet";
+      expect(inferNetworkFromHorizonUrl(TESTNET_URL)).toBe("mainnet");
+    });
+  });
+
+  it("opens after bounded consecutive failures per origin", () => {
+    const breaker = getBreaker(TESTNET_URL, { failureThreshold: 3 });
+
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.state).toBe(STATES.CLOSED);
+
+    breaker.recordFailure();
+    expect(breaker.state).toBe(STATES.OPEN);
+    expect(breaker.snapshot().retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("exposes open and half-open status with retry guidance", () => {
+    const breaker = getBreaker(TESTNET_URL, {
+      failureThreshold: 1,
+      openDurationMs: 1_000,
+      halfOpenMaxProbes: 1,
+    });
+
+    breaker.recordFailure();
+    expect(breaker.snapshot()).toMatchObject({
+      origin: "https://horizon-testnet.stellar.org",
+      network: "testnet",
+      state: STATES.OPEN,
+    });
+
+    breaker.openedAt = Date.now() - 2_000;
+    breaker.refreshState();
+    expect(breaker.state).toBe(STATES.HALF_OPEN);
+
+    expect(getAllBreakerStates()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ state: STATES.HALF_OPEN, network: "testnet" }),
+      ])
+    );
+  });
+
+  it("throws HorizonCircuitOpenError with retry metadata when open", () => {
+    const breaker = getBreaker(TESTNET_URL, { failureThreshold: 1 });
+    breaker.recordFailure();
+
+    expect(() => breaker.assertCanExecute()).toThrow(HorizonCircuitOpenError);
+    try {
+      breaker.assertCanExecute();
+    } catch (err) {
+      expect(err.status).toBe(503);
+      expect(err.code).toBe("HORIZON_CIRCUIT_OPEN");
+      expect(err.retryAfterMs).toBeGreaterThanOrEqual(0);
+      expect(err.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+      expect(err.network).toBe("testnet");
+      expect(err.state).toBe(STATES.OPEN);
+    }
+  });
+
+  it("closes again after a successful half-open probe", () => {
+    const breaker = getBreaker(TESTNET_URL, {
+      failureThreshold: 1,
+      openDurationMs: 0,
+      halfOpenMaxProbes: 1,
+    });
+
+    breaker.recordFailure();
+    breaker.refreshState();
+    expect(breaker.state).toBe(STATES.HALF_OPEN);
+
+    breaker.assertCanExecute();
+    breaker.recordSuccess();
+    expect(breaker.state).toBe(STATES.CLOSED);
+  });
+
+  it("tracks separate breaker state per Horizon origin", () => {
+    const testnetBreaker = getBreaker(TESTNET_URL, { failureThreshold: 1 });
+    const mainnetBreaker = getBreaker(MAINNET_URL, { failureThreshold: 1 });
+
+    testnetBreaker.recordFailure();
+
+    expect(testnetBreaker.state).toBe(STATES.OPEN);
+    expect(mainnetBreaker.state).toBe(STATES.CLOSED);
+    expect(getAllBreakerStates()).toHaveLength(2);
+  });
+});

--- a/backend/__tests__/paymentMonitor.test.js
+++ b/backend/__tests__/paymentMonitor.test.js
@@ -39,6 +39,7 @@ const { startMonitoring } = require("../src/services/paymentMonitor");
 const { getWebhooksByPublicKey } = require("../src/services/webhookStore");
 const { deliverWebhook } = require("../src/services/webhookDelivery");
 const cursorStore = require("../src/services/cursorStore");
+const { getBreaker, resetAllBreakers } = require("../src/services/horizonCircuitBreaker");
 
 const PUBLIC_KEY = "GA0000000000000000000000000000000000000000000000000000";
 
@@ -59,6 +60,7 @@ function payment(over = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  resetAllBreakers();
   streamOptions = null;
   lastCursorArg = null;
   cursorStore.get.mockReturnValue("now");
@@ -96,5 +98,28 @@ describe("paymentMonitor durable cursor (#773)", () => {
     await streamOptions.onmessage(payment({ paging_token: "p2" }));
     await streamOptions.onmessage(payment({ paging_token: "p2" }));
     expect(deliverWebhook).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("paymentMonitor Horizon circuit breaker (#840)", () => {
+  it("does not start a stream while the circuit is open", () => {
+    const breaker = getBreaker("https://horizon-testnet.stellar.org", { failureThreshold: 1 });
+    breaker.recordFailure();
+
+    const result = startMonitoring(PUBLIC_KEY);
+
+    expect(result.started).toBe(false);
+    expect(result.state).toBe("open");
+    expect(result.retryAfterMs).toBeGreaterThanOrEqual(0);
+    expect(streamOptions).toBeNull();
+  });
+
+  it("records stream errors against the breaker", () => {
+    const breaker = getBreaker("https://horizon-testnet.stellar.org", { failureThreshold: 1 });
+    startMonitoring(PUBLIC_KEY);
+
+    streamOptions.onerror(new Error("upstream unavailable"));
+
+    expect(breaker.state).toBe("open");
   });
 });

--- a/backend/__tests__/stellarService.test.js
+++ b/backend/__tests__/stellarService.test.js
@@ -31,12 +31,14 @@ jest.mock("@stellar/stellar-sdk", () => {
 });
 
 const stellarService = require("../src/services/stellarService");
+const { resetAllBreakers, getBreaker } = require("../src/services/horizonCircuitBreaker");
 
 describe("stellarService", () => {
   const validPublicKey = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetAllBreakers();
     stellarService.clearAccountCache();
     mockPaymentsCursor.mockImplementation(() => ({ call: mockPaymentsCall }));
     mockPaymentsOrder.mockImplementation(() => ({ cursor: mockPaymentsCursor, call: mockPaymentsCall }));
@@ -284,6 +286,38 @@ describe("stellarService", () => {
         expect(err.message).toContain("Account not found");
         expect(err.message).toContain("Use Friendbot on testnet");
       }
+    });
+  });
+
+  describe("Horizon circuit breaker (#840)", () => {
+    it("fails fast with retry guidance when the circuit is open", async () => {
+      const breaker = getBreaker("https://horizon-testnet.stellar.org", { failureThreshold: 1 });
+      breaker.recordFailure();
+
+      await expect(stellarService.getAccount(validPublicKey)).rejects.toMatchObject({
+        code: "HORIZON_CIRCUIT_OPEN",
+        status: 503,
+        network: "testnet",
+        state: "open",
+      });
+      expect(mockLoadAccount).not.toHaveBeenCalled();
+    });
+
+    it("does not serve cached account data while the circuit is open", async () => {
+      mockLoadAccount.mockResolvedValue({
+        sequence: "1",
+        subentry_count: 0,
+        balances: [{ asset_type: "native", balance: "10.0000000" }],
+      });
+
+      await stellarService.getAccount(validPublicKey);
+      const breaker = getBreaker("https://horizon-testnet.stellar.org", { failureThreshold: 1 });
+      breaker.recordFailure();
+
+      await expect(stellarService.getAccount(validPublicKey)).rejects.toMatchObject({
+        code: "HORIZON_CIRCUIT_OPEN",
+      });
+      expect(mockLoadAccount).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/src/routes/health.js
+++ b/backend/src/routes/health.js
@@ -6,14 +6,30 @@
 "use strict";
 
 const express = require("express");
+const { getAllBreakerStates } = require("../services/horizonCircuitBreaker");
+const { getMonitorStatus } = require("../services/paymentMonitor");
+
 const router = express.Router();
 
 router.get("/", (req, res) => {
+  const monitor = getMonitorStatus();
+  const circuits = getAllBreakerStates();
+  const openCircuits = circuits.filter((entry) => entry.state === "open");
+  const halfOpenCircuits = circuits.filter((entry) => entry.state === "half_open");
+
   res.json({
-    status: "ok",
+    status: openCircuits.length > 0 ? "degraded" : "ok",
     service: "stellar-micropay-api",
-    network: process.env.STELLAR_NETWORK || "testnet",
+    network: process.env.STELLAR_NETWORK || monitor.network || "testnet",
     timestamp: new Date().toISOString(),
+    horizon: {
+      url: monitor.horizonUrl,
+      network: monitor.network,
+      activeStreams: monitor.activeStreams,
+      circuits,
+      openOrigins: openCircuits.map((entry) => entry.origin),
+      halfOpenOrigins: halfOpenCircuits.map((entry) => entry.origin),
+    },
   });
 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -300,6 +300,22 @@ app.use((err, req, res, next) => {
   const status = err.status || 500;
   const message = sanitizeMessage(err.message) || "Internal Server Error";
   logger.error({ status, message }, "Request error");
+
+  if (err.code === "HORIZON_CIRCUIT_OPEN" && err.retryAfterSeconds) {
+    res.set("Retry-After", String(err.retryAfterSeconds));
+    return res.status(status).json({
+      error: message,
+      code: err.code,
+      retryAfterMs: err.retryAfterMs,
+      retryAfterSeconds: err.retryAfterSeconds,
+      horizon: {
+        origin: err.origin,
+        network: err.network,
+        state: err.state,
+      },
+    });
+  }
+
   res.status(status).json({ error: message });
 });
 

--- a/backend/src/services/horizonCircuitBreaker.js
+++ b/backend/src/services/horizonCircuitBreaker.js
@@ -1,0 +1,263 @@
+/**
+ * src/services/horizonCircuitBreaker.js
+ * Bounded circuit breaker per Horizon origin to prevent retry amplification
+ * during upstream outages (#840).
+ */
+
+"use strict";
+
+const { HORIZON_URL } = require("../config/stellar");
+
+const STATES = Object.freeze({
+  CLOSED: "closed",
+  OPEN: "open",
+  HALF_OPEN: "half_open",
+});
+
+/** @type {Readonly<{ failureThreshold: number, openDurationMs: number, halfOpenMaxProbes: number, maxOrigins: number }>} */
+const DEFAULT_OPTIONS = Object.freeze({
+  failureThreshold: 5,
+  openDurationMs: 30_000,
+  halfOpenMaxProbes: 1,
+  maxOrigins: 8,
+});
+
+/**
+ * Derive Stellar network label from a Horizon URL or STELLAR_NETWORK env.
+ * @param {string} [horizonUrl]
+ * @returns {"testnet" | "mainnet"}
+ */
+function inferNetworkFromHorizonUrl(horizonUrl = HORIZON_URL) {
+  const configured = process.env.STELLAR_NETWORK?.trim().toLowerCase();
+  if (configured === "mainnet" || configured === "testnet") {
+    return configured;
+  }
+  return horizonUrl.includes("testnet") ? "testnet" : "mainnet";
+}
+
+/**
+ * Normalize a Horizon URL to its origin key.
+ * @param {string} horizonUrl
+ * @returns {string}
+ */
+function toOriginKey(horizonUrl) {
+  return new URL(horizonUrl).origin;
+}
+
+class HorizonCircuitOpenError extends Error {
+  /**
+   * @param {object} snapshot
+   * @param {string} snapshot.origin
+   * @param {"testnet" | "mainnet"} snapshot.network
+   * @param {"open" | "half_open"} snapshot.state
+   * @param {number} snapshot.retryAfterMs
+   */
+  constructor(snapshot) {
+    super(
+      `Horizon upstream unavailable (${snapshot.network}); circuit is ${snapshot.state}. Retry after ${snapshot.retryAfterMs} ms.`
+    );
+    this.name = "HorizonCircuitOpenError";
+    this.code = "HORIZON_CIRCUIT_OPEN";
+    this.status = 503;
+    this.origin = snapshot.origin;
+    this.network = snapshot.network;
+    this.state = snapshot.state;
+    this.retryAfterMs = snapshot.retryAfterMs;
+    this.retryAfterSeconds = Math.max(1, Math.ceil(snapshot.retryAfterMs / 1000));
+  }
+}
+
+/**
+ * @typedef {object} BreakerSnapshot
+ * @property {string} origin
+ * @property {"testnet" | "mainnet"} network
+ * @property {"closed" | "open" | "half_open"} state
+ * @property {number} consecutiveFailures
+ * @property {number} halfOpenProbes
+ * @property {number|null} openedAt
+ * @property {number|null} retryAfterMs
+ * @property {number|null} lastFailureAt
+ * @property {number|null} lastSuccessAt
+ */
+
+class HorizonOriginBreaker {
+  /**
+   * @param {string} origin
+   * @param {string} horizonUrl
+   * @param {typeof DEFAULT_OPTIONS} options
+   */
+  constructor(origin, horizonUrl, options) {
+    this.origin = origin;
+    this.horizonUrl = horizonUrl;
+    this.network = inferNetworkFromHorizonUrl(horizonUrl);
+    this.options = options;
+    this.state = STATES.CLOSED;
+    this.consecutiveFailures = 0;
+    this.halfOpenProbes = 0;
+    this.openedAt = null;
+    this.lastFailureAt = null;
+    this.lastSuccessAt = null;
+  }
+
+  /** @returns {BreakerSnapshot} */
+  snapshot() {
+    return {
+      origin: this.origin,
+      network: this.network,
+      state: this.state,
+      consecutiveFailures: this.consecutiveFailures,
+      halfOpenProbes: this.halfOpenProbes,
+      openedAt: this.openedAt,
+      retryAfterMs: this.getRetryAfterMs(),
+      lastFailureAt: this.lastFailureAt,
+      lastSuccessAt: this.lastSuccessAt,
+    };
+  }
+
+  /** @returns {number|null} */
+  getRetryAfterMs() {
+    if (this.state === STATES.CLOSED) return null;
+    if (this.state === STATES.HALF_OPEN) return 0;
+
+    const elapsed = Date.now() - (this.openedAt || 0);
+    const remaining = this.options.openDurationMs - elapsed;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  /** Transition open → half-open when cooldown elapses. */
+  refreshState() {
+    if (this.state !== STATES.OPEN || this.openedAt === null) return;
+    if (Date.now() - this.openedAt >= this.options.openDurationMs) {
+      this.state = STATES.HALF_OPEN;
+      this.halfOpenProbes = 0;
+    }
+  }
+
+  /** @throws {HorizonCircuitOpenError} */
+  assertCanExecute() {
+    this.refreshState();
+
+    if (this.state === STATES.CLOSED) return;
+
+    if (this.state === STATES.OPEN) {
+      throw new HorizonCircuitOpenError(this.snapshot());
+    }
+
+    if (this.halfOpenProbes >= this.options.halfOpenMaxProbes) {
+      throw new HorizonCircuitOpenError(this.snapshot());
+    }
+
+    this.halfOpenProbes += 1;
+  }
+
+  recordSuccess() {
+    this.refreshState();
+    this.consecutiveFailures = 0;
+    this.halfOpenProbes = 0;
+    this.openedAt = null;
+    this.lastSuccessAt = Date.now();
+    this.state = STATES.CLOSED;
+  }
+
+  recordFailure() {
+    this.refreshState();
+    this.consecutiveFailures += 1;
+    this.lastFailureAt = Date.now();
+
+    if (this.state === STATES.HALF_OPEN) {
+      this.tripOpen();
+      return;
+    }
+
+    if (this.consecutiveFailures >= this.options.failureThreshold) {
+      this.tripOpen();
+    }
+  }
+
+  tripOpen() {
+    this.state = STATES.OPEN;
+    this.openedAt = Date.now();
+    this.halfOpenProbes = 0;
+  }
+
+  /** @visibleForTesting */
+  reset() {
+    this.state = STATES.CLOSED;
+    this.consecutiveFailures = 0;
+    this.halfOpenProbes = 0;
+    this.openedAt = null;
+    this.lastFailureAt = null;
+    this.lastSuccessAt = null;
+  }
+}
+
+/** @type {Map<string, HorizonOriginBreaker>} */
+const breakers = new Map();
+
+/**
+ * @param {string} [horizonUrl]
+ * @param {Partial<typeof DEFAULT_OPTIONS>} [overrides]
+ * @returns {HorizonOriginBreaker}
+ */
+function getBreaker(horizonUrl = HORIZON_URL, overrides = {}) {
+  const origin = toOriginKey(horizonUrl);
+  let breaker = breakers.get(origin);
+  if (!breaker) {
+    if (breakers.size >= DEFAULT_OPTIONS.maxOrigins) {
+      const oldest = breakers.keys().next().value;
+      breakers.delete(oldest);
+    }
+    breaker = new HorizonOriginBreaker(origin, horizonUrl, {
+      ...DEFAULT_OPTIONS,
+      ...overrides,
+    });
+    breakers.set(origin, breaker);
+  }
+  return breaker;
+}
+
+/**
+ * Execute a Horizon call through the breaker for the given origin.
+ * Fails fast with retry guidance when the circuit is open.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ horizonUrl?: string, operation?: string }} [context]
+ * @returns {Promise<T>}
+ */
+async function executeThroughBreaker(fn, context = {}) {
+  const breaker = getBreaker(context.horizonUrl || HORIZON_URL);
+  breaker.assertCanExecute();
+
+  try {
+    const result = await fn();
+    breaker.recordSuccess();
+    return result;
+  } catch (err) {
+    breaker.recordFailure();
+    throw err;
+  }
+}
+
+/** @returns {BreakerSnapshot[]} */
+function getAllBreakerStates() {
+  for (const breaker of breakers.values()) {
+    breaker.refreshState();
+  }
+  return [...breakers.values()].map((breaker) => breaker.snapshot());
+}
+
+function resetAllBreakers() {
+  breakers.clear();
+}
+
+module.exports = {
+  STATES,
+  HorizonCircuitOpenError,
+  inferNetworkFromHorizonUrl,
+  toOriginKey,
+  getBreaker,
+  executeThroughBreaker,
+  getAllBreakerStates,
+  resetAllBreakers,
+};

--- a/backend/src/services/paymentMonitor.js
+++ b/backend/src/services/paymentMonitor.js
@@ -13,6 +13,12 @@ const logger = require("../utils/logger");
 const cursorStore = require("./cursorStore");
 const { deliverWebhook } = require("./webhookDelivery");
 const { getWebhooksByPublicKey, getAllWebhooks } = require("./webhookStore");
+const {
+  STATES,
+  getBreaker,
+  HorizonCircuitOpenError,
+  inferNetworkFromHorizonUrl,
+} = require("./horizonCircuitBreaker");
 
 const HORIZON_URL =
   process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
@@ -34,14 +40,48 @@ const activeStreams = new Map();
 const seenTokens = new Map();
 
 /**
+ * @param {string} publicKey
+ * @returns {HorizonCircuitOpenError|null}
+ */
+function getStreamBlockedError(publicKey) {
+  const breaker = getBreaker(HORIZON_URL);
+  breaker.refreshState();
+  if (breaker.state === STATES.OPEN || breaker.state === STATES.HALF_OPEN) {
+    try {
+      breaker.assertCanExecute();
+    } catch (err) {
+      if (err instanceof HorizonCircuitOpenError) {
+        logger.warn(
+          { publicKey, origin: err.origin, state: err.state, retryAfterMs: err.retryAfterMs },
+          "[monitor] Horizon circuit blocked stream start"
+        );
+        return err;
+      }
+      throw err;
+    }
+  }
+  return null;
+}
+
+/**
  * Start monitoring a Stellar account for incoming payments.
  * If a stream is already active for this key, this is a no-op.
  *
  * @param {string} publicKey
+ * @returns {{ started: boolean, retryAfterMs?: number, state?: string }}
  */
 function startMonitoring(publicKey) {
   if (activeStreams.has(publicKey)) {
-    return; // idempotent — already monitored
+    return { started: true };
+  }
+
+  const blocked = getStreamBlockedError(publicKey);
+  if (blocked) {
+    return {
+      started: false,
+      state: blocked.state,
+      retryAfterMs: blocked.retryAfterMs,
+    };
   }
 
   logger.info({ publicKey }, "[monitor] starting SSE stream");
@@ -50,6 +90,7 @@ function startMonitoring(publicKey) {
   // downtime or a reconnect gap are not missed. Falls back to "now" only when
   // no cursor has been persisted yet.
   const resumeCursor = cursorStore.get(publicKey);
+  const breaker = getBreaker(HORIZON_URL);
 
   const closeStream = horizonServer
     .payments()
@@ -77,8 +118,8 @@ function startMonitoring(publicKey) {
             ? "native"
             : `${record.asset_code}:${record.asset_issuer}`;
 
-        const network = HORIZON_URL.includes("testnet") ? "testnet" : "mainnet";
-        
+        const network = inferNetworkFromHorizonUrl(HORIZON_URL);
+
         /** @type {import('./webhookDelivery').PaymentPayload} */
         const payload = {
           eventId: record.id,
@@ -104,11 +145,18 @@ function startMonitoring(publicKey) {
         // Advance the durable cursor even when no webhook is registered, so a
         // payment with no endpoint is not reprocessed on the next reconnect.
         cursorStore.set(publicKey, record.paging_token);
+        breaker.recordSuccess();
       },
 
       onerror: (err) => {
+        breaker.recordFailure();
         logger.error(
-          { publicKey, err },
+          {
+            publicKey,
+            err,
+            circuitState: breaker.snapshot().state,
+            retryAfterMs: breaker.getRetryAfterMs(),
+          },
           `[monitor] stream error for ${publicKey}: ${err.message ?? err}`
         );
         // Remove the dead stream so ensureMonitored can restart it next time
@@ -118,6 +166,7 @@ function startMonitoring(publicKey) {
     });
 
   activeStreams.set(publicKey, closeStream);
+  return { started: true };
 }
 
 /**
@@ -143,9 +192,10 @@ function stopMonitoring(publicKey) {
  * Idempotent — safe to call multiple times for the same key.
  *
  * @param {string} publicKey
+ * @returns {{ started: boolean, retryAfterMs?: number, state?: string }}
  */
 function ensureMonitored(publicKey) {
-  startMonitoring(publicKey);
+  return startMonitoring(publicKey);
 }
 
 /**
@@ -164,9 +214,25 @@ function resumeAllMonitors() {
   }
 }
 
+/**
+ * Observable stream + circuit breaker status for health probes (#840).
+ * @returns {object}
+ */
+function getMonitorStatus() {
+  const breaker = getBreaker(HORIZON_URL);
+  breaker.refreshState();
+  return {
+    horizonUrl: HORIZON_URL,
+    network: inferNetworkFromHorizonUrl(HORIZON_URL),
+    activeStreams: activeStreams.size,
+    circuit: breaker.snapshot(),
+  };
+}
+
 module.exports = {
   startMonitoring,
   stopMonitoring,
   ensureMonitored,
   resumeAllMonitors,
+  getMonitorStatus,
 };

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -6,8 +6,13 @@
 
 "use strict";
 
-const { server } = require("../config/stellar");
+const { server, HORIZON_URL } = require("../config/stellar");
 const logger = require("../utils/logger");
+const {
+  STATES,
+  getBreaker,
+  HorizonCircuitOpenError,
+} = require("./horizonCircuitBreaker");
 
 // ─── In-memory LRU cache for getAccount (5 s TTL) ────────────────────────────
 const ACCOUNT_CACHE_TTL_MS = 5_000;
@@ -41,10 +46,20 @@ function isTransientError(err) {
 /**
  * Run `fn` with a hard timeout and retry up to MAX_RETRIES times on
  * transient errors, using exponential back-off (100 ms × 2^attempt).
+ * When the Horizon circuit is open, fail fast with retry guidance instead
+ * of amplifying upstream load (#840).
  */
 async function withTimeoutAndRetry(fn, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const breaker = getBreaker(HORIZON_URL);
   let lastErr;
+
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      breaker.assertCanExecute();
+    } catch (circuitErr) {
+      throw circuitErr;
+    }
+
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -58,15 +73,30 @@ async function withTimeoutAndRetry(fn, timeoutMs = DEFAULT_TIMEOUT_MS) {
         ),
       ]);
       clearTimeout(timer);
+      breaker.recordSuccess();
       return result;
     } catch (err) {
       clearTimeout(timer);
       lastErr = err;
-      if (!isTransientError(err) || attempt === MAX_RETRIES) throw err;
+
+      if (!isTransientError(err)) {
+        throw err;
+      }
+
+      breaker.recordFailure();
+      if (breaker.state === STATES.OPEN) {
+        throw new HorizonCircuitOpenError(breaker.snapshot());
+      }
+
+      if (attempt === MAX_RETRIES) {
+        throw err;
+      }
+
       // Exponential back-off: 100 ms, 200 ms, 400 ms …
       await new Promise((resolve) => setTimeout(resolve, 100 * 2 ** attempt));
     }
   }
+
   throw lastErr;
 }
 
@@ -106,8 +136,14 @@ function clearAccountCache() {
 async function getAccount(publicKey) {
   validatePublicKey(publicKey);
 
-  const cached = cacheGet(publicKey);
-  if (cached) return cached;
+  const breaker = getBreaker(HORIZON_URL);
+  if (breaker.state === STATES.OPEN) {
+    breaker.refreshState();
+  }
+  if (breaker.state !== STATES.OPEN) {
+    const cached = cacheGet(publicKey);
+    if (cached) return cached;
+  }
 
   try {
     const account = await withTimeoutAndRetry(() => server.loadAccount(publicKey));

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -388,8 +388,32 @@ const options = {
                   schema: {
                     type: "object",
                     properties: {
-                      status: { type: "string", example: "ok" },
+                      status: { type: "string", example: "ok", enum: ["ok", "degraded"] },
+                      service: { type: "string", example: "stellar-micropay-api" },
+                      network: { type: "string", example: "testnet", enum: ["testnet", "mainnet"] },
                       timestamp: { type: "string", format: "date-time" },
+                      horizon: {
+                        type: "object",
+                        properties: {
+                          url: { type: "string", example: "https://horizon-testnet.stellar.org" },
+                          network: { type: "string", enum: ["testnet", "mainnet"] },
+                          activeStreams: { type: "integer", example: 0 },
+                          openOrigins: { type: "array", items: { type: "string" } },
+                          halfOpenOrigins: { type: "array", items: { type: "string" } },
+                          circuits: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                origin: { type: "string" },
+                                network: { type: "string", enum: ["testnet", "mainnet"] },
+                                state: { type: "string", enum: ["closed", "open", "half_open"] },
+                                retryAfterMs: { type: "integer", nullable: true },
+                              },
+                            },
+                          },
+                        },
+                      },
                     },
                   },
                 },

--- a/scripts/generate-openapi.js
+++ b/scripts/generate-openapi.js
@@ -376,10 +376,32 @@ const PATHS = {
               schema: {
                 type: "object",
                 properties: {
-                  status: { type: "string", example: "ok" },
+                  status: { type: "string", example: "ok", enum: ["ok", "degraded"] },
                   service: { type: "string", example: "stellar-micropay-api" },
-                  network: { type: "string", example: "testnet" },
+                  network: { type: "string", example: "testnet", enum: ["testnet", "mainnet"] },
                   timestamp: { type: "string", format: "date-time" },
+                  horizon: {
+                    type: "object",
+                    properties: {
+                      url: { type: "string", example: "https://horizon-testnet.stellar.org" },
+                      network: { type: "string", enum: ["testnet", "mainnet"] },
+                      activeStreams: { type: "integer", example: 0 },
+                      openOrigins: { type: "array", items: { type: "string" } },
+                      halfOpenOrigins: { type: "array", items: { type: "string" } },
+                      circuits: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            origin: { type: "string" },
+                            network: { type: "string", enum: ["testnet", "mainnet"] },
+                            state: { type: "string", enum: ["closed", "open", "half_open"] },
+                            retryAfterMs: { type: "integer", nullable: true },
+                          },
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },


### PR DESCRIPTION
…tates (#840)

Prevent retry amplification during Horizon outages by failing fast with retry guidance, exposing open/half-open status on health checks, and blocking stale reads while the circuit is open.

## Summary

<!-- What does this PR do? 1-2 sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #840

## Changes

<!-- List the key changes made -->
- 
- 

## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`
