### PR TITLE
reliability: add exponential retry and dead-letter handling for scheduled transactions (#766)

### DIFF
--- a/backend/__tests__/scheduledTransactionService.test.js
+++ b/backend/__tests__/scheduledTransactionService.test.js
@@ -2,42 +2,41 @@ const {
   scheduleTransaction,
   getPendingTransactions,
   getTransactionById,
-  cancelTransaction,
   getDueTransactions,
   incrementAttempt,
-  removeTransaction,
   markSubmitted,
   reconcileTransaction,
   reconcileByHash,
   reconcileBySequence,
   getUnreconciledTransactions,
+  deadLetterTransaction,
+  getDeadLetterTransactions,
+  getDeadLetterById,
+  retryDeadLetter,
+  removeDeadLetter,
+  resetScheduler,
+  classifySubmissionError,
+  getBackoffDelayMs,
+  MAX_ATTEMPTS,
 } = require("../src/services/scheduledTransactionService");
 
 describe("Scheduled Transaction Service", () => {
-  const validPublicKey = "GAQWTE4AWTBZYJYZIURRBYD6G4N6WMB4QNY2OXZFTKRYR6XQ4OQK6R37";
+  const validPublicKey =
+    "GAQWTE4AWTBZYJYZIURRBYD6G4N6WMB4QNY2OXZFTKRYR6XQ4OQK6R37";
   const validXDR = "AAAAAgAAAAD..."; // Dummy XDR
 
   beforeEach(() => {
-    // Clear the in-memory map before each test
-    // We can do this by getting all pending and removing them
-    // However, we don't have a direct clear method, so we'll cancel any we create
-    // Or we can just let it persist and ensure we don't conflict.
-  });
-
-  afterEach(() => {
-    // Attempt to clear by getting all due and pending and removing them
-    const pending = getPendingTransactions(validPublicKey);
-    pending.forEach(tx => removeTransaction(tx.id));
-    
-    // Some might be due but not pending for this user? getDueTransactions gets all
-    const due = getDueTransactions();
-    due.forEach(tx => removeTransaction(tx.id));
+    resetScheduler();
   });
 
   describe("Creating a schedule", () => {
     it("stores the expected fields", () => {
       const submitAt = new Date(Date.now() + 10000); // 10 seconds in future
-      const scheduledTx = scheduleTransaction(validXDR, submitAt, validPublicKey);
+      const scheduledTx = scheduleTransaction(
+        validXDR,
+        submitAt,
+        validPublicKey,
+      );
 
       expect(scheduledTx).toBeDefined();
       expect(scheduledTx.id).toBeDefined();
@@ -64,21 +63,25 @@ describe("Scheduled Transaction Service", () => {
     it("returns transactions when their time arrives", () => {
       const pastTime = new Date(Date.now() - 10000); // 10 seconds in the past
       const futureTime = new Date(Date.now() + 10000); // 10 seconds in the future
-      
+
       const dueTx = scheduleTransaction(validXDR, pastTime, validPublicKey);
-      const futureTx = scheduleTransaction(validXDR, futureTime, validPublicKey);
+      const futureTx = scheduleTransaction(
+        validXDR,
+        futureTime,
+        validPublicKey,
+      );
 
       const dueTransactions = getDueTransactions();
-      
-      const foundDue = dueTransactions.find(tx => tx.id === dueTx.id);
-      const foundFuture = dueTransactions.find(tx => tx.id === futureTx.id);
+
+      const foundDue = dueTransactions.find((tx) => tx.id === dueTx.id);
+      const foundFuture = dueTransactions.find((tx) => tx.id === futureTx.id);
 
       expect(foundDue).toBeDefined();
       expect(foundFuture).toBeUndefined();
     });
   });
 
-  describe("Failed executions (retries and marking failed)", () => {
+  describe("Failed executions (retries and dead-lettering)", () => {
     it("increments attempt and stores error", () => {
       const pastTime = new Date(Date.now() - 10000);
       const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
@@ -89,29 +92,86 @@ describe("Scheduled Transaction Service", () => {
       const updatedTx = getTransactionById(tx.id);
       expect(updatedTx.attempts).toBe(1);
       expect(updatedTx.lastError).toBe(errorMessage);
+      expect(updatedTx.lastErrorType).toBe("transient");
     });
 
-    it("stops returning transactions as due after 3 attempts", () => {
+    it("schedules a backoff window after a transient failure", () => {
       const pastTime = new Date(Date.now() - 10000);
       const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
 
-      // Attempt 1
+      const result = incrementAttempt(tx.id, "Network timeout");
+
+      expect(result.status).toBe("retry");
+      expect(result.attempts).toBe(1);
+      // Backoff cap: base (1s) * 2^0 = 1s ± 20% jitter
+      expect(result.delayMs).toBeGreaterThanOrEqual(800);
+      expect(result.delayMs).toBeLessThanOrEqual(1200);
+      expect(result.nextRetryAt).toBeGreaterThan(Date.now());
+
+      // Not immediately due again — it must wait out the backoff window.
+      const due = getDueTransactions().find((t) => t.id === tx.id);
+      expect(due).toBeUndefined();
+    });
+
+    it("becomes due again once the backoff window elapses", () => {
+      const pastTime = new Date(Date.now() - 10000);
+      const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
+
+      incrementAttempt(tx.id, "Network timeout");
+
+      // Force the backoff window into the past (live reference from store).
+      getTransactionById(tx.id).nextRetryAt = Date.now() - 1000;
+
+      const due = getDueTransactions().find((t) => t.id === tx.id);
+      expect(due).toBeDefined();
+      expect(due.attempts).toBe(1);
+    });
+
+    it("exposes MAX_ATTEMPTS as a bounded retry budget", () => {
+      expect(MAX_ATTEMPTS).toBeGreaterThan(0);
+      expect(MAX_ATTEMPTS).toBe(3);
+    });
+
+    it("dead-letters a transaction after exhausting the retry budget", () => {
+      const pastTime = new Date(Date.now() - 10000);
+      const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
+
+      // Attempt 1 & 2 — transient retries with backoff
       incrementAttempt(tx.id, "Error 1");
-      let due = getDueTransactions().find(t => t.id === tx.id);
-      expect(due).toBeDefined();
-
-      // Attempt 2
       incrementAttempt(tx.id, "Error 2");
-      due = getDueTransactions().find(t => t.id === tx.id);
-      expect(due).toBeDefined();
+      expect(getTransactionById(tx.id).deadLetter).toBe(false);
 
-      // Attempt 3 (max attempts reached)
-      incrementAttempt(tx.id, "Error 3");
-      due = getDueTransactions().find(t => t.id === tx.id);
+      // Attempt 3 (max attempts reached) — dead-lettered
+      let result = incrementAttempt(tx.id, "Error 3");
+      expect(result.status).toBe("dead_lettered");
+      expect(getTransactionById(tx.id).attempts).toBe(3);
+      expect(getTransactionById(tx.id).deadLetter).toBe(true);
+      expect(getTransactionById(tx.id).nextRetryAt).toBeNull();
+
+      const due = getDueTransactions().find((t) => t.id === tx.id);
       expect(due).toBeUndefined(); // Should not be due anymore
-      
-      const updatedTx = getTransactionById(tx.id);
-      expect(updatedTx.attempts).toBe(3);
+    });
+
+    it("dead-letters immediately on a permanent error", () => {
+      const pastTime = new Date(Date.now() - 10000);
+      const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
+
+      const permanentError = Object.assign(new Error("tx_bad_seq"), {
+        response: {
+          status: 400,
+          data: { extras: { result_codes: { transaction: "tx_bad_seq" } } },
+        },
+      });
+
+      const result = incrementAttempt(tx.id, permanentError);
+      expect(result.status).toBe("dead_lettered");
+      expect(getTransactionById(tx.id).deadLetter).toBe(true);
+      expect(getTransactionById(tx.id).deadLetterReason).toContain(
+        "tx_bad_seq",
+      );
+
+      const due = getDueTransactions().find((t) => t.id === tx.id);
+      expect(due).toBeUndefined();
     });
   });
 
@@ -132,11 +192,11 @@ describe("Scheduled Transaction Service", () => {
       const pastTime = new Date(Date.now() - 10000);
       const tx = scheduleTransaction(validXDR, pastTime, validPublicKey);
 
-      let due = getDueTransactions().find(t => t.id === tx.id);
+      let due = getDueTransactions().find((t) => t.id === tx.id);
       expect(due).toBeDefined();
 
       markSubmitted(tx.id, "hash1");
-      due = getDueTransactions().find(t => t.id === tx.id);
+      due = getDueTransactions().find((t) => t.id === tx.id);
       expect(due).toBeUndefined();
     });
 
@@ -211,7 +271,7 @@ describe("Scheduled Transaction Service", () => {
       // tx3 never submitted
 
       const unreconciled = getUnreconciledTransactions();
-      const ids = unreconciled.map(t => t.id);
+      const ids = unreconciled.map((t) => t.id);
       expect(ids).toContain(tx1.id);
       expect(ids).not.toContain(tx2.id);
       expect(ids).not.toContain(tx3.id);
@@ -223,7 +283,7 @@ describe("Scheduled Transaction Service", () => {
       markSubmitted(tx.id, "hash1");
       reconcileTransaction(tx.id, true);
 
-      const due = getDueTransactions().find(t => t.id === tx.id);
+      const due = getDueTransactions().find((t) => t.id === tx.id);
       expect(due).toBeUndefined();
     });
 
@@ -233,8 +293,205 @@ describe("Scheduled Transaction Service", () => {
       markSubmitted(tx.id, "hash1");
       reconcileTransaction(tx.id, false, "Not found");
 
-      const due = getDueTransactions().find(t => t.id === tx.id);
+      const due = getDueTransactions().find((t) => t.id === tx.id);
       expect(due).toBeUndefined();
+    });
+  });
+
+  describe("Stellar error classification", () => {
+    it("classifies network timeouts as transient", () => {
+      expect(
+        classifySubmissionError(new Error("socket timed out, ETIMEDOUT")).type,
+      ).toBe("transient");
+      expect(classifySubmissionError(new Error("network failure")).type).toBe(
+        "transient",
+      );
+    });
+
+    it("classifies 5xx and rate-limit (429) responses as transient", () => {
+      const serverErr = Object.assign(new Error("Server unavailable"), {
+        response: { status: 503 },
+      });
+      const rateErr = Object.assign(new Error("Too many requests"), {
+        response: { status: 429 },
+      });
+      expect(classifySubmissionError(serverErr).type).toBe("transient");
+      expect(classifySubmissionError(rateErr).type).toBe("transient");
+    });
+
+    it("classifies 4xx responses as permanent", () => {
+      expect(
+        classifySubmissionError(
+          Object.assign(new Error("bad request"), {
+            response: { status: 400 },
+          }),
+        ).type,
+      ).toBe("permanent");
+      expect(
+        classifySubmissionError(
+          Object.assign(new Error("not found"), { response: { status: 404 } }),
+        ).type,
+      ).toBe("permanent");
+    });
+
+    it("classifies known permanent result codes as permanent", () => {
+      const underfunded = Object.assign(new Error("op_underfunded occurred"), {
+        response: {
+          status: 400,
+          data: {
+            extras: { result_codes: { operations: ["op_underfunded"] } },
+          },
+        },
+      });
+      expect(classifySubmissionError(underfunded).type).toBe("permanent");
+      expect(classifySubmissionError(underfunded).message).toContain(
+        "op_underfunded",
+      );
+
+      const badSeq = Object.assign(new Error("tx_bad_seq"), {
+        response: {
+          status: 400,
+          data: { extras: { result_codes: { transaction: "tx_bad_seq" } } },
+        },
+      });
+      expect(classifySubmissionError(badSeq).type).toBe("permanent");
+    });
+
+    it("classifies unknown errors as transient (fail safe)", () => {
+      expect(
+        classifySubmissionError(new Error("Something unexpected")).type,
+      ).toBe("transient");
+      expect(classifySubmissionError(null).type).toBe("transient");
+      // Plain string messages are treated as transient.
+      expect(classifySubmissionError("boom").type).toBe("transient");
+    });
+  });
+
+  describe("Exponential backoff", () => {
+    it("grows the base delay exponentially per attempt", () => {
+      // Use a fixed RNG so jitter is deterministic (rng() = 0.5 → no jitter).
+      const rng = () => 0.5;
+      const attempt1 = getBackoffDelayMs(1, rng);
+      const attempt2 = getBackoffDelayMs(2, rng);
+      const attempt3 = getBackoffDelayMs(3, rng);
+
+      expect(attempt1).toBe(1000);
+      expect(attempt2).toBe(2000);
+      expect(attempt3).toBe(4000);
+      expect(attempt2).toBeGreaterThan(attempt1);
+      expect(attempt3).toBeGreaterThan(attempt2);
+    });
+
+    it("applies jitter within the expected bounds", () => {
+      // rng extremes actually exceed the bounds check; use variety.
+      const delays = [0.1, 0.9, 0.5, 0.2, 0.8].map((r) =>
+        getBackoffDelayMs(2, () => r),
+      );
+      for (const d of delays) {
+        // base 2000ms ± 20% (400ms) → [1600, 2400]
+        expect(d).toBeGreaterThanOrEqual(1600);
+        expect(d).toBeLessThanOrEqual(2400);
+      }
+      // Jitter produces more than one distinct value.
+      expect(new Set(delays).size).toBeGreaterThan(1);
+    });
+
+    it("caps the backoff delay at the maximum", () => {
+      const rng = () => 0.5;
+      const huge = getBackoffDelayMs(100, rng);
+      expect(huge).toBeLessThanOrEqual(60000);
+    });
+  });
+
+  describe("Dead-letter queue controls", () => {
+    function makeDeadLettered(future = false) {
+      const time = future ? Date.now() + 10000 : Date.now() - 10000;
+      const tx = scheduleTransaction(validXDR, new Date(time), validPublicKey);
+      deadLetterTransaction(tx.id, "manual park");
+      return tx;
+    }
+
+    it("lists dead-lettered transactions", () => {
+      const tx1 = makeDeadLettered();
+      const tx2 = scheduleTransaction(
+        validXDR,
+        new Date(Date.now() - 10000),
+        validPublicKey,
+      );
+
+      const dlq = getDeadLetterTransactions();
+      const ids = dlq.map((t) => t.id);
+      expect(ids).toContain(tx1.id);
+      expect(ids).not.toContain(tx2.id);
+
+      expect(getDeadLetterById(tx1.id).deadLetter).toBe(true);
+      expect(getDeadLetterById(tx2.id)).toBeNull();
+    });
+
+    it("filters dead letters by public key", () => {
+      const otherKey =
+        "GBXRGOTUTQR6Z6RQ3K6HZQRRJ7R2Y62K6Z7PTOCT2ZNVHGHODK43RNLQ";
+      const tx1 = makeDeadLettered();
+      const tx2 = scheduleTransaction(
+        validXDR,
+        new Date(Date.now() - 10000),
+        otherKey,
+      );
+      deadLetterTransaction(tx2.id, "other");
+
+      const mine = getDeadLetterTransactions({ publicKey: validPublicKey });
+      const ids = mine.map((t) => t.id);
+      expect(ids).toContain(tx1.id);
+      expect(ids).not.toContain(tx2.id);
+    });
+
+    it("dead-lettered transactions are excluded from due and pending", () => {
+      const tx = makeDeadLettered();
+      expect(getDueTransactions().find((t) => t.id === tx.id)).toBeUndefined();
+      expect(
+        getPendingTransactions(validPublicKey).find((t) => t.id === tx.id),
+      ).toBeUndefined();
+    });
+
+    it("requeues a dead-lettered transaction for retry", () => {
+      const tx = makeDeadLettered();
+
+      const requeued = retryDeadLetter(tx.id, {
+        retryAt: new Date(Date.now() + 5000),
+      });
+      expect(requeued.deadLetter).toBe(false);
+      expect(requeued.attempts).toBe(0);
+      expect(requeued.deadLetterReason).toBeNull();
+      expect(getTransactionById(tx.id).nextRetryAt).toBeGreaterThan(Date.now());
+      expect(getDeadLetterById(tx.id)).toBeNull();
+    });
+
+    it("requeuing makes the transaction due again immediately by default", () => {
+      const tx = makeDeadLettered();
+      retryDeadLetter(tx.id);
+      expect(getDueTransactions().find((t) => t.id === tx.id)).toBeDefined();
+    });
+
+    it("returns null when requeuing a non-dead-lettered transaction", () => {
+      const tx = scheduleTransaction(
+        validXDR,
+        new Date(Date.now() - 10000),
+        validPublicKey,
+      );
+      expect(retryDeadLetter(tx.id)).toBeNull();
+    });
+
+    it("removes a dead-lettered transaction permanently", () => {
+      const tx = makeDeadLettered();
+      expect(removeDeadLetter(tx.id)).toBe(true);
+      expect(getTransactionById(tx.id)).toBeNull();
+      // Removing a non-dead-lettered tx returns false.
+      const active = scheduleTransaction(
+        validXDR,
+        new Date(Date.now() - 10000),
+        validPublicKey,
+      );
+      expect(removeDeadLetter(active.id)).toBe(false);
     });
   });
 });

--- a/backend/src/services/scheduledTransactionService.js
+++ b/backend/src/services/scheduledTransactionService.js
@@ -8,6 +8,166 @@ const logger = require("../utils/logger");
 const scheduledTransactions = new Map();
 let transactionIdCounter = 1;
 
+// ─── Retry policy (#766) ────────────────────────────────────────────────────────
+// A scheduled transaction that fails with a *transient* error is retried with
+// bounded exponential backoff + jitter. A transaction that fails with a
+// *permanent* error, or exhausts its budget of attempts, is parked in the
+// dead-letter queue for inspection and manual retry instead of being retried
+// forever or silently dropped.
+const MAX_ATTEMPTS = 3; // Bounded retry budget
+const BASE_RETRY_DELAY_MS = 1_000; // First retry waits ~1 s
+const MAX_BACKOFF_MS = 60_000; // Cap the exponential growth at 60 s
+const MAX_JITTER_FRACTION = 0.2; // ±20% equal jitter to avoid thundering-herd alignment
+
+// Horizon result codes that will never succeed if the same signed XDR is
+// resubmitted. These are classified as permanent and parked in the DLQ.
+const PERMANENT_RESULT_CODES = new Set([
+  "tx_bad_auth",
+  "tx_bad_auth_extra",
+  "tx_bad_seq",
+  "tx_bad_source_account",
+  "tx_insufficient_balance",
+  "tx_too_late",
+  "tx_missing_operation",
+  "tx_bad_sponsor",
+  "tx_bad_min_seq_age",
+  "tx_too_many_operations",
+  "tx_too_many_sponsoring",
+  "tx_too_many_subentries",
+  "tx_inner_failed",
+  "op_underfunded",
+  "op_low_reserve",
+  "op_no_destination",
+  "op_no_issuer",
+  "op_bad_auth",
+  "op_malformed",
+  "op_bad_asset",
+  "op_line_full",
+  "op_under_dest_min",
+  "op_too_many_subentries",
+  "op_cross_self",
+  "op_too_big",
+  "op_not_authorized",
+  "op_no_trust",
+  "op_source_not_authorized",
+  "op_disabled_trust",
+  "op_bad_trust",
+  "op_no_claimant",
+  "op_invalid_claimant",
+  "op_sender_no_issuer",
+  "op_liquidity_pool_no_trust",
+  "op_liquidity_pool_underfunded",
+  "op_bad_pool",
+  "op_pool_bad_seq",
+  "op_acc_bad_seq",
+  "op_cross_marker_denied",
+  "op_source_cross_marker_denied",
+  "op_feeless",
+]);
+
+// Network / transport level error markers that indicate a retry is safe.
+const NETWORK_ERROR_MARKERS = [
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPIPE",
+  "SOCKETTIMEDOUT",
+  "network",
+  "AbortError",
+];
+
+/**
+ * Extract Stellar Horizon result codes from a submission error so the caller
+ * can tell whether the failure is permanent. Handles both the shape the SDK
+ * exposes (`error.response.data.extras.result_codes.*`) and a plain
+ * `error.data` fallback.
+ *
+ * @param {Error} error
+ * @returns {string[]} Result codes (transaction code + operation codes)
+ */
+function extractResultCodes(error) {
+  if (!error) return [];
+  const data = error.response?.data ?? error.data ?? {};
+  const resultCodes = data.extras?.result_codes ?? {};
+  const transactionCode = resultCodes.transaction;
+  const operationCodes = Array.isArray(resultCodes.operations)
+    ? resultCodes.operations
+    : [];
+  return [transactionCode, ...operationCodes].filter(Boolean);
+}
+
+/**
+ * Classify a Stellar submission error as either transient (safe to retry with
+ * backoff) or permanent (never resolves on retry → dead-letter).
+ *
+ * Classification priority:
+ *  1. Known network / transport markers → transient.
+ *  2. Known permanent Horizon result codes → permanent.
+ *  3. HTTP status: 429 / ≥500 → transient; 4xx (incl. 404) → permanent.
+ *  4. No status and no known marker → transient (fail safe, keep retrying).
+ *
+ * @param {Error|string|null} err - The submission error, or a plain string
+ * @returns {{ type: "transient"|"permanent", message: string|null }}
+ */
+function classifySubmissionError(err) {
+  const error = typeof err === "string" ? new Error(err) : err;
+  if (!error) {
+    return { type: "transient", message: null };
+  }
+
+  const message =
+    typeof error.message === "string"
+      ? error.message
+      : String(error.message ?? error);
+  const status = error.response?.status ?? error.status ?? null;
+
+  // 1. Network / transport-level failures are always retryable.
+  if (NETWORK_ERROR_MARKERS.some((marker) => message.includes(marker))) {
+    return { type: "transient", message };
+  }
+
+  // 2. Known permanent result codes never resolve on retry.
+  const resultCodes = extractResultCodes(error);
+  for (const code of resultCodes) {
+    if (PERMANENT_RESULT_CODES.has(code)) {
+      return {
+        type: "permanent",
+        message: `${message} (result code: ${code})`,
+      };
+    }
+  }
+
+  // 3. HTTP status based classification.
+  if (status !== null && status !== undefined) {
+    if (status === 429 || status >= 500) {
+      return { type: "transient", message };
+    }
+    if (status >= 400 && status < 500) {
+      return { type: "permanent", message };
+    }
+  }
+
+  // 4. Unknown (no status / marker) — retry to be safe, the budget bounds it.
+  return { type: "transient", message };
+}
+
+/**
+ * Compute the delay (ms) before the next attempt using exponential backoff
+ * with equal jitter, capped at MAX_BACKOFF_MS.
+ *
+ * @param {number} attemptNumber - Which attempt just failed (1-based)
+ * @param {() => number} [rng] - Random source, injectable for deterministic tests
+ * @returns {number} Delay in milliseconds
+ */
+function getBackoffDelayMs(attemptNumber, rng = Math.random) {
+  const n = Math.max(1, Number(attemptNumber) || 1);
+  const base = Math.min(MAX_BACKOFF_MS, BASE_RETRY_DELAY_MS * 2 ** (n - 1));
+  const spread = base * MAX_JITTER_FRACTION;
+  return Math.max(0, Math.round(base + (rng() * 2 - 1) * spread));
+}
+
 /**
  * Store a pre-signed transaction for future submission
  * @param {string} signedXDR - The signed transaction XDR
@@ -43,10 +203,17 @@ function scheduleTransaction(signedXDR, submitAt, publicKey) {
     submitAt: submitAt.getTime(), // Store as timestamp for easier comparison
     publicKey,
     attempts: 0,
+    // Retry/backoff state (#766)
+    nextRetryAt: null, // Earliest timestamp the tx may be retried
     lastError: null,
+    lastErrorType: null, // "transient" | "permanent" | null
     createdAt: new Date().getTime(),
     paused: false,
     pausedAt: null,
+    // Dead-letter state (#766)
+    deadLetter: false,
+    deadLetterAt: null,
+    deadLetterReason: null,
     // Reconciliation state: null | "unknown" | "confirmed" | "failed"
     submissionState: null,
     /** @type {string|null} Transaction hash after submission */
@@ -76,7 +243,13 @@ function getPendingTransactions(publicKey) {
   const pending = [];
 
   for (const [, tx] of scheduledTransactions.entries()) {
-    if (tx.publicKey === publicKey && tx.submitAt > now && tx.attempts < 3 && !tx.paused) {
+    if (
+      tx.publicKey === publicKey &&
+      tx.submitAt > now &&
+      tx.attempts < MAX_ATTEMPTS &&
+      !tx.paused &&
+      !tx.deadLetter
+    ) {
       pending.push({
         id: tx.id,
         submitAt: new Date(tx.submitAt),
@@ -84,6 +257,7 @@ function getPendingTransactions(publicKey) {
         attempts: tx.attempts,
         createdAt: new Date(tx.createdAt),
         paused: tx.paused || false,
+        nextRetryAt: tx.nextRetryAt ? new Date(tx.nextRetryAt) : null,
       });
     }
   }
@@ -111,7 +285,13 @@ function cancelTransaction(id) {
 }
 
 /**
- * Get transactions that are due for submission (submitAt <= now)
+ * Get transactions that are due for submission.
+ *
+ * A transaction is due when BOTH its original `submitAt` and any backoff
+ * window (`nextRetryAt`) have elapsed, it still has retry budget remaining,
+ * and it has not been paused, parked in the dead-letter queue, or already
+ * submitted/reconciled.
+ *
  * @returns {Array} Array of transactions ready for submission
  */
 function getDueTransactions() {
@@ -119,17 +299,17 @@ function getDueTransactions() {
   const due = [];
 
   for (const [, tx] of scheduledTransactions.entries()) {
-    // Only include transactions that:
-    // 1. Are due for submission (submitAt <= now)
-    // 2. Haven't exceeded max attempts (attempts < 3)
-    // 3. Are not paused (paused !== true)
-    // 4. Haven't already been submitted or reconciled (avoids duplicate resubmission)
+    const eligibleAt = Math.max(tx.submitAt, tx.nextRetryAt || 0);
     if (
-      tx.submitAt <= now &&
-      tx.attempts < 3 &&
+      eligibleAt <= now &&
+      tx.attempts < MAX_ATTEMPTS &&
       !tx.paused &&
+      !tx.deadLetter &&
       tx.submissionState !== "confirmed" &&
-      tx.submissionState !== "unknown"
+      tx.submissionState !== "unknown" &&
+      // Terminal — reconciled as failed on-ledger (or via sequence) must not
+      // be resubmitted. This is the durable terminal-failure path (#766).
+      tx.submissionState !== "failed"
     ) {
       due.push(tx);
     }
@@ -140,18 +320,50 @@ function getDueTransactions() {
 }
 
 /**
- * Increment the attempt counter for a transaction
+ * Increment the attempt counter for a transaction and apply the retry policy.
+ *
+ * - A *transient* failure schedules a bounded exponential backoff window
+ *   (`nextRetryAt`) and keeps the transaction eligible for resubmission.
+ * - A *permanent* failure, or exhausting the retry budget, parks the
+ *   transaction in the dead-letter queue.
+ *
  * @param {number} id - The transaction ID
- * @param {string|null} error - Error message if submission failed, null if successful
+ * @param {Error|string|null} err - The error (or message) from the failed attempt
+ * @returns {{ status: "retry"|"dead_lettered", id: number, attempts: number, nextRetryAt?: number, delayMs?: number, reason?: string }|null}
  */
-function incrementAttempt(id, error = null) {
+function incrementAttempt(id, err = null) {
   const tx = scheduledTransactions.get(id);
-  if (tx) {
-    tx.attempts += 1;
-    tx.lastError = error || null;
-    // If successful, we could remove it from the queue, but for now
-    // we'll let the caller handle removal if needed
+  if (!tx) return null;
+
+  tx.attempts += 1;
+  const classification = classifySubmissionError(err);
+  tx.lastError = classification.message;
+  tx.lastErrorType = classification.type;
+
+  const attemptsExhausted = tx.attempts >= MAX_ATTEMPTS;
+  if (classification.type === "permanent" || attemptsExhausted) {
+    deadLetterTransaction(id, classification.message);
+    return {
+      status: "dead_lettered",
+      id,
+      attempts: tx.attempts,
+      reason: tx.deadLetterReason,
+    };
   }
+
+  const delayMs = getBackoffDelayMs(tx.attempts);
+  tx.nextRetryAt = Date.now() + delayMs;
+  logger.warn(
+    { id, attempts: tx.attempts, delayMs, nextRetryAt: tx.nextRetryAt },
+    "Scheduled transaction failed; retrying with backoff",
+  );
+  return {
+    status: "retry",
+    id,
+    attempts: tx.attempts,
+    delayMs,
+    nextRetryAt: tx.nextRetryAt,
+  };
 }
 
 /**
@@ -194,11 +406,20 @@ function reconcileTransaction(id, confirmed, reason) {
 
   if (confirmed) {
     tx.submissionState = "confirmed";
-    logger.info(JSON.stringify({ type: "transaction_confirmed", id, txHash: tx.txHash }));
+    tx.deadLetter = false;
+    logger.info(
+      JSON.stringify({ type: "transaction_confirmed", id, txHash: tx.txHash }),
+    );
   } else {
     tx.submissionState = "failed";
     tx.lastError = reason || "Reconciled as not found on-ledger";
-    logger.info(JSON.stringify({ type: "transaction_failed_reconciliation", id, reason: tx.lastError }));
+    logger.info(
+      JSON.stringify({
+        type: "transaction_failed_reconciliation",
+        id,
+        reason: tx.lastError,
+      }),
+    );
   }
 }
 
@@ -214,13 +435,20 @@ function reconcileByHash(id, horizonTx) {
   const tx = scheduledTransactions.get(id);
   if (!tx) return "unknown";
 
-  if (horizonTx && (horizonTx.successful === true || horizonTx.successful === undefined)) {
+  if (
+    horizonTx &&
+    (horizonTx.successful === true || horizonTx.successful === undefined)
+  ) {
     reconcileTransaction(id, true);
     return "confirmed";
   }
 
   // Found on-ledger but not successful, or not found at all
-  reconcileTransaction(id, false, horizonTx ? "Transaction failed on-ledger" : "Transaction not found");
+  reconcileTransaction(
+    id,
+    false,
+    horizonTx ? "Transaction failed on-ledger" : "Transaction not found",
+  );
   return "failed";
 }
 
@@ -250,7 +478,11 @@ function reconcileBySequence(id, currentSequence) {
   }
 
   // Sequence hasn't advanced — transaction was never applied
-  reconcileTransaction(id, false, "Sequence unchanged — transaction not applied");
+  reconcileTransaction(
+    id,
+    false,
+    "Sequence unchanged — transaction not applied",
+  );
   return "failed";
 }
 
@@ -266,6 +498,101 @@ function getUnreconciledTransactions() {
     }
   }
   return unreconciled;
+}
+
+// ─── Dead-letter queue (#766) ──────────────────────────────────────────────────
+// Transactions that fail permanently or exhaust their retry budget are parked
+// here (flagged `deadLetter` in the store) and surfaced for inspection and
+// manual retry instead of being silently dropped.
+
+/**
+ * Park a scheduled transaction in the dead-letter queue.
+ * @param {number} id - The transaction ID
+ * @param {string} [reason] - Why the transaction was dead-lettered
+ * @returns {Object|null} The dead-lettered transaction, or null if not found
+ */
+function deadLetterTransaction(id, reason) {
+  const tx = scheduledTransactions.get(id);
+  if (!tx) return null;
+
+  tx.deadLetter = true;
+  tx.deadLetterAt = Date.now();
+  tx.deadLetterReason =
+    reason || tx.lastError || "Max retry attempts exhausted";
+  tx.nextRetryAt = null; // No longer eligible for automatic retry
+  logger.warn(
+    { id, reason: tx.deadLetterReason },
+    "Transaction parked in dead-letter queue",
+  );
+  return tx;
+}
+
+/**
+ * List dead-lettered transactions, optionally filtered by public key.
+ * Sorted oldest-first by when they were dead-lettered.
+ *
+ * @param {{ publicKey?: string }} [options]
+ * @returns {Array} Copies of dead-lettered transactions
+ */
+function getDeadLetterTransactions({ publicKey } = {}) {
+  const result = [];
+  for (const [, tx] of scheduledTransactions.entries()) {
+    if (!tx.deadLetter) continue;
+    if (publicKey && tx.publicKey !== publicKey) continue;
+    result.push({ ...tx });
+  }
+  return result.sort((a, b) => (a.deadLetterAt || 0) - (b.deadLetterAt || 0));
+}
+
+/**
+ * Get a single dead-lettered transaction by ID.
+ * @param {number} id - The transaction ID
+ * @returns {Object|null} A copy of the dead-lettered transaction, or null
+ */
+function getDeadLetterById(id) {
+  const tx = scheduledTransactions.get(id);
+  if (!tx || !tx.deadLetter) return null;
+  return { ...tx };
+}
+
+/**
+ * Requeue a dead-lettered transaction for retry. Resets the attempt counter
+ * and clears the dead-letter state so the transaction becomes due again
+ * (immediately unless a `retryAt` is supplied).
+ *
+ * @param {number} id - The transaction ID
+ * @param {{ retryAt?: Date|number }} [options]
+ * @returns {Object|null} The requeued transaction (live reference), or null
+ */
+function retryDeadLetter(id, { retryAt } = {}) {
+  const tx = scheduledTransactions.get(id);
+  if (!tx || !tx.deadLetter) return null;
+
+  tx.deadLetter = false;
+  tx.deadLetterAt = null;
+  tx.deadLetterReason = null;
+  tx.lastError = null;
+  tx.lastErrorType = null;
+  tx.attempts = 0;
+  if (retryAt !== undefined) {
+    tx.nextRetryAt =
+      retryAt instanceof Date ? retryAt.getTime() : Number(retryAt);
+  } else {
+    tx.nextRetryAt = null;
+  }
+  logger.info({ id }, "Dead-letter transaction requeued for retry");
+  return tx;
+}
+
+/**
+ * Permanently remove a dead-lettered transaction from the store (acknowledge).
+ * @param {number} id - The transaction ID
+ * @returns {boolean} True if removed, false if not found / not dead-lettered
+ */
+function removeDeadLetter(id) {
+  const tx = scheduledTransactions.get(id);
+  if (!tx || !tx.deadLetter) return false;
+  return scheduledTransactions.delete(id);
 }
 
 /**
@@ -300,6 +627,15 @@ function resumeTransaction(id) {
   return false;
 }
 
+/**
+ * Reset the scheduler state. Primarily used in tests to get a clean slate.
+ * @returns {void}
+ */
+function resetScheduler() {
+  scheduledTransactions.clear();
+  transactionIdCounter = 1;
+}
+
 module.exports = {
   scheduleTransaction,
   getPendingTransactions,
@@ -315,4 +651,16 @@ module.exports = {
   reconcileByHash,
   reconcileBySequence,
   getUnreconciledTransactions,
+  // Retry / classification helpers (#766)
+  MAX_ATTEMPTS,
+  classifySubmissionError,
+  getBackoffDelayMs,
+  // Dead-letter controls (#766)
+  deadLetterTransaction,
+  getDeadLetterTransactions,
+  getDeadLetterById,
+  retryDeadLetter,
+  removeDeadLetter,
+  // Test helper
+  resetScheduler,
 };


### PR DESCRIPTION
## Summary

Closes #766 — Adds reliability handling to the scheduled transaction service so failed submissions are retried with bounded exponential backoff rather than incrementing blindly, and permanent/exhausted failures land in a durable dead-letter queue instead of being silently dropped or retried forever.

The retry/dead-letter policy is implemented in `backend/src/services/scheduledTransactionService.js` with per-transaction state (`nextRetryAt`, `lastErrorType`, `deadLetter*`) and a set of new inspection/control functions.

## Changes

**1. Stellar error classification (`classifySubmissionError`)**
- Reuses the Horizon error shape (`error.response.data.extras.result_codes.*`).
- Classifies each failure as `transient` (safe to retry) or `permanent` (never resolves on retry):
  - Network / transport markers (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `AbortError`, …) → **transient**
  - Known permanent Horizon result codes (`tx_bad_seq`, `op_underfunded`, `op_no_destination`, …) → **permanent**
  - HTTP `429` / `≥500` → **transient**; other `4xx` (incl. `404`) → **permanent**
  - Unknown errors → **transient** (fail safe; the retry budget bounds them)

**2. Bounded exponential retries with jitter**
- `incrementAttempt(id, err)` now increments, classifies the error, then:
  - Transient failure → computes `nextRetryAt = now + backoff` and returns `{ status: "retry", delayMs, nextRetryAt }`.
  - `getBackoffDelayMs(attempt)` = `min(MAX_BACKOFF_MS, BASE (1s) × 2^(attempt-1))` with **±20% equal jitter** to avoid thundering-herd alignment.
  - Attempt budget is bounded by `MAX_ATTEMPTS = 3`.
- `getDueTransactions()` now only returns a tx once BOTH `submitAt` and any backoff window (`nextRetryAt`) have elapsed.

**3. Dead-letter queue (inspection + retry controls)**
- Permanent failures OR try-budget exhaustion park the tx in the DLQ (`deadLetter = true`, with `deadLetterReason`/`deadLetterAt`).
- New exported API:
  - `deadLetterTransaction(id, reason)` — park a transaction
  - `getDeadLetterTransactions({ publicKey })` — inspect dead letters
  - `getDeadLetterById(id)` — single inspection
  - `retryDeadLetter(id, { retryAt })` — requeue for resubmission (reset attempts/state)
  - `removeDeadLetter(id)` — acknowledge/delete permanently

**4. Durable terminal-failure path**
- Fixes a latent bug: a transaction reconciled as `failed` (on-ledger or by sequence) was previously still returned by `getDueTransactions()` and would be resubmitted forever. It is now treated as terminal.

**5. Test-maintainability**
- Added `resetScheduler()` so tests get a clean slate (the previous tests leaked shared in-memory state across cases).
- Backoff delay uses an injectable RNG for deterministic tests.

## Acceptance criteria

- ✅ Classify transient and permanent Stellar errors — `classifySubmissionError`
- ✅ Schedule bounded exponential retries with jitter — `getBackoffDelayMs` + `nextRetryAt`
- ✅ Expose dead-letter inspection and retry controls — DLQ API above
- ✅ Automated coverage updated/added — see validation

## Validation

- **Unit tests:** `npx jest __tests__/scheduledTransactionService.test.js`
  - ✅ **35 passed, 0 failed** (added error-classification, backoff/jitter, and dead-letter-control suites; updated retry cases to assert the backoff window).
- **Full backend suite:** `npx jest`
  - ✅ 28/31 suites pass. The 3 failing suites (`accountController`, `paymentMonitor`, `turretsService`) fail **identically on the base branch** (verified via `git stash`) — pre-existing environment/test-fixture issues unrelated to this change. No changed-code failure.
- **Lint:** `npx eslint src/services/scheduledTransactionService.js` → **0 errors** (the project's `lint` script scopes to `src/**/*.js`; test files aren't linted by project config).
- **Format:** `npx prettier --check` on both changed files → **clean**.

## Network state note

These changes are purely in-memory scheduling/retry policy and do **not** make any Horizon/network calls, so there is no testnet/mainnet behavior to toggle. Network selection remains in `backend/src/config/stellar.js`, which already resolves `HORIZON_URL`/`STEMMLAR_NETWORK` (defaulting to Horizon testnet). The error classifier is network-agnostic and handles Horizon result codes from either network, but no on-ledger submission is exercised in these tests.
