### PR TITLE
fix(security): upgrade Morgan and sanitize access log tokens (#811)

### DIFF
--- a/backend/__tests__/sanitizeLogToken.test.js
+++ b/backend/__tests__/sanitizeLogToken.test.js
@@ -1,0 +1,73 @@
+/**
+ * __tests__/sanitizeLogToken.test.js (#811)
+ */
+
+"use strict";
+
+const {
+  sanitizeLogToken,
+  sanitizeLogHeaders,
+  sanitizeReqLogRecord,
+  sanitizeAccessLogLine,
+} = require("../src/utils/sanitizeLogToken");
+
+describe("sanitizeLogToken (#811)", () => {
+  it("neutralizes CRLF log-forging attempts", () => {
+    const forged = "attacker\r\n127.0.0.1 - admin [01/Jan/2026:00:00:00 +0000] \"GET /secrets HTTP/1.1\" 200";
+    const sanitized = sanitizeLogToken(forged);
+
+    expect(sanitized).not.toMatch(/[\r\n]/);
+    expect(sanitized).toContain("attacker");
+    expect(sanitized).toContain("127.0.0.1 - admin");
+  });
+
+  it("neutralizes terminal control characters", () => {
+    const payload = "user\x1b[31mred\x07bell";
+    const sanitized = sanitizeLogToken(payload);
+
+    expect(sanitized).not.toMatch(/[\u0000-\u001F\u007F]/);
+    expect(sanitized).toContain("user");
+    expect(sanitized).toContain("red");
+    expect(sanitized).toContain("bell");
+  });
+
+  it("sanitizes Basic auth usernames in header maps", () => {
+    const authorization = `Basic ${Buffer.from("evil\r\nadmin").toString("base64")}`;
+    const headers = sanitizeLogHeaders({
+      authorization,
+      "user-agent": "scanner\r\nFORGED",
+    });
+
+    expect(headers.authorization).not.toMatch(/[\r\n]/);
+    expect(headers["user-agent"]).not.toMatch(/[\r\n]/);
+  });
+
+  it("sanitizes structured request log records", () => {
+    const record = sanitizeReqLogRecord({
+      id: 1,
+      method: "GET",
+      url: "/health\r\nINJECTED",
+      remoteAddress: "10.0.0.1\r\n",
+      headers: {
+        authorization: "Basic forged\r\nuser",
+      },
+    });
+
+    expect(record.url).toBe("/health INJECTED");
+    expect(record.remoteAddress).toBe("10.0.0.1  ");
+    expect(record.headers.authorization).toBe("Basic forged user");
+  });
+
+  it("sanitizes full access-log lines", () => {
+    const line = '127.0.0.1 - evil\r\nadmin [01/Jan/2026:00:00:00 +0000] "GET / HTTP/1.1" 200 0\n';
+    const sanitized = sanitizeAccessLogLine(line);
+
+    expect(sanitized).not.toMatch(/[\r\n]/);
+  });
+
+  it("passes through nullish and numeric values unchanged", () => {
+    expect(sanitizeLogToken(null)).toBeNull();
+    expect(sanitizeLogToken(undefined)).toBeUndefined();
+    expect(sanitizeLogToken(404)).toBe(404);
+  });
+});

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,7 @@
         "express-rate-limit": "^7.3.1",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.3",
-        "morgan": "^1.10.0",
+        "morgan": "^1.12.0",
         "nodemailer": "^9.0.3",
         "pino": "^9.0.0",
         "pino-http": "^10.3.0",
@@ -7746,19 +7746,23 @@
       "license": "MIT"
     },
     "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.12.0.tgz",
+      "integrity": "sha512-OHpTRQwn2ezasILW8iKe+Yww1XsfWsZIpUOLF7RDb2g5GwO3trPaRwi7+8BDiJ7HFx2Kg2mfUdCBcVhwYlOz2g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/morgan/node_modules/debug": {
@@ -7775,18 +7779,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "express-rate-limit": "^7.3.1",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.3",
-    "morgan": "^1.10.0",
+    "morgan": "^1.12.0",
     "nodemailer": "^9.0.3",
     "pino": "^9.0.0",
     "pino-http": "^10.3.0",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,6 +11,7 @@ const cors = require("cors");
 const express = require("express");
 const rateLimit = require("express-rate-limit");
 const helmet = require("helmet");
+const pino = require("pino");
 const pinoHttp = require("pino-http");
 require("dotenv").config();
 const Sentry = require("@sentry/node");
@@ -30,6 +31,7 @@ const { resumeAllMonitors } = require("./services/paymentMonitor");
 const swaggerSpec = require("./swagger");
 const { startTurretsServer } = require("./turretsServer");
 const logger = require("./utils/logger");
+const { sanitizeLogToken, sanitizeReqLogRecord } = require("./utils/sanitizeLogToken");
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -175,7 +177,17 @@ app.use(
 );
 // Structured JSON request logging (#269) — replaces morgan('dev'); reuses the
 // shared pino logger so HTTP logs are machine-parseable (Datadog/CloudWatch).
-app.use(pinoHttp({ logger }));
+// Untrusted request tokens are sanitized before logging (#811).
+app.use(
+  pinoHttp({
+    logger,
+    serializers: {
+      req(req) {
+        return sanitizeReqLogRecord(pino.stdSerializers.req(req));
+      },
+    },
+  })
+);
 app.use(express.json({ limit: "10kb" }));
 // Parses the Cookie header into req.cookies so the SEP-0010 session cookie
 // (set in routes/auth.js) can be read back by middleware/auth.js's
@@ -285,7 +297,7 @@ app.get("/api/docs.json", (req, res) => {
 // ─── 404 Handler ───────────────────────────────────────────────────────────────
 
 app.use((req, res) => {
-  const sanitizedPath = req.path.replace(/[\r\n]/g, "");
+  const sanitizedPath = sanitizeLogToken(req.path);
   logger.warn({ method: req.method, path: sanitizedPath }, "Route not found");
   res.status(404).json({ error: "Route not found" });
 });

--- a/backend/src/turretsServer.js
+++ b/backend/src/turretsServer.js
@@ -12,6 +12,10 @@ const morgan = require("morgan");
 
 const turretsRoutes = require("./routes/turrets");
 const { startRunner } = require("./services/turretsService");
+const { sanitizeAccessLogLine } = require("./utils/sanitizeLogToken");
+
+const TURRETS_LOG_FORMAT =
+  ":remote-addr - :method :url :status :res[content-length] - :response-time ms";
 
 const TURRETS_PORT = Number(process.env.TURRETS_PORT || 4100);
 
@@ -37,7 +41,15 @@ function createTurretsApp() {
       },
     })
   );
-  app.use(morgan("tiny"));
+  app.use(
+    morgan(TURRETS_LOG_FORMAT, {
+      stream: {
+        write(message) {
+          process.stdout.write(sanitizeAccessLogLine(message));
+        },
+      },
+    })
+  );
   app.use(express.json({ limit: "10kb" }));
   app.use(cors());
 

--- a/backend/src/utils/sanitizeLogToken.js
+++ b/backend/src/utils/sanitizeLogToken.js
@@ -1,0 +1,71 @@
+/**
+ * src/utils/sanitizeLogToken.js
+ * Neutralize control characters in untrusted values written to access logs (#811).
+ */
+
+"use strict";
+
+/** C0 controls and DEL — common log-forging and terminal escape vectors. */
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/g;
+
+/**
+ * Replace control characters in a single log token with spaces.
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sanitizeLogToken(value) {
+  if (value == null) return value;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  return String(value).replace(CONTROL_CHAR_PATTERN, " ");
+}
+
+/**
+ * Sanitize string values in a header map before logging.
+ * @param {Record<string, unknown>|undefined|null} headers
+ * @returns {Record<string, unknown>|undefined|null}
+ */
+function sanitizeLogHeaders(headers) {
+  if (!headers || typeof headers !== "object") return headers;
+
+  const sanitized = {};
+  for (const [key, rawValue] of Object.entries(headers)) {
+    if (Array.isArray(rawValue)) {
+      sanitized[sanitizeLogToken(key)] = rawValue.map((entry) => sanitizeLogToken(entry));
+    } else {
+      sanitized[sanitizeLogToken(key)] = sanitizeLogToken(rawValue);
+    }
+  }
+  return sanitized;
+}
+
+/**
+ * Sanitize a serialized HTTP request record for structured access logs.
+ * @param {Record<string, unknown>|undefined|null} record
+ * @returns {Record<string, unknown>|undefined|null}
+ */
+function sanitizeReqLogRecord(record) {
+  if (!record || typeof record !== "object") return record;
+
+  return {
+    ...record,
+    url: sanitizeLogToken(record.url),
+    remoteAddress: sanitizeLogToken(record.remoteAddress),
+    headers: sanitizeLogHeaders(record.headers),
+  };
+}
+
+/**
+ * Sanitize a full access-log line before writing to stdout.
+ * @param {unknown} line
+ * @returns {string}
+ */
+function sanitizeAccessLogLine(line) {
+  return sanitizeLogToken(line);
+}
+
+module.exports = {
+  sanitizeLogToken,
+  sanitizeLogHeaders,
+  sanitizeReqLogRecord,
+  sanitizeAccessLogLine,
+};


### PR DESCRIPTION
Upgrade Morgan to a patched release and neutralize CRLF and terminal control characters in pino-http and turrets access logs.

## Summary

<!-- What does this PR do? 1-2 sentences. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Smart contract change

## Related issue

Closes #811

## Changes

<!-- List the key changes made -->
- 
- 

## Testing

<!-- How did you test this? -->
- [ ] Tested locally on Testnet
- [ ] Added/updated unit tests
- [ ] Manually tested UI flow

## Screenshots (if UI change)

<!-- Add before/after screenshots -->

## Checklist

- [ ] My code follows the project style
- [ ] I've updated docs if needed
- [ ] No console errors or warnings
- [ ] I've rebased on latest `main`
